### PR TITLE
R2: Appliance-grade runnable system

### DIFF
--- a/.claude/skills/garden-calendar.md
+++ b/.claude/skills/garden-calendar.md
@@ -93,19 +93,20 @@ SUCCESSION PLANTING:
 
 Be specific: name exact beds, include quantities, flag time-sensitive actions.
 
-### 6. Push summary to Telegram queue
-After completing the digest/summary, push it to the Telegram notification queue:
+### 6. Push summary to notification queue
+After completing the digest/summary, push it to the runtime.db notification queue:
 ```bash
 node -e "
-const fs=require('fs'),path=require('path'),home=require('os').homedir();
-const qFile=path.join(home,'.jarvis','telegram-queue.json');
-const q=fs.existsSync(qFile)?JSON.parse(fs.readFileSync(qFile,'utf8')):[];
-q.push({agent:'garden-calendar',message:`Garden Calendar: ${summary}`,ts:new Date().toISOString(),sent:false});
-fs.writeFileSync(qFile,JSON.stringify(q,null,2));
+const{DatabaseSync}=require('node:sqlite'),path=require('path'),home=require('os').homedir(),crypto=require('crypto');
+const db=new DatabaseSync(path.join(home,'.jarvis','runtime.db'));
+db.exec('PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;');
+db.prepare('INSERT INTO notifications (notification_id,channel,kind,payload_json,status,created_at) VALUES (?,?,?,?,?,?)')
+  .run(crypto.randomUUID(),'telegram','agent_complete',JSON.stringify({agent:'garden-calendar',message:'Garden Calendar: weekly brief generated'}),'pending',new Date().toISOString());
+db.close();
 "
 ```
 
-Note: In practice, construct the `summary` variable from the actual output of prior steps (e.g. weather alerts, sow/transplant/harvest tasks for the week) and embed it in the node -e command above.
+Note: In practice, construct the message from the actual output of prior steps (weather alerts, sow/transplant/harvest tasks) and embed it in the payload above.
 
 ## No Approval Gates
 This agent is advisory only. No emails, no purchases, no modifications.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate contracts
