### PR TITLE
R4: Model registry and evidence-backed routing

### DIFF
--- a/packages/jarvis-dashboard/src/api/models.ts
+++ b/packages/jarvis-dashboard/src/api/models.ts
@@ -1,0 +1,131 @@
+/**
+ * Model registry and benchmark API endpoints.
+ *
+ * Exposes model discovery results, benchmark summaries, and
+ * per-model enable/disable controls.
+ */
+
+import { Router } from "express";
+import { DatabaseSync } from "node:sqlite";
+import os from "node:os";
+import { join } from "node:path";
+import { writeAuditLog, getActor } from "./middleware/audit.js";
+import type { AuthenticatedRequest } from "./middleware/auth.js";
+
+function getDb(): DatabaseSync {
+  const db = new DatabaseSync(join(os.homedir(), ".jarvis", "runtime.db"));
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  return db;
+}
+
+export const modelsRouter = Router();
+
+// GET / — list all registered models with latest benchmark summary
+modelsRouter.get("/", (_req, res) => {
+  const db = getDb();
+  try {
+    const models = db.prepare(`
+      SELECT model_id, runtime, capabilities_json, limits_json, tags_json,
+             discovered_at, last_seen_at, enabled
+      FROM model_registry
+      ORDER BY enabled DESC, last_seen_at DESC
+    `).all() as Array<{
+      model_id: string; runtime: string; capabilities_json: string;
+      limits_json: string; tags_json: string;
+      discovered_at: string; last_seen_at: string; enabled: number;
+    }>;
+
+    // Attach latest benchmarks
+    const result = models.map(m => {
+      const benchmarks = db.prepare(`
+        SELECT benchmark_type, latency_ms, tokens_per_sec, json_success, tool_call_success, measured_at
+        FROM model_benchmarks
+        WHERE model_id = ?
+        ORDER BY measured_at DESC
+        LIMIT 5
+      `).all(m.model_id) as Array<{
+        benchmark_type: string; latency_ms: number;
+        tokens_per_sec: number | null;
+        json_success: number | null;
+        tool_call_success: number | null;
+        measured_at: string;
+      }>;
+
+      return {
+        id: m.model_id,
+        runtime: m.runtime,
+        capabilities: JSON.parse(m.capabilities_json),
+        limits: JSON.parse(m.limits_json),
+        tags: JSON.parse(m.tags_json),
+        discovered_at: m.discovered_at,
+        last_seen_at: m.last_seen_at,
+        enabled: m.enabled === 1,
+        benchmarks,
+      };
+    });
+
+    res.json(result);
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+});
+
+// PATCH /:modelId — enable or disable a model
+modelsRouter.patch("/:modelId", (req, res) => {
+  const { modelId } = req.params;
+  const { enabled } = req.body as { enabled?: boolean };
+
+  if (typeof enabled !== "boolean") {
+    res.status(400).json({ error: "Expected { enabled: boolean }" });
+    return;
+  }
+
+  const db = getDb();
+  try {
+    const existing = db.prepare("SELECT model_id FROM model_registry WHERE model_id = ?").get(modelId!) as { model_id: string } | undefined;
+    if (!existing) {
+      res.status(404).json({ error: `Model not found: ${modelId}` });
+      return;
+    }
+
+    db.prepare("UPDATE model_registry SET enabled = ? WHERE model_id = ?").run(enabled ? 1 : 0, modelId!);
+
+    const actor = getActor(req as AuthenticatedRequest);
+    writeAuditLog(actor.type, actor.id, "model.toggled", "model", modelId!, { enabled });
+
+    res.json({ id: modelId, enabled });
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+});
+
+// GET /:modelId/benchmarks — get detailed benchmark history
+modelsRouter.get("/:modelId/benchmarks", (req, res) => {
+  const { modelId } = req.params;
+  const db = getDb();
+  try {
+    const rows = db.prepare(`
+      SELECT benchmark_type, latency_ms, tokens_per_sec, json_success, tool_call_success, notes_json, measured_at
+      FROM model_benchmarks
+      WHERE model_id = ?
+      ORDER BY measured_at DESC
+      LIMIT 50
+    `).all(modelId!) as Array<{
+      benchmark_type: string; latency_ms: number;
+      tokens_per_sec: number | null;
+      json_success: number | null;
+      tool_call_success: number | null;
+      notes_json: string;
+      measured_at: string;
+    }>;
+
+    res.json(rows.map(r => ({
+      ...r,
+      notes: r.notes_json ? JSON.parse(r.notes_json) : null,
+      notes_json: undefined,
+    })));
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+});

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -14,6 +14,7 @@ import { analyticsRouter } from './analytics.js'
 import { settingsRouter } from './settings.js'
 import { portalRouter } from './portal.js'
 import { godmodeRouter } from './godmode.js'
+import { modelsRouter } from './models.js'
 import fs from 'fs'
 import { getHealthReport, getReadinessReport } from '@jarvis/runtime'
 import { createAuthMiddleware } from './middleware/auth.js'
@@ -62,6 +63,7 @@ app.use('/api/analytics', analyticsRouter)
 app.use('/api/settings', settingsRouter)
 app.use('/portal/api', portalRouter)
 app.use('/api/godmode', godmodeRouter)
+app.use('/api/models', modelsRouter)
 
 app.get('/api/health', (_req, res) => {
   const report = getHealthReport()

--- a/packages/jarvis-inference/src/benchmark.ts
+++ b/packages/jarvis-inference/src/benchmark.ts
@@ -1,0 +1,284 @@
+/**
+ * Model Benchmarking — measures model performance for evidence-based routing.
+ *
+ * Runs lightweight benchmarks against local models:
+ *   - latency: time to first token and total response time
+ *   - json_success: ability to produce valid JSON output
+ *   - tool_call_success: ability to format tool calls correctly
+ *
+ * Results are cached in the model_benchmarks table with TTL.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import type { ModelInfo } from "./router.js";
+
+export type BenchmarkType = "latency" | "json_reliability" | "tool_call" | "code_quality";
+
+export type BenchmarkResult = {
+  model_id: string;
+  runtime: string;
+  benchmark_type: BenchmarkType;
+  latency_ms: number;
+  tokens_per_sec: number | null;
+  json_success: number | null;
+  tool_call_success: number | null;
+  notes: Record<string, unknown>;
+};
+
+const JSON_TEST_PROMPT = `Respond ONLY with valid JSON (no markdown, no explanation). The JSON should be an object with keys: "name" (string), "score" (number 1-100), "tags" (array of strings). Example topic: a random fruit.`;
+
+const TOOL_CALL_TEST_PROMPT = `You have access to a function called "get_weather" that takes a "city" parameter (string). Call this function for "Paris". Respond ONLY with a JSON object: {"function": "get_weather", "arguments": {"city": "Paris"}}`;
+
+/**
+ * Run a simple latency benchmark against a model.
+ */
+async function benchmarkLatency(
+  baseUrl: string,
+  modelId: string,
+): Promise<BenchmarkResult> {
+  const start = Date.now();
+
+  try {
+    const resp = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: "Say hello in exactly 3 words." }],
+        max_tokens: 20,
+        temperature: 0,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    const elapsed = Date.now() - start;
+
+    if (!resp.ok) {
+      return {
+        model_id: modelId, runtime: baseUrl, benchmark_type: "latency",
+        latency_ms: elapsed, tokens_per_sec: null, json_success: null, tool_call_success: null,
+        notes: { error: `HTTP ${resp.status}` },
+      };
+    }
+
+    const data = await resp.json() as {
+      usage?: { completion_tokens?: number };
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const tokens = data.usage?.completion_tokens ?? 0;
+    const tps = tokens > 0 && elapsed > 0 ? (tokens / (elapsed / 1000)) : null;
+
+    return {
+      model_id: modelId, runtime: baseUrl, benchmark_type: "latency",
+      latency_ms: elapsed, tokens_per_sec: tps, json_success: null, tool_call_success: null,
+      notes: { tokens, response_length: data.choices?.[0]?.message?.content?.length ?? 0 },
+    };
+  } catch (e) {
+    return {
+      model_id: modelId, runtime: baseUrl, benchmark_type: "latency",
+      latency_ms: Date.now() - start, tokens_per_sec: null, json_success: null, tool_call_success: null,
+      notes: { error: e instanceof Error ? e.message : String(e) },
+    };
+  }
+}
+
+/**
+ * Run a JSON reliability benchmark — can the model produce valid JSON?
+ */
+async function benchmarkJsonReliability(
+  baseUrl: string,
+  modelId: string,
+  trials = 3,
+): Promise<BenchmarkResult> {
+  let successes = 0;
+  const latencies: number[] = [];
+
+  for (let i = 0; i < trials; i++) {
+    const start = Date.now();
+    try {
+      const resp = await fetch(`${baseUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: modelId,
+          messages: [{ role: "user", content: JSON_TEST_PROMPT }],
+          max_tokens: 200,
+          temperature: 0.1,
+        }),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      latencies.push(Date.now() - start);
+
+      if (resp.ok) {
+        const data = await resp.json() as { choices?: Array<{ message?: { content?: string } }> };
+        const content = data.choices?.[0]?.message?.content?.trim() ?? "";
+        try {
+          const parsed = JSON.parse(content);
+          if (typeof parsed === "object" && parsed !== null && "name" in parsed) {
+            successes++;
+          }
+        } catch { /* invalid JSON */ }
+      }
+    } catch {
+      latencies.push(Date.now() - start);
+    }
+  }
+
+  const avgLatency = latencies.length > 0 ? latencies.reduce((a, b) => a + b, 0) / latencies.length : 0;
+
+  return {
+    model_id: modelId, runtime: baseUrl, benchmark_type: "json_reliability",
+    latency_ms: avgLatency, tokens_per_sec: null,
+    json_success: successes / trials,
+    tool_call_success: null,
+    notes: { trials, successes },
+  };
+}
+
+/**
+ * Run a tool call formatting benchmark.
+ */
+async function benchmarkToolCall(
+  baseUrl: string,
+  modelId: string,
+  trials = 3,
+): Promise<BenchmarkResult> {
+  let successes = 0;
+  const latencies: number[] = [];
+
+  for (let i = 0; i < trials; i++) {
+    const start = Date.now();
+    try {
+      const resp = await fetch(`${baseUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: modelId,
+          messages: [{ role: "user", content: TOOL_CALL_TEST_PROMPT }],
+          max_tokens: 100,
+          temperature: 0,
+        }),
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      latencies.push(Date.now() - start);
+
+      if (resp.ok) {
+        const data = await resp.json() as { choices?: Array<{ message?: { content?: string } }> };
+        const content = data.choices?.[0]?.message?.content?.trim() ?? "";
+        try {
+          const parsed = JSON.parse(content) as Record<string, unknown>;
+          if (parsed.function === "get_weather" &&
+              typeof parsed.arguments === "object" &&
+              (parsed.arguments as Record<string, unknown>).city === "Paris") {
+            successes++;
+          }
+        } catch { /* invalid format */ }
+      }
+    } catch {
+      latencies.push(Date.now() - start);
+    }
+  }
+
+  const avgLatency = latencies.length > 0 ? latencies.reduce((a, b) => a + b, 0) / latencies.length : 0;
+
+  return {
+    model_id: modelId, runtime: baseUrl, benchmark_type: "tool_call",
+    latency_ms: avgLatency, tokens_per_sec: null,
+    json_success: null,
+    tool_call_success: successes / trials,
+    notes: { trials, successes },
+  };
+}
+
+/**
+ * Run all benchmarks for a model.
+ */
+export async function benchmarkModel(
+  model: ModelInfo,
+  options?: { lmStudioUrl?: string; trials?: number },
+): Promise<BenchmarkResult[]> {
+  const baseUrl = model.runtime === "ollama"
+    ? "http://localhost:11434"
+    : (options?.lmStudioUrl ?? "http://localhost:1234");
+
+  const trials = options?.trials ?? 3;
+
+  // Only benchmark chat-capable models
+  if (!model.capabilities.includes("chat")) {
+    return [];
+  }
+
+  const results = await Promise.all([
+    benchmarkLatency(baseUrl, model.id),
+    benchmarkJsonReliability(baseUrl, model.id, trials),
+    benchmarkToolCall(baseUrl, model.id, trials),
+  ]);
+
+  return results;
+}
+
+/**
+ * Persist benchmark results to the model_benchmarks table.
+ */
+export function saveBenchmarkResults(db: DatabaseSync, results: BenchmarkResult[]): void {
+  const stmt = db.prepare(`
+    INSERT INTO model_benchmarks
+      (benchmark_id, model_id, runtime, benchmark_type, latency_ms, tokens_per_sec, json_success, tool_call_success, notes_json, measured_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const now = new Date().toISOString();
+  for (const r of results) {
+    stmt.run(
+      randomUUID(), r.model_id, r.runtime, r.benchmark_type,
+      r.latency_ms, r.tokens_per_sec, r.json_success, r.tool_call_success,
+      JSON.stringify(r.notes), now,
+    );
+  }
+}
+
+/**
+ * Load cached benchmark results for a model.
+ * Only returns results newer than maxAge.
+ */
+export function loadBenchmarks(
+  db: DatabaseSync,
+  modelId: string,
+  maxAgeMs = 24 * 60 * 60 * 1000,
+): BenchmarkResult[] {
+  const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+  const rows = db.prepare(
+    "SELECT * FROM model_benchmarks WHERE model_id = ? AND measured_at > ? ORDER BY measured_at DESC",
+  ).all(modelId, cutoff) as Array<{
+    model_id: string; runtime: string; benchmark_type: string;
+    latency_ms: number; tokens_per_sec: number | null;
+    json_success: number | null; tool_call_success: number | null;
+    notes_json: string;
+  }>;
+
+  return rows.map(r => ({
+    model_id: r.model_id,
+    runtime: r.runtime,
+    benchmark_type: r.benchmark_type as BenchmarkType,
+    latency_ms: r.latency_ms,
+    tokens_per_sec: r.tokens_per_sec,
+    json_success: r.json_success,
+    tool_call_success: r.tool_call_success,
+    notes: r.notes_json ? JSON.parse(r.notes_json) : {},
+  }));
+}
+
+/**
+ * Check if a model has fresh benchmarks.
+ */
+export function hasFreshBenchmarks(db: DatabaseSync, modelId: string, maxAgeMs = 24 * 60 * 60 * 1000): boolean {
+  const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+  const row = db.prepare(
+    "SELECT COUNT(*) as n FROM model_benchmarks WHERE model_id = ? AND measured_at > ?",
+  ).get(modelId, cutoff) as { n: number };
+  return row.n > 0;
+}

--- a/packages/jarvis-inference/src/index.ts
+++ b/packages/jarvis-inference/src/index.ts
@@ -331,6 +331,8 @@ export * from "./router.js";
 export * from "./rag.js";
 export * from "./streaming.js";
 export * from "./task-profile.js";
+export * from "./registry.js";
+export * from "./benchmark.js";
 
 export default definePluginEntry({
   id: "jarvis-inference",

--- a/packages/jarvis-inference/src/registry.ts
+++ b/packages/jarvis-inference/src/registry.ts
@@ -1,0 +1,165 @@
+/**
+ * Model Registry — discovers and tracks locally available models.
+ *
+ * Probes Ollama (localhost:11434) and LM Studio (configurable) to discover
+ * models, classifies their capabilities and size, and persists to the
+ * model_registry table in runtime.db.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
+import { buildModelInfo, type ModelInfo } from "./router.js";
+
+export type DiscoveryResult = {
+  discovered: ModelInfo[];
+  errors: string[];
+};
+
+/**
+ * Discover models from Ollama API.
+ */
+async function discoverOllama(timeoutMs = 5000): Promise<{ models: ModelInfo[]; error?: string }> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const resp = await fetch("http://localhost:11434/api/tags", { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return { models: [], error: `Ollama returned ${resp.status}` };
+    }
+
+    const data = await resp.json() as { models?: Array<{ name: string; size?: number; parameter_size?: string }> };
+    const models = (data.models ?? []).map(m => {
+      const info = buildModelInfo(m.name, "ollama");
+      if (m.parameter_size) {
+        info.parameterCount = m.parameter_size;
+      }
+      return info;
+    });
+
+    return { models };
+  } catch (e) {
+    return { models: [], error: `Ollama unreachable: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+/**
+ * Discover models from LM Studio API (OpenAI-compatible).
+ */
+async function discoverLmStudio(baseUrl = "http://localhost:1234", timeoutMs = 5000): Promise<{ models: ModelInfo[]; error?: string }> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const resp = await fetch(`${baseUrl}/v1/models`, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return { models: [], error: `LM Studio returned ${resp.status}` };
+    }
+
+    const data = await resp.json() as { data?: Array<{ id: string }> };
+    const models = (data.data ?? []).map(m => buildModelInfo(m.id, "lmstudio"));
+
+    return { models };
+  } catch (e) {
+    return { models: [], error: `LM Studio unreachable: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+/**
+ * Discover all locally available models from Ollama and LM Studio.
+ */
+export async function discoverModels(lmStudioUrl?: string): Promise<DiscoveryResult> {
+  const [ollama, lmstudio] = await Promise.all([
+    discoverOllama(),
+    discoverLmStudio(lmStudioUrl),
+  ]);
+
+  const errors: string[] = [];
+  if (ollama.error) errors.push(ollama.error);
+  if (lmstudio.error) errors.push(lmstudio.error);
+
+  return {
+    discovered: [...ollama.models, ...lmstudio.models],
+    errors,
+  };
+}
+
+/**
+ * Persist discovered models to the model_registry table.
+ * Uses UPSERT: updates last_seen_at for known models, inserts new ones.
+ */
+export function syncModelRegistry(db: DatabaseSync, models: ModelInfo[]): { added: number; updated: number } {
+  const now = new Date().toISOString();
+  let added = 0;
+  let updated = 0;
+
+  const upsert = db.prepare(`
+    INSERT INTO model_registry (model_id, runtime, capabilities_json, limits_json, tags_json, discovered_at, last_seen_at, enabled)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+    ON CONFLICT(model_id) DO UPDATE SET
+      capabilities_json = excluded.capabilities_json,
+      last_seen_at = excluded.last_seen_at,
+      runtime = excluded.runtime
+  `);
+
+  for (const model of models) {
+    const existing = db.prepare("SELECT model_id FROM model_registry WHERE model_id = ?").get(model.id) as { model_id: string } | undefined;
+
+    upsert.run(
+      model.id,
+      model.runtime,
+      JSON.stringify(model.capabilities),
+      JSON.stringify({ size_class: model.size_class, parameter_count: model.parameterCount }),
+      JSON.stringify([model.size_class]),
+      now,
+      now,
+    );
+
+    if (existing) {
+      updated++;
+    } else {
+      added++;
+    }
+  }
+
+  return { added, updated };
+}
+
+/**
+ * Load all enabled models from the registry.
+ */
+export function loadRegisteredModels(db: DatabaseSync): ModelInfo[] {
+  const rows = db.prepare(
+    "SELECT model_id, runtime, capabilities_json, limits_json FROM model_registry WHERE enabled = 1 ORDER BY last_seen_at DESC",
+  ).all() as Array<{
+    model_id: string;
+    runtime: string;
+    capabilities_json: string;
+    limits_json: string;
+  }>;
+
+  return rows.map(row => {
+    const caps = JSON.parse(row.capabilities_json) as string[];
+    const limits = JSON.parse(row.limits_json) as { size_class?: string; parameter_count?: string };
+    return {
+      id: row.model_id,
+      runtime: row.runtime as "ollama" | "lmstudio",
+      size_class: (limits.size_class ?? "medium") as ModelInfo["size_class"],
+      capabilities: caps as ModelInfo["capabilities"],
+      parameterCount: limits.parameter_count,
+    };
+  });
+}
+
+/**
+ * Disable models not seen since the given threshold.
+ * Returns the number of models disabled.
+ */
+export function pruneStaleModels(db: DatabaseSync, staleThreshold: Date): number {
+  const result = db.prepare(
+    "UPDATE model_registry SET enabled = 0 WHERE enabled = 1 AND last_seen_at < ?",
+  ).run(staleThreshold.toISOString());
+  return (result as { changes: number }).changes;
+}

--- a/packages/jarvis-inference/src/router.ts
+++ b/packages/jarvis-inference/src/router.ts
@@ -145,6 +145,96 @@ export function selectByProfile(
   return selectModel(available, policy);
 }
 
+/**
+ * Evidence-backed model selection.
+ *
+ * Consults benchmark data when available to make better-informed decisions.
+ * Falls back to heuristic selection when no benchmarks exist.
+ */
+export type ModelBenchmarkData = {
+  model_id: string;
+  latency_ms: number;
+  tokens_per_sec: number | null;
+  json_success: number | null;
+  tool_call_success: number | null;
+};
+
+export function selectByProfileWithEvidence(
+  available: ModelInfo[],
+  profile: TaskProfile,
+  benchmarks: ModelBenchmarkData[],
+): ModelInfo | null {
+  if (available.length === 0) return null;
+  if (benchmarks.length === 0) return selectByProfile(available, profile);
+
+  const policy = derivePolicy(profile);
+  const chatModels = available.filter(m => m.capabilities.includes("chat"));
+  if (chatModels.length === 0) return available[0] ?? null;
+
+  // Build a benchmark lookup
+  const benchMap = new Map<string, ModelBenchmarkData>();
+  for (const b of benchmarks) {
+    // Keep the one with the most data
+    const existing = benchMap.get(b.model_id);
+    if (!existing) {
+      benchMap.set(b.model_id, b);
+    }
+  }
+
+  switch (policy) {
+    case "fastest_local": {
+      // Sort by latency (lowest first), prefer benchmarked models
+      const sorted = [...chatModels].sort((a, b) => {
+        const ba = benchMap.get(a.id);
+        const bb = benchMap.get(b.id);
+        if (ba && bb) return ba.latency_ms - bb.latency_ms;
+        if (ba) return -1; // prefer benchmarked
+        if (bb) return 1;
+        // Fall back to size class
+        const sizeOrder = { small: 0, medium: 1, large: 2 };
+        return sizeOrder[a.size_class] - sizeOrder[b.size_class];
+      });
+      return sorted[0] ?? null;
+    }
+
+    case "best_reasoning_local": {
+      // Prefer largest with good tool call success
+      const sorted = [...chatModels].sort((a, b) => {
+        const sizeOrder = { small: 0, medium: 1, large: 2 };
+        const sizeDiff = sizeOrder[b.size_class] - sizeOrder[a.size_class];
+        if (sizeDiff !== 0) return sizeDiff;
+        // Among same size, prefer higher tool call success
+        const ba = benchMap.get(a.id);
+        const bb = benchMap.get(b.id);
+        const ta = ba?.tool_call_success ?? 0;
+        const tb = bb?.tool_call_success ?? 0;
+        return tb - ta;
+      });
+      return sorted[0] ?? null;
+    }
+
+    case "json_reliable_local": {
+      // Prefer models with proven JSON output
+      const withBench = chatModels
+        .map(m => ({ model: m, bench: benchMap.get(m.id) }))
+        .filter(x => x.bench?.json_success !== null && x.bench?.json_success !== undefined);
+
+      if (withBench.length > 0) {
+        withBench.sort((a, b) => (b.bench!.json_success ?? 0) - (a.bench!.json_success ?? 0));
+        // Pick the best JSON success rate, but only if > 50%
+        if ((withBench[0]!.bench!.json_success ?? 0) > 0.5) {
+          return withBench[0]!.model;
+        }
+      }
+      // Fall back to heuristic
+      return selectModel(available, policy);
+    }
+
+    default:
+      return selectModel(available, policy);
+  }
+}
+
 export function selectEmbeddingModel(available: ModelInfo[]): ModelInfo | null {
   // Prefer dedicated embedding models first
   const dedicated = available.find((m) => m.capabilities.includes("embedding"));

--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -19,6 +19,7 @@ import { Logger } from "./logger.js";
 import { StatusWriter } from "./status-writer.js";
 import type { AgentTrigger } from "@jarvis/agent-framework";
 import { randomUUID } from "node:crypto";
+import { discoverModels, syncModelRegistry } from "@jarvis/inference";
 
 async function main() {
   // ─── Phase 1: Init ──────────────────────────────────────────────────────────
@@ -95,6 +96,20 @@ async function main() {
         logger.info(`  Schedule: ${def.agent_id} @ ${trigger.cron}`);
       }
     }
+  }
+
+  // Discover local models and populate registry
+  try {
+    const discovery = await discoverModels(config.lmstudio_url);
+    if (discovery.discovered.length > 0) {
+      const sync = syncModelRegistry(runtimeDb, discovery.discovered);
+      logger.info(`Model discovery: ${discovery.discovered.length} models (${sync.added} new, ${sync.updated} updated)`);
+    }
+    for (const err of discovery.errors) {
+      logger.warn(`Model discovery: ${err}`);
+    }
+  } catch (e) {
+    logger.warn(`Model discovery failed: ${e instanceof Error ? e.message : String(e)}`);
   }
 
   logger.info(`Jarvis daemon started: ${allAgentDefs.length} agents (${pluginManifests.length} plugins), ${scheduleCount} schedules`);


### PR DESCRIPTION
## Summary
- **Model discovery** — probes Ollama (localhost:11434/api/tags) and LM Studio (/v1/models) at daemon startup, classifies models by size/capabilities, persists to model_registry table via UPSERT
- **Benchmark framework** — measures latency, JSON reliability (can it produce valid JSON?), and tool call formatting per model. 3 trials per benchmark type. Results cached in model_benchmarks with 24h TTL.
- **Evidence-backed selection** — `selectByProfileWithEvidence()` consults benchmarks: fastest_local sorts by measured latency, json_reliable_local picks highest JSON success rate, best_reasoning_local favors tool call accuracy. Falls back to regex heuristics when no benchmarks exist.
- **Dashboard model API** — GET /api/models lists registry with benchmark summaries, PATCH /:modelId to enable/disable, GET /:modelId/benchmarks for detailed history

## Test plan
- [x] All 990 tests pass (35 files)
- [x] TypeScript build succeeds
- [ ] Manual: start daemon with LM Studio running, verify model_registry populated
- [ ] Manual: verify /api/models returns discovered models with benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)