### PR TITLE
R3: Safe local production

### DIFF
--- a/packages/jarvis-dashboard/src/api/approvals.ts
+++ b/packages/jarvis-dashboard/src/api/approvals.ts
@@ -3,6 +3,8 @@ import { DatabaseSync } from 'node:sqlite'
 import os from 'os'
 import { join } from 'path'
 import { listApprovals, resolveApproval } from '@jarvis/runtime'
+import { writeAuditLog, getActor } from './middleware/audit.js'
+import type { AuthenticatedRequest } from './middleware/auth.js'
 
 function getDb(): DatabaseSync {
   const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
@@ -37,6 +39,8 @@ approvalsRouter.post('/:id/approve', (req, res) => {
       res.status(404).json({ error: 'Approval not found or already resolved' })
       return
     }
+    const actor = getActor(req as AuthenticatedRequest)
+    writeAuditLog(actor.type, actor.id, 'approval.approved', 'approval', req.params.id!, {})
     const approvals = listApprovals(db)
     const entry = approvals.find(a => a.id === req.params.id)
     res.json(entry)
@@ -54,6 +58,8 @@ approvalsRouter.post('/:id/reject', (req, res) => {
       res.status(404).json({ error: 'Approval not found or already resolved' })
       return
     }
+    const actor = getActor(req as AuthenticatedRequest)
+    writeAuditLog(actor.type, actor.id, 'approval.rejected', 'approval', req.params.id!, {})
     const approvals = listApprovals(db)
     const entry = approvals.find(a => a.id === req.params.id)
     res.json(entry)

--- a/packages/jarvis-dashboard/src/api/middleware/audit.ts
+++ b/packages/jarvis-dashboard/src/api/middleware/audit.ts
@@ -1,0 +1,68 @@
+/**
+ * Audit log helpers for the dashboard API.
+ *
+ * Writes to the audit_log table in runtime.db for all security-sensitive actions.
+ */
+
+import { randomUUID } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import os from "node:os";
+import { join } from "node:path";
+import type { AuthenticatedRequest } from "./auth.js";
+
+function getDb(): DatabaseSync {
+  const db = new DatabaseSync(join(os.homedir(), ".jarvis", "runtime.db"));
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  return db;
+}
+
+/**
+ * Write an audit log entry.
+ *
+ * @param actor - Who performed the action (e.g., "dashboard:admin", "webhook:github")
+ * @param action - What was done (e.g., "approval.approved", "settings.updated")
+ * @param target - What was affected (e.g., "approval:abc-123", "agent:bd-pipeline")
+ * @param payload - Additional context
+ */
+export function writeAuditLog(
+  actorType: string,
+  actorId: string,
+  action: string,
+  targetType: string,
+  targetId: string,
+  payload?: Record<string, unknown>,
+): void {
+  let db: DatabaseSync | null = null;
+  try {
+    db = getDb();
+    db.prepare(`
+      INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(),
+      actorType,
+      actorId,
+      action,
+      targetType,
+      targetId,
+      payload ? JSON.stringify(payload) : null,
+      new Date().toISOString(),
+    );
+  } catch {
+    // Non-fatal — audit should never block the operation
+  } finally {
+    try { db?.close(); } catch { /* best-effort */ }
+  }
+}
+
+/**
+ * Extract actor info from an authenticated request.
+ */
+export function getActor(req: AuthenticatedRequest): { type: string; id: string } {
+  const user = (req as AuthenticatedRequest).user;
+  if (user) {
+    return { type: "dashboard", id: `${user.role}:${user.token_prefix}` };
+  }
+  return { type: "dashboard", id: "anonymous" };
+}

--- a/packages/jarvis-dashboard/src/api/middleware/auth.ts
+++ b/packages/jarvis-dashboard/src/api/middleware/auth.ts
@@ -1,0 +1,180 @@
+/**
+ * Authentication and authorization middleware for the Jarvis dashboard API.
+ *
+ * Uses Bearer token auth with role-based access control.
+ * Token is read from JARVIS_API_TOKEN env var or ~/.jarvis/config.json.
+ *
+ * Roles:
+ *   admin    — full access, can change settings, approve actions, manage plugins
+ *   operator — can trigger agents, approve/reject, view everything
+ *   viewer   — read-only access to dashboards and status
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import fs from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+
+export type UserRole = "admin" | "operator" | "viewer";
+
+export type AuthenticatedRequest = Request & {
+  user?: { role: UserRole; token_prefix: string };
+};
+
+type TokenEntry = {
+  token: string;
+  role: UserRole;
+};
+
+/** Load API tokens from config. Supports single token or role-based token map. */
+function loadTokens(): TokenEntry[] {
+  // Check env first
+  const envToken = process.env.JARVIS_API_TOKEN;
+  if (envToken) {
+    return [{ token: envToken, role: "admin" }];
+  }
+
+  // Check config file
+  const configPath = join(os.homedir(), ".jarvis", "config.json");
+  if (!fs.existsSync(configPath)) return [];
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+
+    // Simple token: api_token: "secret" -> admin role
+    if (typeof raw.api_token === "string") {
+      return [{ token: raw.api_token, role: "admin" }];
+    }
+
+    // Role-based tokens: api_tokens: { admin: "...", operator: "...", viewer: "..." }
+    if (raw.api_tokens && typeof raw.api_tokens === "object") {
+      const tokens: TokenEntry[] = [];
+      const map = raw.api_tokens as Record<string, string>;
+      for (const [role, token] of Object.entries(map)) {
+        if (isValidRole(role) && typeof token === "string") {
+          tokens.push({ token, role });
+        }
+      }
+      return tokens;
+    }
+  } catch { /* can't read config */ }
+
+  return [];
+}
+
+function isValidRole(role: string): role is UserRole {
+  return role === "admin" || role === "operator" || role === "viewer";
+}
+
+/** Route permission matrix. Maps HTTP method to minimum required role. */
+const ROUTE_PERMISSIONS: Record<string, Record<string, UserRole>> = {
+  // Settings and plugin management require admin
+  "/api/settings": { GET: "viewer", POST: "admin", PATCH: "admin", DELETE: "admin" },
+  "/api/plugins": { GET: "viewer", POST: "admin", DELETE: "admin" },
+  "/api/godmode": { GET: "operator", POST: "admin" },
+
+  // Approvals: viewing is operator, resolving is operator
+  "/api/approvals": { GET: "operator", POST: "operator", PATCH: "operator" },
+
+  // Agent triggers and webhooks require operator
+  "/api/webhooks": { POST: "operator" },
+
+  // CRM mutations require operator
+  "/api/crm": { GET: "viewer", POST: "operator", PATCH: "operator", DELETE: "admin" },
+
+  // Knowledge mutations require operator
+  "/api/knowledge": { GET: "viewer", POST: "operator", PATCH: "operator", DELETE: "admin" },
+
+  // Read-only routes
+  "/api/agents": { GET: "viewer" },
+  "/api/daemon": { GET: "viewer" },
+  "/api/runs": { GET: "viewer" },
+  "/api/entities": { GET: "viewer" },
+  "/api/analytics": { GET: "viewer" },
+  "/api/chat": { GET: "viewer", POST: "operator" },
+};
+
+const ROLE_HIERARCHY: Record<UserRole, number> = {
+  admin: 3,
+  operator: 2,
+  viewer: 1,
+};
+
+function hasPermission(userRole: UserRole, requiredRole: UserRole): boolean {
+  return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[requiredRole];
+}
+
+/**
+ * Resolve the minimum role required for a given route and method.
+ * Falls back to "viewer" for GET, "operator" for mutations.
+ */
+function getRequiredRole(path: string, method: string): UserRole {
+  // Find matching route prefix
+  for (const [prefix, perms] of Object.entries(ROUTE_PERMISSIONS)) {
+    if (path.startsWith(prefix)) {
+      const role = perms[method.toUpperCase()];
+      if (role) return role;
+    }
+  }
+
+  // Default: GET is viewer, everything else is operator
+  return method.toUpperCase() === "GET" ? "viewer" : "operator";
+}
+
+/**
+ * Auth middleware factory. Returns middleware that:
+ * - Skips auth for /api/health and /api/ready (always public)
+ * - If no tokens configured, allows all requests (dev mode)
+ * - Otherwise requires Bearer token and checks role permissions
+ */
+export function createAuthMiddleware() {
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+    // Health and readiness are always public
+    if (req.path === "/api/health" || req.path === "/api/ready") {
+      next();
+      return;
+    }
+
+    // Non-API routes (SPA, static assets) don't need auth
+    if (!req.path.startsWith("/api/")) {
+      next();
+      return;
+    }
+
+    const tokens = loadTokens();
+
+    // If no tokens configured, allow all (dev mode)
+    if (tokens.length === 0) {
+      req.user = { role: "admin", token_prefix: "none" };
+      next();
+      return;
+    }
+
+    // Extract Bearer token
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Missing or invalid Authorization header. Use: Bearer <token>" });
+      return;
+    }
+
+    const providedToken = authHeader.slice(7);
+    const match = tokens.find(t => t.token === providedToken);
+
+    if (!match) {
+      res.status(401).json({ error: "Invalid API token" });
+      return;
+    }
+
+    // Check role permission for this route + method
+    const requiredRole = getRequiredRole(req.path, req.method);
+    if (!hasPermission(match.role, requiredRole)) {
+      res.status(403).json({
+        error: `Insufficient permissions. Required: ${requiredRole}, have: ${match.role}`,
+      });
+      return;
+    }
+
+    req.user = { role: match.role, token_prefix: providedToken.slice(0, 4) };
+    next();
+  };
+}

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -16,23 +16,37 @@ import { portalRouter } from './portal.js'
 import { godmodeRouter } from './godmode.js'
 import fs from 'fs'
 import { getHealthReport, getReadinessReport } from '@jarvis/runtime'
+import { createAuthMiddleware } from './middleware/auth.js'
 
 const app = express()
 const PORT = Number(process.env.PORT ?? 4242)
+const ALLOWED_ORIGIN = process.env.JARVIS_CORS_ORIGIN ?? `http://localhost:${PORT}`
 const distPath = join(process.cwd(), 'packages', 'jarvis-dashboard', 'dist')
 const indexHtml = join(distPath, 'index.html')
 
-app.use(express.json())
+// Request size limit
+app.use(express.json({ limit: '1mb' }))
 app.use((req, _res, next) => {
   console.log(`[${req.method}] ${req.path}`)
   next()
 })
+
+// CORS — restricted to configured origin (defaults to localhost)
 app.use((_req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*')
-  res.header('Access-Control-Allow-Headers', 'Content-Type')
-  res.header('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE')
+  res.header('Access-Control-Allow-Origin', ALLOWED_ORIGIN)
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  res.header('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS')
+  res.header('Access-Control-Max-Age', '3600')
   next()
 })
+
+// Handle CORS preflight
+app.options('/{*splat}', (_req, res) => {
+  res.sendStatus(204)
+})
+
+// Auth middleware — protects all /api/* except /api/health and /api/ready
+app.use(createAuthMiddleware())
 
 app.use('/api/crm', crmRouter)
 app.use('/api/knowledge', knowledgeRouter)

--- a/packages/jarvis-dashboard/src/api/settings.ts
+++ b/packages/jarvis-dashboard/src/api/settings.ts
@@ -2,6 +2,8 @@ import { Router } from 'express'
 import os from 'os'
 import { join } from 'path'
 import fs from 'fs'
+import { writeAuditLog, getActor } from './middleware/audit.js'
+import type { AuthenticatedRequest } from './middleware/auth.js'
 
 const JARVIS_DIR = join(os.homedir(), '.jarvis')
 const CONFIG_PATH = join(JARVIS_DIR, 'config.json')
@@ -119,6 +121,8 @@ settingsRouter.patch('/', (req, res) => {
   }
   const merged = deepMerge(config, updates, maskedConfig)
   writeConfig(merged)
+  const actor = getActor(req as AuthenticatedRequest)
+  writeAuditLog(actor.type, actor.id, 'settings.updated', 'settings', 'config', { keys: Object.keys(updates) })
   res.json(maskSensitive(merged))
 })
 
@@ -146,5 +150,7 @@ settingsRouter.patch('/agents/:id', (req, res) => {
   if (!config.enabled_agents) config.enabled_agents = {}
   ;(config.enabled_agents as Record<string, boolean>)[id] = enabled !== false
   writeConfig(config)
+  const actor = getActor(req as AuthenticatedRequest)
+  writeAuditLog(actor.type, actor.id, 'agent.toggled', 'agent', id, { enabled: enabled !== false })
   res.json({ id, enabled: enabled !== false })
 })

--- a/packages/jarvis-dashboard/src/api/webhooks.ts
+++ b/packages/jarvis-dashboard/src/api/webhooks.ts
@@ -122,8 +122,39 @@ webhookRouter.post('/github', (req, res) => {
   })
 })
 
+/**
+ * Validate HMAC signature for non-GitHub webhooks when webhook_secret is configured.
+ * Expects X-Jarvis-Signature header with format: sha256=<hex>
+ */
+function validateHmac(req: import('express').Request, secret: string | undefined): boolean {
+  if (!secret) return true; // no secret configured, skip validation
+
+  const signature = req.headers['x-jarvis-signature'] as string | undefined
+  if (!signature) return false
+
+  const hmac = crypto.createHmac('sha256', secret)
+  hmac.update(JSON.stringify(req.body))
+  const expected = 'sha256=' + hmac.digest('hex')
+
+  const sigBuf = Buffer.from(signature)
+  const expBuf = Buffer.from(expected)
+  const maxLen = Math.max(sigBuf.length, expBuf.length)
+  const paddedSig = Buffer.alloc(maxLen)
+  const paddedExp = Buffer.alloc(maxLen)
+  sigBuf.copy(paddedSig)
+  expBuf.copy(paddedExp)
+
+  return sigBuf.length === expBuf.length && crypto.timingSafeEqual(paddedSig, paddedExp)
+}
+
 // POST /api/webhooks/generic — generic JSON webhook
 webhookRouter.post('/generic', (req, res) => {
+  const secret = loadWebhookSecret()
+  if (secret && !validateHmac(req, secret)) {
+    res.status(401).json({ error: 'Invalid or missing X-Jarvis-Signature' })
+    return
+  }
+
   const body = req.body as Record<string, unknown>
   const agentId = body.agent_id as string | undefined
   const context = (body.context as Record<string, unknown>) ?? {}
@@ -144,6 +175,12 @@ webhookRouter.post('/generic', (req, res) => {
 
 // POST /api/webhooks/:agentId — trigger any agent with optional payload
 webhookRouter.post('/:agentId', (req, res) => {
+  const secret = loadWebhookSecret()
+  if (secret && !validateHmac(req, secret)) {
+    res.status(401).json({ error: 'Invalid or missing X-Jarvis-Signature' })
+    return
+  }
+
   const { agentId } = req.params
   const payload = req.body as Record<string, unknown>
 

--- a/packages/jarvis-runtime/src/config.ts
+++ b/packages/jarvis-runtime/src/config.ts
@@ -146,9 +146,18 @@ export function loadConfig(): JarvisRuntimeConfig {
     webhook_secret: typeof raw.webhook_secret === "string" ? raw.webhook_secret : undefined,
   };
 
-  // Environment overrides for paths
+  // Environment overrides
   if (process.env.JARVIS_PROJECT_ROOT) {
     config.project_root = process.env.JARVIS_PROJECT_ROOT;
+  }
+  if (process.env.JARVIS_WEBHOOK_SECRET) {
+    config.webhook_secret = process.env.JARVIS_WEBHOOK_SECRET;
+  }
+  if (process.env.JARVIS_TELEGRAM_BOT_TOKEN && process.env.JARVIS_TELEGRAM_CHAT_ID) {
+    config.telegram = {
+      bot_token: process.env.JARVIS_TELEGRAM_BOT_TOKEN,
+      chat_id: process.env.JARVIS_TELEGRAM_CHAT_ID,
+    };
   }
 
   // Validate


### PR DESCRIPTION
## Summary
- **Auth middleware** — Bearer token with role-based access (admin/operator/viewer). Token from `JARVIS_API_TOKEN` env or `config.json`. No token configured = dev mode (full access).
- **Route permissions** — Settings/plugins require admin; approvals/webhooks/triggers require operator; read-only routes allow viewer
- **CORS hardening** — Origin restricted to `JARVIS_CORS_ORIGIN` (defaults to `localhost:4242`), replaces `Access-Control-Allow-Origin: *`
- **Request limits** — JSON body capped at 1MB
- **Webhook HMAC** — Generic and per-agent webhooks validate `X-Jarvis-Signature` when `webhook_secret` is configured (GitHub already had HMAC)
- **Audit logging** — Approval resolve, settings update, agent toggle all write to `audit_log` table with actor context
- **Secret env overrides** — `JARVIS_WEBHOOK_SECRET`, `JARVIS_TELEGRAM_BOT_TOKEN`, `JARVIS_TELEGRAM_CHAT_ID`

## Test plan
- [x] All 990 tests pass (35 files)
- [x] TypeScript build succeeds
- [ ] Manual: verify unauthenticated request gets 401 when token is configured
- [ ] Manual: verify viewer role gets 403 on POST /api/settings
- [ ] Manual: verify audit_log rows appear after approval resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)