+        run: npm run validate:contracts
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -10702,9 +10702,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11745,6 +11745,7 @@
     "packages/jarvis-dashboard": {
       "version": "0.1.0",
       "dependencies": {
+        "@jarvis/runtime": "file:../jarvis-runtime",
         "express": "^5.1.0",
         "highlight.js": "^11.11.1",
         "marked": "^15.0.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dashboard:dev": "concurrently \"tsx packages/jarvis-dashboard/src/api/server.ts\" \"vite -c packages/jarvis-dashboard/vite.config.ts\"",
     "dashboard:build": "vite build -c packages/jarvis-dashboard/vite.config.ts",
     "telegram-bot": "tsx packages/jarvis-telegram/src/index.ts",
+    "jarvis": "node scripts/jarvis.mjs",
     "daemon": "tsx packages/jarvis-runtime/src/daemon.ts",
     "setup": "tsx scripts/setup-jarvis.ts",
     "setup:status": "tsx scripts/setup-jarvis.ts status",

--- a/packages/jarvis-dashboard/package.json
+++ b/packages/jarvis-dashboard/package.json
@@ -9,6 +9,7 @@
     "preview": "tsx src/api/server.ts"
   },
   "dependencies": {
+    "@jarvis/runtime": "file:../jarvis-runtime",
     "express": "^5.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -14,9 +14,8 @@ import { analyticsRouter } from './analytics.js'
 import { settingsRouter } from './settings.js'
 import { portalRouter } from './portal.js'
 import { godmodeRouter } from './godmode.js'
-import os from 'os'
-import { DatabaseSync } from 'node:sqlite'
 import fs from 'fs'
+import { getHealthReport, getReadinessReport } from '@jarvis/runtime'
 
 const app = express()
 const PORT = Number(process.env.PORT ?? 4242)
@@ -51,47 +50,24 @@ app.use('/portal/api', portalRouter)
 app.use('/api/godmode', godmodeRouter)
 
 app.get('/api/health', (_req, res) => {
-  const jarvisDir = join(os.homedir(), '.jarvis')
-  let crmCount = 0, docsCount = 0, playbooksCount = 0, decisionsCount = 0
-  try {
-    const crm = new DatabaseSync(join(jarvisDir, 'crm.db'))
-    crmCount = (crm.prepare('SELECT COUNT(*) as n FROM contacts').get() as { n: number }).n
-    crm.close()
-  } catch (err) {
-    console.error('Failed to query CRM database:', err)
-  }
-  try {
-    const kb = new DatabaseSync(join(jarvisDir, 'knowledge.db'))
-    docsCount = (kb.prepare('SELECT COUNT(*) as n FROM documents').get() as { n: number }).n
-    playbooksCount = (kb.prepare('SELECT COUNT(*) as n FROM playbooks').get() as { n: number }).n
-    decisionsCount = (kb.prepare('SELECT COUNT(*) as n FROM decisions').get() as { n: number }).n
-    kb.close()
-  } catch (err) {
-    console.error('Failed to query Knowledge database:', err)
-  }
-  const approvalsPath = join(jarvisDir, 'approvals.json')
-  let pendingApprovals = 0
-  if (fs.existsSync(approvalsPath)) {
-    try {
-      const a = JSON.parse(fs.readFileSync(approvalsPath, 'utf8')) as Array<{ status: string }>
-      pendingApprovals = a.filter(x => x.status === 'pending').length
-    } catch (err) {
-      console.error('Failed to read approvals file:', err)
-    }
-  }
-  const telegramConfigured = fs.existsSync(join(jarvisDir, 'config.json'))
-
+  const report = getHealthReport()
   res.json({
-    ok: true,
-    distPath,
+    ok: report.status !== 'unhealthy',
+    status: report.status,
+    uptime_seconds: report.uptime_seconds,
+    crm: report.crm,
+    knowledge: report.knowledge,
+    runtime: report.runtime,
+    daemon: report.daemon,
+    disk_free_gb: report.disk_free_gb,
     distExists: fs.existsSync(indexHtml),
-    crm: { contacts: crmCount },
-    knowledge: { documents: docsCount, playbooks: playbooksCount },
-    decisions: { total: decisionsCount },
-    pendingApprovals,
-    telegramConfigured,
     dashboardUrl: `http://localhost:${PORT}`
   })
+})
+
+app.get('/api/ready', (_req, res) => {
+  const report = getReadinessReport()
+  res.status(report.ready ? 200 : 503).json(report)
 })
 
 // SPA: serve index.html for all non-API routes

--- a/packages/jarvis-runtime/src/doctor.ts
+++ b/packages/jarvis-runtime/src/doctor.ts
@@ -1,0 +1,292 @@
+/**
+ * Jarvis Doctor — system health diagnostic.
+ *
+ * Checks prerequisites, configuration, databases, model runtime,
+ * and reports pass/fail for each category.
+ *
+ * Usage: npx tsx packages/jarvis-runtime/src/doctor.ts
+ *        jarvis doctor
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  JARVIS_DIR,
+  CRM_DB_PATH,
+  KNOWLEDGE_DB_PATH,
+  RUNTIME_DB_PATH,
+  loadConfig,
+  validateConfig,
+} from "./config.js";
+
+type CheckResult = {
+  name: string;
+  status: "pass" | "warn" | "fail";
+  detail: string;
+};
+
+const results: CheckResult[] = [];
+
+function pass(name: string, detail: string) {
+  results.push({ name, status: "pass", detail });
+}
+
+function warn(name: string, detail: string) {
+  results.push({ name, status: "warn", detail });
+}
+
+function fail(name: string, detail: string) {
+  results.push({ name, status: "fail", detail });
+}
+
+// ─── Node Version ──────────────────────────────────────────────────────────
+
+function checkNodeVersion() {
+  const version = process.version;
+  const major = parseInt(version.slice(1), 10);
+  if (major >= 22) {
+    pass("Node.js", `${version} (>= 22 required)`);
+  } else {
+    fail("Node.js", `${version} — Node 22+ required for node:sqlite`);
+  }
+}
+
+// ─── Jarvis Directory ──────────────────────────────────────────────────────
+
+function checkJarvisDir() {
+  if (fs.existsSync(JARVIS_DIR)) {
+    pass("~/.jarvis", "Directory exists");
+  } else {
+    fail("~/.jarvis", `Missing — run: jarvis init`);
+  }
+}
+
+// ─── Config ────────────────────────────────────────────────────────────────
+
+function checkConfig() {
+  const configPath = join(JARVIS_DIR, "config.json");
+  if (!fs.existsSync(configPath)) {
+    warn("Config", `${configPath} not found — using defaults`);
+    return;
+  }
+
+  try {
+    const config = loadConfig();
+    const result = validateConfig(config);
+    if (result.valid && result.warnings.length === 0) {
+      pass("Config", "Valid configuration");
+    } else if (result.valid) {
+      warn("Config", `Valid with warnings: ${result.warnings.join("; ")}`);
+    } else {
+      fail("Config", `Invalid: ${result.errors.join("; ")}`);
+    }
+  } catch (e) {
+    fail("Config", `Load error: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+// ─── Databases ─────────────────────────────────────────────────────────────
+
+function checkDatabase(name: string, dbPath: string, tables: string[]) {
+  if (!fs.existsSync(dbPath)) {
+    fail(name, `Not found at ${dbPath}`);
+    return;
+  }
+
+  try {
+    const db = new DatabaseSync(dbPath);
+    const rows = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    ).all() as Array<{ name: string }>;
+    const existing = rows.map(r => r.name);
+    db.close();
+
+    const missing = tables.filter(t => !existing.includes(t));
+    if (missing.length === 0) {
+      pass(name, `OK (${existing.length} tables)`);
+    } else {
+      warn(name, `Missing tables: ${missing.join(", ")}`);
+    }
+  } catch (e) {
+    fail(name, `Cannot open: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+function checkDatabases() {
+  checkDatabase("CRM DB", CRM_DB_PATH, ["contacts", "notes", "stage_history"]);
+  checkDatabase("Knowledge DB", KNOWLEDGE_DB_PATH, ["documents", "playbooks", "entities", "relations", "decisions"]);
+  checkDatabase("Runtime DB", RUNTIME_DB_PATH, [
+    "schema_migrations", "approvals", "agent_commands", "run_events",
+    "daemon_heartbeats", "notifications", "plugin_installs", "audit_log",
+    "settings", "model_registry", "model_benchmarks", "schedules", "agent_memory",
+  ]);
+}
+
+// ─── WAL Mode ──────────────────────────────────────────────────────────────
+
+function checkWalMode() {
+  for (const [name, dbPath] of [["CRM", CRM_DB_PATH], ["Knowledge", KNOWLEDGE_DB_PATH], ["Runtime", RUNTIME_DB_PATH]] as const) {
+    if (!fs.existsSync(dbPath)) continue;
+    try {
+      const db = new DatabaseSync(dbPath);
+      const row = db.prepare("PRAGMA journal_mode").get() as { journal_mode: string } | undefined;
+      db.close();
+      if (row?.journal_mode === "wal") {
+        pass(`${name} WAL`, "WAL mode enabled");
+      } else {
+        warn(`${name} WAL`, `journal_mode=${row?.journal_mode ?? "unknown"} — WAL recommended`);
+      }
+    } catch { /* skip if can't open */ }
+  }
+}
+
+// ─── LM Studio / Ollama ───────────────────────────────────────────────────
+
+async function checkModelRuntime() {
+  let config;
+  try {
+    config = loadConfig();
+  } catch {
+    config = { lmstudio_url: "http://localhost:1234" };
+  }
+
+  const lmsUrl = (config as { lmstudio_url: string }).lmstudio_url;
+
+  // Check LM Studio
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const resp = await fetch(`${lmsUrl}/v1/models`, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (resp.ok) {
+      const data = await resp.json() as { data?: Array<{ id: string }> };
+      const models = data.data ?? [];
+      pass("LM Studio", `Reachable at ${lmsUrl} — ${models.length} model(s) loaded`);
+      if (models.length > 0) {
+        for (const m of models.slice(0, 5)) {
+          pass("  Model", m.id);
+        }
+        if (models.length > 5) {
+          pass("  ...", `and ${models.length - 5} more`);
+        }
+      }
+    } else {
+      warn("LM Studio", `Reachable but returned ${resp.status}`);
+    }
+  } catch {
+    warn("LM Studio", `Not reachable at ${lmsUrl}`);
+  }
+
+  // Check Ollama
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const resp = await fetch("http://localhost:11434/api/tags", { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (resp.ok) {
+      const data = await resp.json() as { models?: Array<{ name: string }> };
+      const models = data.models ?? [];
+      pass("Ollama", `Reachable — ${models.length} model(s) available`);
+    } else {
+      warn("Ollama", `Reachable but returned ${resp.status}`);
+    }
+  } catch {
+    warn("Ollama", "Not reachable at localhost:11434");
+  }
+}
+
+// ─── Chrome Debugging ──────────────────────────────────────────────────────
+
+async function checkChrome() {
+  let debugUrl = "http://localhost:9222";
+  try {
+    const config = loadConfig();
+    if (config.chrome?.debugging_url) {
+      debugUrl = config.chrome.debugging_url;
+    }
+  } catch { /* use default */ }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const resp = await fetch(`${debugUrl}/json/version`, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (resp.ok) {
+      pass("Chrome", `Debugging protocol available at ${debugUrl}`);
+    } else {
+      warn("Chrome", `Reachable but returned ${resp.status}`);
+    }
+  } catch {
+    warn("Chrome", `Not reachable at ${debugUrl} — browser automation unavailable`);
+  }
+}
+
+// ─── Disk Space ────────────────────────────────────────────────────────────
+
+function checkDiskSpace() {
+  try {
+    const stats = fs.statfsSync(JARVIS_DIR);
+    const freeGB = (stats.bfree * stats.bsize) / (1024 ** 3);
+    if (freeGB > 5) {
+      pass("Disk", `${freeGB.toFixed(1)} GB free`);
+    } else if (freeGB > 1) {
+      warn("Disk", `${freeGB.toFixed(1)} GB free — low disk space`);
+    } else {
+      fail("Disk", `${freeGB.toFixed(1)} GB free — critically low`);
+    }
+  } catch {
+    warn("Disk", "Could not check disk space");
+  }
+}
+
+// ─── Run ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("\n  Jarvis Doctor\n");
+
+  checkNodeVersion();
+  checkJarvisDir();
+  checkConfig();
+  checkDatabases();
+  checkWalMode();
+  await checkModelRuntime();
+  await checkChrome();
+  checkDiskSpace();
+
+  // Print results
+  console.log("");
+  const icons = { pass: "[PASS]", warn: "[WARN]", fail: "[FAIL]" } as const;
+  let failCount = 0;
+  let warnCount = 0;
+
+  for (const r of results) {
+    const icon = icons[r.status];
+    console.log(`  ${icon} ${r.name}: ${r.detail}`);
+    if (r.status === "fail") failCount++;
+    if (r.status === "warn") warnCount++;
+  }
+
+  console.log("");
+  const total = results.length;
+  const passCount = total - failCount - warnCount;
+  console.log(`  ${passCount}/${total} passed, ${warnCount} warnings, ${failCount} failures`);
+
+  if (failCount > 0) {
+    console.log("\n  Fix failures above before running Jarvis.\n");
+    process.exitCode = 1;
+  } else if (warnCount > 0) {
+    console.log("\n  Jarvis can run but some features may be unavailable.\n");
+  } else {
+    console.log("\n  All checks passed. Jarvis is ready.\n");
+  }
+}
+
+main().catch(e => {
+  console.error("Doctor error:", e);
+  process.exitCode = 1;
+});

--- a/packages/jarvis-runtime/src/health.ts
+++ b/packages/jarvis-runtime/src/health.ts
@@ -1,0 +1,148 @@
+/**
+ * Reusable health check logic for Jarvis runtime.
+ *
+ * Used by both the dashboard API /api/health endpoint and `jarvis doctor`.
+ */
+
+import fs from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { JARVIS_DIR, CRM_DB_PATH, KNOWLEDGE_DB_PATH, RUNTIME_DB_PATH } from "./config.js";
+
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+
+export type HealthReport = {
+  status: HealthStatus;
+  uptime_seconds: number;
+  crm: { ok: boolean; contacts: number };
+  knowledge: { ok: boolean; documents: number; playbooks: number; decisions: number };
+  runtime: { ok: boolean; pending_approvals: number; pending_commands: number; recent_runs: number };
+  daemon: { running: boolean; pid: number | null; last_seen: string | null };
+  disk_free_gb: number | null;
+};
+
+export type ReadinessReport = {
+  ready: boolean;
+  checks: {
+    jarvis_dir: boolean;
+    crm_db: boolean;
+    knowledge_db: boolean;
+    runtime_db: boolean;
+    daemon_running: boolean;
+  };
+};
+
+const startTime = Date.now();
+
+function queryCount(db: DatabaseSync, sql: string): number {
+  try {
+    return (db.prepare(sql).get() as { n: number }).n;
+  } catch {
+    return 0;
+  }
+}
+
+export function getHealthReport(): HealthReport {
+  const report: HealthReport = {
+    status: "healthy",
+    uptime_seconds: Math.floor((Date.now() - startTime) / 1000),
+    crm: { ok: false, contacts: 0 },
+    knowledge: { ok: false, documents: 0, playbooks: 0, decisions: 0 },
+    runtime: { ok: false, pending_approvals: 0, pending_commands: 0, recent_runs: 0 },
+    daemon: { running: false, pid: null, last_seen: null },
+    disk_free_gb: null,
+  };
+
+  // CRM
+  try {
+    const crm = new DatabaseSync(CRM_DB_PATH);
+    report.crm.contacts = queryCount(crm, "SELECT COUNT(*) as n FROM contacts");
+    report.crm.ok = true;
+    crm.close();
+  } catch { /* CRM unavailable */ }
+
+  // Knowledge
+  try {
+    const kb = new DatabaseSync(KNOWLEDGE_DB_PATH);
+    report.knowledge.documents = queryCount(kb, "SELECT COUNT(*) as n FROM documents");
+    report.knowledge.playbooks = queryCount(kb, "SELECT COUNT(*) as n FROM playbooks");
+    report.knowledge.decisions = queryCount(kb, "SELECT COUNT(*) as n FROM decisions");
+    report.knowledge.ok = true;
+    kb.close();
+  } catch { /* Knowledge unavailable */ }
+
+  // Runtime
+  try {
+    const rtDb = new DatabaseSync(RUNTIME_DB_PATH);
+    rtDb.exec("PRAGMA journal_mode = WAL;");
+    rtDb.exec("PRAGMA busy_timeout = 5000;");
+
+    report.runtime.pending_approvals = queryCount(rtDb, "SELECT COUNT(*) as n FROM approvals WHERE status = 'pending'");
+    report.runtime.pending_commands = queryCount(rtDb, "SELECT COUNT(*) as n FROM agent_commands WHERE status = 'queued'");
+    report.runtime.recent_runs = queryCount(rtDb, "SELECT COUNT(DISTINCT run_id) as n FROM run_events WHERE created_at > datetime('now', '-24 hours')");
+    report.runtime.ok = true;
+
+    // Daemon heartbeat
+    const heartbeat = rtDb.prepare(
+      "SELECT pid, last_seen_at FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1",
+    ).get() as { pid: number; last_seen_at: string } | undefined;
+
+    if (heartbeat) {
+      const stale = Date.now() - new Date(heartbeat.last_seen_at).getTime() > 30_000;
+      report.daemon.running = !stale;
+      report.daemon.pid = heartbeat.pid;
+      report.daemon.last_seen = heartbeat.last_seen_at;
+    }
+
+    rtDb.close();
+  } catch { /* Runtime unavailable */ }
+
+  // Disk
+  try {
+    if (fs.existsSync(JARVIS_DIR)) {
+      const stats = fs.statfsSync(JARVIS_DIR);
+      report.disk_free_gb = parseFloat(((stats.bfree * stats.bsize) / (1024 ** 3)).toFixed(1));
+    }
+  } catch { /* can't check disk */ }
+
+  // Determine overall status
+  if (!report.crm.ok || !report.knowledge.ok || !report.runtime.ok) {
+    report.status = "unhealthy";
+  } else if (!report.daemon.running || (report.disk_free_gb !== null && report.disk_free_gb < 2)) {
+    report.status = "degraded";
+  }
+
+  return report;
+}
+
+export function getReadinessReport(): ReadinessReport {
+  const checks = {
+    jarvis_dir: fs.existsSync(JARVIS_DIR),
+    crm_db: fs.existsSync(CRM_DB_PATH),
+    knowledge_db: fs.existsSync(KNOWLEDGE_DB_PATH),
+    runtime_db: fs.existsSync(RUNTIME_DB_PATH),
+    daemon_running: false,
+  };
+
+  // Check daemon heartbeat
+  if (checks.runtime_db) {
+    try {
+      const rtDb = new DatabaseSync(RUNTIME_DB_PATH);
+      rtDb.exec("PRAGMA journal_mode = WAL;");
+      rtDb.exec("PRAGMA busy_timeout = 5000;");
+      const row = rtDb.prepare(
+        "SELECT last_seen_at FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1",
+      ).get() as { last_seen_at: string } | undefined;
+      rtDb.close();
+
+      if (row) {
+        checks.daemon_running = Date.now() - new Date(row.last_seen_at).getTime() < 30_000;
+      }
+    } catch { /* can't check */ }
+  }
+
+  return {
+    ready: checks.jarvis_dir && checks.crm_db && checks.knowledge_db && checks.runtime_db,
+    checks,
+  };
+}

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -1,7 +1,7 @@
 export { loadConfig, validateConfig, type JarvisRuntimeConfig, type ConfigCheckResult } from "./config.js";
 export { openRuntimeDb } from "./runtime-db.js";
 export { runMigrations } from "./migrations/runner.js";
-export { Logger } from "./logger.js";
+export { Logger, type LogContext } from "./logger.js";
 export { createWorkerRegistry, buildEnvelope, type WorkerRegistry } from "./worker-registry.js";
 export { buildPlanWithInference } from "./planner-real.js";
 export { runAgent, type OrchestratorDeps } from "./orchestrator.js";
@@ -13,3 +13,4 @@ export { StatusWriter, type DaemonStatusData } from "./status-writer.js";
 export { AgentQueue } from "./agent-queue.js";
 export { RagPipeline } from "./rag-pipeline.js";
 export { loadPlugins, installPlugin, uninstallPlugin, listPlugins, type PluginManifest } from "./plugin-loader.js";
+export { getHealthReport, getReadinessReport, type HealthReport, type HealthStatus, type ReadinessReport } from "./health.js";

--- a/packages/jarvis-runtime/src/logger.ts
+++ b/packages/jarvis-runtime/src/logger.ts
@@ -1,21 +1,63 @@
 import fs from "node:fs";
 import { join } from "node:path";
-import { JARVIS_DIR, TELEGRAM_QUEUE_FILE } from "./config.js";
+import { JARVIS_DIR } from "./config.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
 const LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
 const LOG_FILE = join(JARVIS_DIR, "daemon.log");
 
+/** Patterns that should be redacted in log output. */
+const REDACT_PATTERNS = [
+  /(?:api[_-]?key|api[_-]?token|secret|password|refresh[_-]?token|client[_-]?secret|bot[_-]?token|webhook[_-]?secret)["']?\s*[:=]\s*["']?([a-zA-Z0-9_\-./+=]{8,})/gi,
+];
+
+function redact(text: string): string {
+  let result = text;
+  for (const pattern of REDACT_PATTERNS) {
+    result = result.replace(pattern, (match, _value) => {
+      const eqIdx = match.search(/[:=]/);
+      return match.slice(0, eqIdx + 1) + " [REDACTED]";
+    });
+  }
+  return result;
+}
+
+/**
+ * Correlation context for structured log entries.
+ * Attach to a Logger via `withContext()` to automatically include
+ * run_id, agent_id, command_id, step_no, action in every log line.
+ */
+export type LogContext = {
+  run_id?: string;
+  agent_id?: string;
+  command_id?: string;
+  step_no?: number;
+  action?: string;
+};
+
 export class Logger {
   private level: number;
   private logToFile: boolean;
   private alertOnError: boolean;
+  private context: LogContext;
 
-  constructor(level: LogLevel = "info", options?: { logToFile?: boolean; alertOnError?: boolean }) {
+  constructor(level: LogLevel = "info", options?: { logToFile?: boolean; alertOnError?: boolean; context?: LogContext }) {
     this.level = LEVELS[level];
     this.logToFile = options?.logToFile ?? true;
     this.alertOnError = options?.alertOnError ?? true;
+    this.context = options?.context ?? {};
+  }
+
+  /**
+   * Create a child logger with additional correlation context.
+   * The child shares the same level and output settings.
+   */
+  withContext(ctx: LogContext): Logger {
+    return new Logger(
+      Object.entries(LEVELS).find(([, v]) => v === this.level)?.[0] as LogLevel ?? "info",
+      { logToFile: this.logToFile, alertOnError: this.alertOnError, context: { ...this.context, ...ctx } },
+    );
   }
 
   debug(msg: string, data?: Record<string, unknown>): void {
@@ -33,46 +75,51 @@ export class Logger {
   error(msg: string, data?: Record<string, unknown>): void {
     if (this.level <= 3) {
       this.write("ERROR", msg, data);
-      if (this.alertOnError) this.sendTelegramAlert(msg, data);
+      if (this.alertOnError) this.sendAlert(msg, data);
     }
   }
 
   private write(level: string, msg: string, data?: Record<string, unknown>): void {
     const ts = new Date().toISOString();
     const tsShort = ts.slice(11, 19);
-    const suffix = data ? ` ${JSON.stringify(data)}` : "";
 
-    // Console output (human-friendly)
-    const consoleLine = `[${tsShort}] [${level.padEnd(5)}] ${msg}${suffix}`;
+    // Merge context + data for structured output
+    const merged = { ...this.context, ...(data ?? {}) };
+    const hasMerged = Object.keys(merged).length > 0;
+    const suffix = hasMerged ? ` ${JSON.stringify(merged)}` : "";
+
+    // Console output (human-friendly with optional context prefix)
+    const ctxPrefix = this.context.agent_id ? `[${this.context.agent_id}] ` : "";
+    const consoleLine = redact(`[${tsShort}] [${level.padEnd(5)}] ${ctxPrefix}${msg}${suffix}`);
     if (level === "ERROR" || level === "WARN") {
       console.error(consoleLine);
     } else {
       console.log(consoleLine);
     }
 
-    // File output (structured JSON, one line per entry)
+    // File output (structured JSON, one line per entry, redacted)
     if (this.logToFile) {
       try {
-        const jsonLine = JSON.stringify({ ts, level, msg, ...(data ?? {}) }) + "\n";
+        const jsonLine = redact(JSON.stringify({ ts, level, msg, ...merged })) + "\n";
         fs.appendFileSync(LOG_FILE, jsonLine);
       } catch { /* non-fatal */ }
     }
   }
 
-  /** Push critical errors to Telegram queue for immediate notification */
-  private sendTelegramAlert(msg: string, data?: Record<string, unknown>): void {
+  /** Push critical errors as alerts (notification system handles delivery) */
+  private sendAlert(msg: string, data?: Record<string, unknown>): void {
     try {
-      const alertMsg = `JARVIS ERROR\n${msg}${data ? "\n" + JSON.stringify(data).slice(0, 300) : ""}`;
-
-      let queue: Array<{ agent: string; message: string; ts: string; sent: boolean }> = [];
-      try {
-        if (fs.existsSync(TELEGRAM_QUEUE_FILE)) {
-          queue = JSON.parse(fs.readFileSync(TELEGRAM_QUEUE_FILE, "utf8")) as typeof queue;
-        }
-      } catch { /* start fresh */ }
-
-      queue.push({ agent: "daemon", message: alertMsg, ts: new Date().toISOString(), sent: false });
-      fs.writeFileSync(TELEGRAM_QUEUE_FILE, JSON.stringify(queue, null, 2));
+      // Write to a simple alert file that the notification system picks up
+      const alertFile = join(JARVIS_DIR, "alerts.jsonl");
+      const entry = JSON.stringify({
+        ts: new Date().toISOString(),
+        level: "ERROR",
+        msg: redact(msg),
+        agent_id: this.context.agent_id ?? "daemon",
+        run_id: this.context.run_id,
+        data: data ? JSON.parse(redact(JSON.stringify(data))) : undefined,
+      });
+      fs.appendFileSync(alertFile, entry + "\n");
     } catch { /* non-fatal */ }
   }
 }

--- a/packages/jarvis-runtime/src/migrate-cli.ts
+++ b/packages/jarvis-runtime/src/migrate-cli.ts
@@ -1,0 +1,30 @@
+/**
+ * Run pending database migrations.
+ *
+ * Usage: jarvis migrate
+ */
+
+import { openRuntimeDb } from "./runtime-db.js";
+
+function main() {
+  console.log("Running pending migrations...");
+  try {
+    const db = openRuntimeDb();
+    const rows = db.prepare(
+      "SELECT name, applied_at FROM schema_migrations ORDER BY applied_at",
+    ).all() as Array<{ name: string; applied_at: string }>;
+
+    console.log(`\n  ${rows.length} migration(s) applied:\n`);
+    for (const row of rows) {
+      console.log(`    ${row.name} — ${row.applied_at}`);
+    }
+    console.log("");
+
+    db.close();
+  } catch (e) {
+    console.error(`Migration error: ${e instanceof Error ? e.message : String(e)}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -39,14 +39,16 @@ export async function runAgent(
   const def = runtime.getDefinition(agentId);
   if (!def) throw new Error(`Agent not registered: ${agentId}`);
 
-  logger.info(`Starting agent: ${agentId} (trigger: ${trigger.kind})`);
-
   // Initialize durable run tracking if runtime DB is available
   const runStore = runtimeDb ? new RunStore(runtimeDb) : null;
 
   // 1. Start run
   const run = runtime.startRun(agentId, trigger);
   runStore?.startRun(agentId); // Emits run_started event
+
+  // Create a context-aware logger for this run
+  const log = logger.withContext({ run_id: run.run_id, agent_id: agentId });
+  log.info(`Starting agent (trigger: ${trigger.kind})`);
 
   // Notify status writer that an agent run started (steps TBD until plan completes)
   statusWriter?.setCurrentRun(agentId, 0);
@@ -78,7 +80,7 @@ export async function runAgent(
     });
 
     if (plan.steps.length === 0) {
-      logger.warn(`Agent ${agentId} produced empty plan`);
+      log.warn("Produced empty plan");
       runStore?.transition(run.run_id, agentId, "completed", "run_completed", {
         details: { reason: "empty_plan" },
       });
@@ -90,11 +92,12 @@ export async function runAgent(
     // Update status writer with actual step count after planning
     statusWriter?.updateTotalSteps(plan.steps.length);
 
-    logger.info(`Agent ${agentId} plan: ${plan.steps.length} steps`);
+    log.info(`Plan: ${plan.steps.length} steps`);
 
     // 4. Execute steps sequentially
     for (const step of plan.steps) {
-      logger.info(`  Step ${step.step}/${plan.steps.length}: ${step.action}`, { reasoning: step.reasoning.slice(0, 100) });
+      const stepLog = log.withContext({ step_no: step.step, action: step.action });
+      stepLog.info(`Step ${step.step}/${plan.steps.length}: ${step.action}`, { reasoning: step.reasoning.slice(0, 100) });
 
       // Emit step_started event
       runStore?.emitEvent(run.run_id, agentId, "step_started", {
@@ -107,7 +110,7 @@ export async function runAgent(
       // Check approval gate
       const gate = def.approval_gates.find(g => g.action === step.action);
       if (gate && runtimeDb) {
-        logger.info(`  Approval required for ${step.action} (${gate.severity})`);
+        stepLog.info(`Approval required (${gate.severity})`);
 
         // Emit approval_requested event
         runStore?.transition(run.run_id, agentId, "awaiting_approval", "approval_requested", {
@@ -136,7 +139,7 @@ export async function runAgent(
         });
 
         if (decision === "rejected") {
-          logger.info(`  Step ${step.step} rejected — skipping`);
+          stepLog.info("Rejected — skipping");
           decisionLog.logDecision({
             agent_id: agentId, run_id: run.run_id, step: step.step,
             action: step.action, reasoning: step.reasoning, outcome: "rejected",
@@ -145,7 +148,7 @@ export async function runAgent(
         }
 
         if (decision === "timeout") {
-          logger.warn(`  Approval timeout for step ${step.step} — aborting run`);
+          stepLog.warn("Approval timeout — aborting run");
           runStore?.transition(run.run_id, agentId, "failed", "run_failed", {
             step_no: step.step, action: step.action,
             details: { reason: "approval_timeout" },
@@ -164,7 +167,7 @@ export async function runAgent(
         runStore?.transition(run.run_id, agentId, "executing", "step_started", {
           step_no: step.step, action: step.action,
         });
-        logger.info(`  Step ${step.step} approved — executing`);
+        stepLog.info("Approved — executing");
       }
 
       // Execute the job
@@ -191,10 +194,10 @@ export async function runAgent(
 
           // Retry once if retryable
           if (result.error?.retryable) {
-            logger.info(`  Step ${step.step} failed (retryable) — retrying`);
+            stepLog.info("Failed (retryable) — retrying");
             const retry = await registry.executeJob({ ...envelope, attempt: 2 });
             if (retry.status === "failed") {
-              logger.warn(`  Step ${step.step} retry also failed`);
+              stepLog.warn("Retry also failed");
             } else {
               runStore?.emitEvent(run.run_id, agentId, "step_completed", {
                 step_no: step.step, action: step.action,
@@ -202,7 +205,7 @@ export async function runAgent(
               });
             }
           } else {
-            logger.warn(`  Step ${step.step} failed: ${result.error?.message}`);
+            stepLog.warn(`Failed: ${result.error?.message}`);
           }
         } else {
           runStore?.emitEvent(run.run_id, agentId, "step_completed", {
@@ -214,7 +217,7 @@ export async function runAgent(
         run.updated_at = new Date().toISOString();
       } catch (e) {
         const errMsg = e instanceof Error ? e.message : String(e);
-        logger.error(`  Step ${step.step} threw: ${errMsg}`);
+        stepLog.error(`Threw: ${errMsg}`);
         runStore?.emitEvent(run.run_id, agentId, "step_failed", {
           step_no: step.step, action: step.action,
           details: { error: errMsg },
@@ -232,7 +235,7 @@ export async function runAgent(
     });
     statusWriter?.completeRun("completed");
     runtime.completeRun(run.run_id);
-    logger.info(`Agent ${agentId} completed (${run.current_step} steps)`);
+    log.info(`Completed (${run.current_step} steps)`);
 
     // 6. Capture lessons
     const decisions = decisionLog.getDecisions(agentId, run.run_id);
@@ -245,7 +248,7 @@ export async function runAgent(
     return runtime.getRun(run.run_id)!;
   } catch (e) {
     const errMsg = e instanceof Error ? e.message : String(e);
-    logger.error(`Agent ${agentId} run failed: ${errMsg}`);
+    log.error(`Run failed: ${errMsg}`);
     runStore?.transition(run.run_id, agentId, "failed", "run_failed", {
       details: { error: errMsg },
     });

--- a/packages/jarvis-runtime/src/status-cli.ts
+++ b/packages/jarvis-runtime/src/status-cli.ts
@@ -1,0 +1,73 @@
+/**
+ * Show daemon status from runtime.db heartbeat.
+ *
+ * Usage: jarvis status
+ */
+
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { RUNTIME_DB_PATH } from "./config.js";
+
+function main() {
+  if (!fs.existsSync(RUNTIME_DB_PATH)) {
+    console.log("Runtime database not found. Run: jarvis init");
+    process.exitCode = 1;
+    return;
+  }
+
+  const db = new DatabaseSync(RUNTIME_DB_PATH);
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+
+  const row = db.prepare(
+    "SELECT daemon_id, pid, status, last_seen_at, details_json FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1",
+  ).get() as { daemon_id: string; pid: number; status: string; last_seen_at: string; details_json: string } | undefined;
+
+  db.close();
+
+  if (!row) {
+    console.log("No daemon heartbeat found. Daemon has not been started.");
+    return;
+  }
+
+  const lastSeen = new Date(row.last_seen_at);
+  const stale = Date.now() - lastSeen.getTime() > 30_000;
+  const details = row.details_json ? JSON.parse(row.details_json) as Record<string, unknown> : {};
+
+  console.log("\n  Jarvis Daemon Status\n");
+  console.log(`  Status:     ${stale ? "STOPPED (heartbeat stale)" : "RUNNING"}`);
+  console.log(`  PID:        ${row.pid}`);
+  console.log(`  Last seen:  ${row.last_seen_at}`);
+
+  if (details.started_at) {
+    const uptime = Math.floor((Date.now() - new Date(details.started_at as string).getTime()) / 1000);
+    if (!stale) {
+      console.log(`  Uptime:     ${formatDuration(uptime)}`);
+    }
+  }
+
+  if (details.agents_registered) {
+    console.log(`  Agents:     ${details.agents_registered}`);
+  }
+  if (details.schedules_active) {
+    console.log(`  Schedules:  ${details.schedules_active}`);
+  }
+
+  const current = details.current_run as Record<string, unknown> | null;
+  if (current && !stale) {
+    console.log(`  Running:    ${current.agent_id} (step ${current.step}/${current.total_steps})`);
+  }
+
+  console.log("");
+}
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+main();

--- a/packages/jarvis-runtime/src/stop-cli.ts
+++ b/packages/jarvis-runtime/src/stop-cli.ts
@@ -1,0 +1,53 @@
+/**
+ * Stop the running Jarvis daemon by sending SIGTERM to the heartbeat PID.
+ *
+ * Usage: jarvis stop
+ */
+
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { RUNTIME_DB_PATH } from "./config.js";
+
+function main() {
+  if (!fs.existsSync(RUNTIME_DB_PATH)) {
+    console.log("Runtime database not found. Daemon is not running.");
+    return;
+  }
+
+  const db = new DatabaseSync(RUNTIME_DB_PATH);
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+
+  const row = db.prepare(
+    "SELECT pid, last_seen_at FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1",
+  ).get() as { pid: number; last_seen_at: string } | undefined;
+
+  db.close();
+
+  if (!row) {
+    console.log("No daemon heartbeat found. Daemon is not running.");
+    return;
+  }
+
+  const lastSeen = new Date(row.last_seen_at);
+  const stale = Date.now() - lastSeen.getTime() > 30_000;
+
+  if (stale) {
+    console.log(`Daemon heartbeat is stale (last seen ${row.last_seen_at}). Daemon may have already stopped.`);
+    return;
+  }
+
+  try {
+    process.kill(row.pid, "SIGTERM");
+    console.log(`Sent SIGTERM to daemon (PID ${row.pid}). Daemon will drain and shut down.`);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ESRCH") {
+      console.log(`PID ${row.pid} not found. Daemon already stopped.`);
+    } else {
+      console.error(`Failed to stop daemon: ${e instanceof Error ? e.message : String(e)}`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+main();

--- a/scripts/init-jarvis.ts
+++ b/scripts/init-jarvis.ts
@@ -19,6 +19,7 @@ import { DatabaseSync } from "node:sqlite";
 const JARVIS_DIR = join(homedir(), ".jarvis");
 const CRM_DB_PATH = join(JARVIS_DIR, "crm.db");
 const KNOWLEDGE_DB_PATH = join(JARVIS_DIR, "knowledge.db");
+const RUNTIME_DB_PATH = join(JARVIS_DIR, "runtime.db");
 
 function now(): string {
   return new Date().toISOString();
@@ -369,6 +370,40 @@ function initKnowledgeDatabase(): boolean {
   return true;
 }
 
+// ─── Runtime Database ──────────────────────────────────────────────────────
+
+function initRuntimeDatabase(): boolean {
+  const isNew = !existsSync(RUNTIME_DB_PATH);
+
+  // openRuntimeDb handles creation + WAL + migrations
+  // We import it dynamically to avoid circular dependency issues in the init script
+  const db = new DatabaseSync(RUNTIME_DB_PATH);
+  try {
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec("PRAGMA busy_timeout = 5000;");
+
+    // Run the migration runner from the runtime package
+    // We inline the migration check here to avoid needing a built package
+    const rows = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'",
+    ).all() as Array<{ name: string }>;
+
+    if (rows.length > 0) {
+      // Migrations table exists — runtime-db.ts will handle pending migrations at daemon startup
+      const applied = db.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number };
+      console.log(`  [exists]  Runtime database: ${RUNTIME_DB_PATH} (${applied.n} migrations applied)`);
+    } else {
+      // Fresh database — openRuntimeDb() in the daemon will create and migrate
+      console.log(`  [created] Runtime database: ${RUNTIME_DB_PATH}`);
+      console.log(`            Migrations will run on first daemon start`);
+    }
+  } finally {
+    db.close();
+  }
+  return isNew;
+}
+
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 function main(): void {
@@ -385,11 +420,13 @@ function main(): void {
 
   const crmCreated = initCrmDatabase();
   const knowledgeCreated = initKnowledgeDatabase();
+  const runtimeCreated = initRuntimeDatabase();
 
   console.log("\n── Summary ──────────────────────────────────────────────");
   console.log(`  Directory:    ${JARVIS_DIR}`);
   console.log(`  CRM DB:       ${crmCreated ? "CREATED" : "already existed"}`);
   console.log(`  Knowledge DB: ${knowledgeCreated ? "CREATED" : "already existed"}`);
+  console.log(`  Runtime DB:   ${runtimeCreated ? "CREATED" : "already existed"}`);
   console.log("  Done.\n");
 }
 

--- a/scripts/jarvis.mjs
+++ b/scripts/jarvis.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Jarvis CLI entrypoint.
+ *
+ * Dispatches to subcommands without adding a CLI framework dependency.
+ *
+ * Usage:
+ *   node scripts/jarvis.mjs <command> [options]
+ *   npm run jarvis -- <command> [options]
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import os from "node:os";
+import path from "node:path";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+
+const COMMANDS = {
+  doctor: {
+    description: "Check system health and prerequisites",
+    run: () => tsx("packages/jarvis-runtime/src/doctor.ts"),
+  },
+  init: {
+    description: "Initialize ~/.jarvis databases and config",
+    run: () => tsx("scripts/init-jarvis.ts"),
+  },
+  migrate: {
+    description: "Run pending database migrations",
+    run: () => tsx("packages/jarvis-runtime/src/migrate-cli.ts"),
+  },
+  start: {
+    description: "Start the Jarvis daemon",
+    run: () => tsx("packages/jarvis-runtime/src/daemon.ts"),
+  },
+  stop: {
+    description: "Stop the running Jarvis daemon",
+    run: () => stopDaemon(),
+  },
+  status: {
+    description: "Show daemon status",
+    run: () => tsx("packages/jarvis-runtime/src/status-cli.ts"),
+  },
+  logs: {
+    description: "Tail daemon logs",
+    run: () => tailLogs(),
+  },
+  health: {
+    description: "Run ops health check",
+    run: () => runScript("node", ["scripts/ops/healthcheck.mjs"]),
+  },
+  backup: {
+    description: "Create a runtime backup bundle",
+    run: () => runScript("node", ["scripts/ops/backup-runtime.mjs"]),
+  },
+  restore: {
+    description: "Restore from a backup bundle",
+    run: () => runScript("node", ["scripts/ops/recover-runtime.mjs"]),
+  },
+  dashboard: {
+    description: "Start the dashboard server",
+    run: () => tsx("packages/jarvis-dashboard/src/api/server.ts"),
+  },
+  "benchmark-models": {
+    description: "Benchmark locally available models",
+    run: () => tsx("packages/jarvis-inference/src/benchmark-cli.ts"),
+  },
+  demo: {
+    description: "Run a demo agent cycle",
+    run: () => tsx("scripts/demo.ts"),
+  },
+};
+
+function tsx(script) {
+  return runScript("npx", ["tsx", script]);
+}
+
+function runScript(cmd, args) {
+  const passthrough = process.argv.slice(3); // skip node, jarvis.mjs, command
+  const child = spawn(cmd, [...args, ...passthrough], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: true,
+  });
+  child.on("exit", (code) => {
+    process.exitCode = code ?? 1;
+  });
+}
+
+function stopDaemon() {
+  tsx("packages/jarvis-runtime/src/stop-cli.ts");
+}
+
+function tailLogs() {
+  const logFile = path.join(os.homedir(), ".jarvis", "daemon.log");
+  const passthrough = process.argv.slice(3);
+  const lines = passthrough.find(a => a.startsWith("-n"))?.slice(2) || "50";
+
+  if (process.platform === "win32") {
+    runScript("powershell", ["-Command", `Get-Content -Path "${logFile}" -Tail ${lines} -Wait`]);
+  } else {
+    runScript("tail", ["-f", "-n", lines, logFile]);
+  }
+}
+
+function showHelp() {
+  console.log("");
+  console.log("  Jarvis CLI — Autonomous Agent System");
+  console.log("");
+  console.log("  Usage: jarvis <command> [options]");
+  console.log("");
+  console.log("  Commands:");
+  const maxLen = Math.max(...Object.keys(COMMANDS).map(k => k.length));
+  for (const [name, cmd] of Object.entries(COMMANDS)) {
+    console.log(`    ${name.padEnd(maxLen + 2)} ${cmd.description}`);
+  }
+  console.log("");
+  console.log("  Options:");
+  console.log("    --help    Show this help message");
+  console.log("");
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+const command = process.argv[2];
+
+if (!command || command === "--help" || command === "-h" || command === "help") {
+  showHelp();
+  process.exit(0);
+}
+
+const entry = COMMANDS[command];
+if (!entry) {
+  console.error(`Unknown command: ${command}`);
+  console.error(`Run "jarvis --help" for available commands.`);
+  process.exit(1);
+}
+
+entry.run();

--- a/scripts/ops/backup-runtime.mjs
+++ b/scripts/ops/backup-runtime.mjs
@@ -1,4 +1,7 @@
 import path from "node:path";
+import os from "node:os";
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
 import {
   DEFAULT_PROFILE,
   buildBackupManifest,
@@ -54,6 +57,42 @@ async function main() {
     copiedArtifacts.push(copiedReportPath);
   }
 
+  // Backup Jarvis runtime databases (~/.jarvis/*.db)
+  const jarvisDir = path.join(os.homedir(), ".jarvis");
+  const jarvisTarget = path.join(bundleDir, "jarvis");
+  const copiedDatabases = [];
+  for (const dbName of ["runtime.db", "crm.db", "knowledge.db"]) {
+    const dbPath = path.join(jarvisDir, dbName);
+    try {
+      await fs.access(dbPath);
+      await ensureDir(jarvisTarget);
+      await fs.copyFile(dbPath, path.join(jarvisTarget, dbName));
+      copiedDatabases.push(dbName);
+      // Also copy WAL/SHM files if they exist
+      for (const suffix of ["-wal", "-shm"]) {
+        try {
+          await fs.access(dbPath + suffix);
+          await fs.copyFile(dbPath + suffix, path.join(jarvisTarget, dbName + suffix));
+        } catch { /* no WAL/SHM file, fine */ }
+      }
+    } catch { /* db doesn't exist, skip */ }
+  }
+  // Copy config.json if it exists
+  try {
+    const configJsonPath = path.join(jarvisDir, "config.json");
+    await fs.access(configJsonPath);
+    await ensureDir(jarvisTarget);
+    await fs.copyFile(configJsonPath, path.join(jarvisTarget, "config.json"));
+  } catch { /* no config.json */ }
+
+  // Compute checksums for integrity verification
+  const checksums = {};
+  for (const dbName of copiedDatabases) {
+    const filePath = path.join(jarvisTarget, dbName);
+    const content = await fs.readFile(filePath);
+    checksums[dbName] = crypto.createHash("sha256").update(content).digest("hex");
+  }
+
   const manifest = buildBackupManifest({
     profile,
     bundleDir,
@@ -64,6 +103,8 @@ async function main() {
     copiedWorkspace,
     copiedArtifacts
   });
+  manifest.jarvisDatabases = copiedDatabases;
+  manifest.checksums = checksums;
 
   await writeJson(path.join(bundleDir, "manifest.json"), manifest);
 

--- a/scripts/ops/recover-runtime.mjs
+++ b/scripts/ops/recover-runtime.mjs
@@ -1,4 +1,7 @@
 import path from "node:path";
+import os from "node:os";
+import { promises as fs } from "node:fs";
+import crypto from "node:crypto";
 import {
   DEFAULT_PROFILE,
   copyTree,
@@ -38,10 +41,52 @@ async function restoreBundle(bundleDir, profile, restoreWorkspace) {
     }
   }
 
+  // Restore Jarvis databases if backup contains them
+  const jarvisDir = path.join(os.homedir(), ".jarvis");
+  const bundleJarvisDir = path.join(bundleDir, "jarvis");
+  const restoredDatabases = [];
+  const checksumResults = {};
+
+  try {
+    await fs.access(bundleJarvisDir);
+    await ensureDir(jarvisDir);
+
+    for (const dbName of ["runtime.db", "crm.db", "knowledge.db", "config.json"]) {
+      const srcPath = path.join(bundleJarvisDir, dbName);
+      try {
+        await fs.access(srcPath);
+
+        // Validate checksum before restoring
+        if (manifest.checksums?.[dbName]) {
+          const content = await fs.readFile(srcPath);
+          const actual = crypto.createHash("sha256").update(content).digest("hex");
+          if (actual !== manifest.checksums[dbName]) {
+            checksumResults[dbName] = "MISMATCH";
+            continue; // Skip corrupted files
+          }
+          checksumResults[dbName] = "OK";
+        }
+
+        await fs.copyFile(srcPath, path.join(jarvisDir, dbName));
+        restoredDatabases.push(dbName);
+
+        // Restore WAL/SHM if present
+        for (const suffix of ["-wal", "-shm"]) {
+          try {
+            await fs.access(srcPath + suffix);
+            await fs.copyFile(srcPath + suffix, path.join(jarvisDir, dbName + suffix));
+          } catch { /* no WAL/SHM */ }
+        }
+      } catch { /* file not in backup */ }
+    }
+  } catch { /* no jarvis backup dir */ }
+
   return {
     manifest,
     activeProfileDir,
-    activeConfigPath
+    activeConfigPath,
+    restoredDatabases,
+    checksumResults
   };
 }
 

--- a/tests/daemon-components.test.ts
+++ b/tests/daemon-components.test.ts
@@ -559,20 +559,22 @@ describe("Logger", () => {
     expect(firstLine.ts).toBeTruthy();
   });
 
-  it("error level triggers Telegram alert", () => {
+  it("error level triggers alert", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const alertsFile = join(TEMP_DIR, "alerts.jsonl");
 
     const logger = new Logger("info", { logToFile: false, alertOnError: true });
     logger.error("critical failure", { component: "crm" });
 
     consoleSpy.mockRestore();
 
-    expect(fs.existsSync(TEMP_TELEGRAM_QUEUE)).toBe(true);
-    const queue = JSON.parse(fs.readFileSync(TEMP_TELEGRAM_QUEUE, "utf8")) as Array<Record<string, unknown>>;
-    expect(queue.length).toBeGreaterThan(0);
-    expect(queue[0]!.agent).toBe("daemon");
-    expect((queue[0]!.message as string)).toContain("critical failure");
-    expect(queue[0]!.sent).toBe(false);
+    expect(fs.existsSync(alertsFile)).toBe(true);
+    const lines = fs.readFileSync(alertsFile, "utf8").trim().split("\n");
+    expect(lines.length).toBeGreaterThan(0);
+    const entry = JSON.parse(lines[0]!) as Record<string, unknown>;
+    expect(entry.level).toBe("ERROR");
+    expect(entry.msg).toContain("critical failure");
+    expect(entry.agent_id).toBe("daemon");
   });
 
   it("debug messages filtered when level is 'info'", () => {

--- a/tests/smoke/lifecycle.test.ts
+++ b/tests/smoke/lifecycle.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Smoke tests for the Jarvis runtime lifecycle.
+ *
+ * These tests exercise the core control plane: database init, migration,
+ * health checks, config validation, run store, approval bridge, and
+ * daemon heartbeat — all against temp SQLite databases.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { runMigrations, RunStore, validateConfig, type JarvisRuntimeConfig } from "@jarvis/runtime";
+import { requestApproval, resolveApproval, listApprovals } from "@jarvis/runtime";
+import { StatusWriter } from "@jarvis/runtime";
+import { Logger } from "@jarvis/runtime";
+
+function createTestDb(): { db: DatabaseSync; path: string } {
+  const dbPath = join(os.tmpdir(), `jarvis-smoke-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA foreign_keys = ON;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  runMigrations(db);
+  return { db, path: dbPath };
+}
+
+function cleanup(db: DatabaseSync, dbPath: string) {
+  try { db.close(); } catch { /* ok */ }
+  try { fs.unlinkSync(dbPath); } catch { /* ok */ }
+  try { fs.unlinkSync(dbPath + "-wal"); } catch { /* ok */ }
+  try { fs.unlinkSync(dbPath + "-shm"); } catch { /* ok */ }
+}
+
+describe("Smoke: Database Lifecycle", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("creates all 12 runtime tables", () => {
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name != 'schema_migrations'",
+    ).all() as Array<{ name: string }>;
+    const names = tables.map(t => t.name).sort();
+    expect(names).toEqual([
+      "agent_commands", "agent_memory", "approvals", "audit_log",
+      "daemon_heartbeats", "model_benchmarks", "model_registry",
+      "notifications", "plugin_installs", "run_events",
+      "schedules", "settings",
+    ]);
+  });
+
+  it("migration is idempotent", () => {
+    runMigrations(db); // second time
+    runMigrations(db); // third time
+    const rows = db.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number };
+    expect(rows.n).toBe(1);
+  });
+});
+
+describe("Smoke: Run Store", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("tracks a run through its lifecycle", () => {
+    const store = new RunStore(db);
+    const runId = store.startRun("test-agent");
+
+    // startRun transitions: queued -> planning
+    expect(store.getStatus(runId)).toBe("planning");
+
+    store.transition(runId, "test-agent", "executing", "step_started");
+    expect(store.getStatus(runId)).toBe("executing");
+
+    store.transition(runId, "test-agent", "completed", "run_completed");
+    expect(store.getStatus(runId)).toBe("completed");
+  });
+
+  it("records events for replay", () => {
+    const store = new RunStore(db);
+    const runId = store.startRun("test-agent");
+    store.emitEvent(runId, "test-agent", "step_started", { step_no: 1, action: "test.action" });
+    store.emitEvent(runId, "test-agent", "step_completed", { step_no: 1, action: "test.action" });
+
+    const events = store.getRunEvents(runId);
+    expect(events.length).toBeGreaterThanOrEqual(3); // run_started + 2 manual
+    expect(events.some(e => e.event_type === "step_started")).toBe(true);
+    expect(events.some(e => e.event_type === "step_completed")).toBe(true);
+  });
+
+  it("rejects invalid transitions", () => {
+    const store = new RunStore(db);
+    const runId = store.startRun("test-agent");
+    // startRun transitions to planning; go to executing then completed
+    store.transition(runId, "test-agent", "executing", "step_started");
+    store.transition(runId, "test-agent", "completed", "run_completed");
+
+    // completed -> executing is not allowed
+    expect(() =>
+      store.transition(runId, "test-agent", "executing", "step_started"),
+    ).toThrow();
+  });
+});
+
+describe("Smoke: Approval Bridge", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("creates, lists, and resolves approvals", () => {
+    const approvalId = requestApproval(db, {
+      agent_id: "test-agent",
+      run_id: "run-1",
+      action: "email.send",
+      severity: "critical",
+      payload: "Send email to client",
+    });
+
+    expect(approvalId).toBeTruthy();
+
+    const pending = listApprovals(db, "pending");
+    expect(pending.length).toBe(1);
+    expect(pending[0].action).toBe("email.send");
+
+    resolveApproval(db, approvalId, "approved", "admin", "Looks good");
+
+    const afterResolve = listApprovals(db, "pending");
+    expect(afterResolve.length).toBe(0);
+
+    const all = listApprovals(db);
+    expect(all.length).toBe(1);
+    expect(all[0].status).toBe("approved");
+  });
+});
+
+describe("Smoke: Daemon Heartbeat", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("writes and reads heartbeat data", () => {
+    const logger = new Logger("warn", { logToFile: false, alertOnError: false });
+    const writer = new StatusWriter(5, 3, logger, db);
+
+    // Manual flush
+    (writer as unknown as { flush: () => void }).flush();
+
+    const row = db.prepare(
+      "SELECT pid, status, details_json FROM daemon_heartbeats LIMIT 1",
+    ).get() as { pid: number; status: string; details_json: string } | undefined;
+
+    expect(row).toBeTruthy();
+    expect(row!.pid).toBe(process.pid);
+    expect(row!.status).toBe("idle");
+
+    const details = JSON.parse(row!.details_json);
+    expect(details.agents_registered).toBe(5);
+    expect(details.schedules_active).toBe(3);
+  });
+});
+
+describe("Smoke: Config Validation", () => {
+  it("validates a correct config", () => {
+    const config: JarvisRuntimeConfig = {
+      lmstudio_url: "http://localhost:1234",
+      default_model: "auto",
+      adapter_mode: "mock",
+      poll_interval_ms: 60000,
+      trigger_poll_ms: 10000,
+      max_concurrent: 2,
+      log_level: "info",
+    };
+
+    const result = validateConfig(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects invalid poll interval", () => {
+    const config = {
+      lmstudio_url: "http://localhost:1234",
+      default_model: "auto",
+      adapter_mode: "mock",
+      poll_interval_ms: 100, // too low
+      trigger_poll_ms: 10000,
+      max_concurrent: 2,
+      log_level: "info",
+    } as unknown as JarvisRuntimeConfig;
+
+    const result = validateConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Smoke: Agent Commands", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("inserts, claims, and completes commands", () => {
+    const id = "cmd-" + Date.now();
+    db.prepare(
+      "INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, priority, created_at, created_by) VALUES (?, ?, ?, 'queued', 0, ?, ?)",
+    ).run(id, "run_agent", "test-agent", new Date().toISOString(), "test");
+
+    // Read queued
+    const queued = db.prepare("SELECT * FROM agent_commands WHERE status='queued'").all();
+    expect(queued.length).toBe(1);
+
+    // Claim
+    db.prepare("UPDATE agent_commands SET status='claimed', claimed_at=? WHERE command_id=?").run(new Date().toISOString(), id);
+
+    // Complete
+    db.prepare("UPDATE agent_commands SET status='completed', completed_at=? WHERE command_id=?").run(new Date().toISOString(), id);
+
+    const final = db.prepare("SELECT status FROM agent_commands WHERE command_id=?").get(id) as { status: string };
+    expect(final.status).toBe("completed");
+  });
+
+  it("enforces idempotency key uniqueness", () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      "INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, priority, created_at, created_by, idempotency_key) VALUES (?, ?, ?, 'queued', 0, ?, ?, ?)",
+    ).run("cmd-1", "run_agent", "agent-a", now, "test", "unique-key-1");
+
+    expect(() =>
+      db.prepare(
+        "INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, priority, created_at, created_by, idempotency_key) VALUES (?, ?, ?, 'queued', 0, ?, ?, ?)",
+      ).run("cmd-2", "run_agent", "agent-a", now, "test", "unique-key-1"),
+    ).toThrow();
+  });
+});
+
+describe("Smoke: Notifications", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("inserts and reads notifications", () => {
+    db.prepare(
+      "INSERT INTO notifications (notification_id, channel, kind, payload_json, status, created_at) VALUES (?, ?, ?, ?, 'pending', ?)",
+    ).run("notif-1", "telegram", "agent_complete", JSON.stringify({ message: "Test done" }), new Date().toISOString());
+
+    const pending = db.prepare("SELECT * FROM notifications WHERE status='pending'").all();
+    expect(pending.length).toBe(1);
+  });
+});
+
+describe("Smoke: Logger", () => {
+  it("creates child loggers with context", () => {
+    const logger = new Logger("debug", { logToFile: false, alertOnError: false });
+    const child = logger.withContext({ run_id: "r1", agent_id: "test" });
+    const grandchild = child.withContext({ step_no: 3, action: "email.send" });
+
+    // Should not throw
+    grandchild.info("test message", { extra: "data" });
+    grandchild.debug("debug");
+    grandchild.warn("warning");
+  });
+});


### PR DESCRIPTION
## Summary
- **CLI entrypoint** (`jarvis doctor/init/start/stop/status/logs/backup/restore`) — thin dispatcher, no framework dependency
- **`jarvis doctor`** — checks Node version, databases (CRM/knowledge/runtime), WAL mode, config validation, LM Studio, Ollama, Chrome debugging, disk space
- **Init integration** — `jarvis init` now creates `runtime.db` alongside CRM and knowledge databases
- **Backup/restore** — includes all 3 SQLite databases with SHA-256 checksums and integrity validation on restore
- **Health & readiness endpoints** — `/api/health` uses runtime.db (pending approvals, commands, recent runs, daemon heartbeat); new `/api/ready` for probes
- **Structured logging** — correlation context (`run_id`, `agent_id`, `step_no`, `action`), child loggers via `withContext()`, automatic secret redaction
- **Smoke test suite** — 8 describe blocks covering DB lifecycle, run store, approval bridge, heartbeat, config validation, agent commands, notifications, logger
- **CI workflow** — GitHub Actions: install, validate contracts, test (990 tests), build
- **Garden-calendar** — skill updated to use runtime.db notifications instead of deprecated telegram-queue.json

## Test plan
- [x] All 990 tests pass (35 files)
- [x] TypeScript build succeeds
- [x] 143 contracts validated
- [x] Smoke tests cover core control plane operations
- [ ] Manual: run `jarvis doctor` on EVO-X2
- [ ] Manual: run `jarvis init` on clean ~/.jarvis
- [ ] Manual: backup/restore round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)