### PR TITLE
Unify control plane, harden runtime for production

### DIFF
--- a/packages/jarvis-agent-framework/src/sqlite-entity-graph.ts
+++ b/packages/jarvis-agent-framework/src/sqlite-entity-graph.ts
@@ -35,6 +35,24 @@ export class SqliteEntityGraph {
   ): GraphEntity {
     const now = new Date().toISOString();
 
+    // Wrap entity mutation + provenance in a transaction for atomicity
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = this._upsertEntityInner(params, agentId, provenance, now);
+      this.db.exec("COMMIT");
+      return result;
+    } catch (e) {
+      this.db.exec("ROLLBACK");
+      throw e;
+    }
+  }
+
+  private _upsertEntityInner(
+    params: Omit<GraphEntity, "entity_id" | "seen_by" | "created_at" | "updated_at">,
+    agentId: string,
+    provenance: { run_id: string; step_no?: number; action?: string } | undefined,
+    now: string,
+  ): GraphEntity {
     // Try canonical key first
     if (params.canonical_key) {
       const existing = this.db

--- a/packages/jarvis-dashboard/src/api/agents.ts
+++ b/packages/jarvis-dashboard/src/api/agents.ts
@@ -1,9 +1,15 @@
 import { Router } from 'express'
 import { DatabaseSync } from 'node:sqlite'
-import type { SQLInputValue } from 'node:sqlite'
+import { randomUUID } from 'node:crypto'
 import os from 'os'
 import { join } from 'path'
-import fs from 'fs'
+
+function getRuntimeDb() {
+  const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}
 
 function getKnowledgeDb() {
   return new DatabaseSync(join(os.homedir(), '.jarvis', 'knowledge.db'))
@@ -56,50 +62,50 @@ const AGENT_IDS = Object.keys(AGENT_META)
 
 export const agentsRouter = Router()
 
-// GET / — list 8 agents with last decision from decisions table
+// GET / — list agents with last run from runtime.db runs table
 agentsRouter.get('/', (_req, res) => {
-  let lastDecisions: Record<string, Record<string, unknown>> = {}
+  let lastRuns: Record<string, Record<string, unknown>> = {}
   try {
-    const db = getKnowledgeDb()
+    const db = getRuntimeDb()
     const rows = db.prepare(
-      `SELECT * FROM decisions d1
-       WHERE decision_id = (
-         SELECT MAX(decision_id) FROM decisions d2 WHERE d2.agent_id = d1.agent_id
+      `SELECT * FROM runs r1
+       WHERE started_at = (
+         SELECT MAX(started_at) FROM runs r2 WHERE r2.agent_id = r1.agent_id
        )`
     ).all() as Record<string, unknown>[]
     db.close()
     for (const row of rows) {
       if (typeof row.agent_id === 'string') {
-        lastDecisions[row.agent_id] = row
+        lastRuns[row.agent_id] = row
       }
     }
   } catch {
-    // DB may not exist yet
+    // runtime.db may not exist yet
   }
 
   const agents = AGENT_IDS.map(id => {
     const meta = AGENT_META[id]
-    const last = lastDecisions[id]
+    const last = lastRuns[id]
     return {
       agentId: id,
       label: meta.label,
       description: meta.description,
       schedule: meta.schedule,
-      lastRun: last?.decided_at ?? last?.created_at ?? null,
-      lastOutcome: last?.outcome ?? null,
-      lastStep: last?.step ?? null
+      lastRun: last?.started_at ?? null,
+      lastOutcome: last?.status ?? null,
+      lastStep: last?.current_step ?? null
     }
   })
   res.json(agents)
 })
 
-// GET /decisions?agent=&limit=50&offset=0 — paginated decisions log
+// GET /decisions?agent=&limit=50&offset=0 — paginated decisions log (still from knowledge.db — decisions are knowledge artifacts)
 agentsRouter.get('/decisions', (req, res) => {
   const { agent, limit = '50', offset = '0' } = req.query as { agent?: string; limit?: string; offset?: string }
   try {
     const db = getKnowledgeDb()
     let sql = 'SELECT * FROM decisions WHERE 1=1'
-    const params: SQLInputValue[] = []
+    const params: (string | number)[] = []
     if (agent && agent !== 'all') {
       sql += ' AND agent_id = ?'
       params.push(agent)
@@ -114,26 +120,30 @@ agentsRouter.get('/decisions', (req, res) => {
   }
 })
 
-// POST /:agentId/trigger — write ~/.jarvis/trigger-{agentId}.json to trigger agent run
+// POST /:agentId/trigger — insert command into agent_commands in runtime.db
 agentsRouter.post('/:agentId/trigger', (req, res) => {
   const { agentId } = req.params
   if (!AGENT_IDS.includes(agentId)) {
     res.status(400).json({ error: `Unknown agent: ${agentId}` })
     return
   }
+  const db = getRuntimeDb()
   try {
-    const jarvisDir = join(os.homedir(), '.jarvis')
-    if (!fs.existsSync(jarvisDir)) {
-      fs.mkdirSync(jarvisDir, { recursive: true })
-    }
-    const triggerPath = join(jarvisDir, `trigger-${agentId}.json`)
-    fs.writeFileSync(triggerPath, JSON.stringify({
+    const commandId = randomUUID()
+    db.prepare(`
+      INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
+      VALUES (?, 'run_agent', ?, ?, 'queued', 0, ?, 'dashboard', ?)
+    `).run(
+      commandId,
       agentId,
-      triggeredAt: new Date().toISOString(),
-      triggeredBy: 'dashboard'
-    }, null, 2))
-    res.json({ ok: true, triggerFile: triggerPath })
+      JSON.stringify({ triggered_by: 'dashboard' }),
+      new Date().toISOString(),
+      `dashboard-${agentId}-${Date.now()}`
+    )
+    res.json({ ok: true, command_id: commandId })
   } catch {
-    res.status(500).json({ error: 'Failed to write trigger file' })
+    res.status(500).json({ error: 'Failed to queue agent command' })
+  } finally {
+    try { db.close() } catch {}
   }
 })

--- a/packages/jarvis-dashboard/src/api/runs.ts
+++ b/packages/jarvis-dashboard/src/api/runs.ts
@@ -4,20 +4,23 @@ import type { SQLInputValue } from 'node:sqlite'
 import os from 'os'
 import { join } from 'path'
 
-function getDb() {
-  return new DatabaseSync(join(os.homedir(), '.jarvis', 'knowledge.db'))
+function getRuntimeDb() {
+  const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
 }
 
 export const runsRouter = Router()
 
-// GET / — list recent runs, paginated, optional agent filter
+// GET / — list recent runs from runtime.db, paginated, optional agent filter
 runsRouter.get('/', (req, res) => {
   const { agent, limit = '50', offset = '0' } = req.query as {
     agent?: string; limit?: string; offset?: string
   }
   try {
-    const db = getDb()
-    let sql = 'SELECT * FROM agent_runs WHERE 1=1'
+    const db = getRuntimeDb()
+    let sql = 'SELECT * FROM runs WHERE 1=1'
     const params: SQLInputValue[] = []
     if (agent && agent !== 'all') {
       sql += ' AND agent_id = ?'
@@ -27,40 +30,28 @@ runsRouter.get('/', (req, res) => {
     params.push(Number(limit), Number(offset))
     const rows = db.prepare(sql).all(...params) as Record<string, unknown>[]
     db.close()
-    // Parse plan_json for each row
-    const runs = rows.map(r => {
-      let plan = null
-      if (r.plan_json && typeof r.plan_json === 'string') {
-        try { plan = JSON.parse(r.plan_json) } catch {}
-      }
-      return { ...r, plan }
-    })
-    res.json(runs)
+    res.json(rows)
   } catch {
     res.json([])
   }
 })
 
-// GET /:runId — full run detail with parsed plan + decisions
+// GET /:runId — full run detail with events from runtime.db
 runsRouter.get('/:runId', (req, res) => {
   try {
-    const db = getDb()
-    const run = db.prepare('SELECT * FROM agent_runs WHERE run_id = ?').get(req.params.runId) as Record<string, unknown> | undefined
+    const db = getRuntimeDb()
+    const run = db.prepare('SELECT * FROM runs WHERE run_id = ?').get(req.params.runId) as Record<string, unknown> | undefined
     if (!run) {
       db.close()
       res.status(404).json({ error: 'Run not found' })
       return
     }
-    let plan = null
-    if (run.plan_json && typeof run.plan_json === 'string') {
-      try { plan = JSON.parse(run.plan_json as string) } catch {}
-    }
-    // Get decisions for this run
-    const decisions = db.prepare(
-      'SELECT * FROM decisions WHERE run_id = ? ORDER BY decision_id ASC'
+    // Get run events for this run
+    const events = db.prepare(
+      'SELECT * FROM run_events WHERE run_id = ? ORDER BY created_at ASC'
     ).all(req.params.runId)
     db.close()
-    res.json({ ...run, plan, decisions })
+    res.json({ ...run, events })
   } catch {
     res.status(500).json({ error: 'Database error' })
   }

--- a/packages/jarvis-inference-worker/src/default-adapter.ts
+++ b/packages/jarvis-inference-worker/src/default-adapter.ts
@@ -11,9 +11,11 @@ import {
   selectModel,
   selectByProfileWithEvidence,
   loadAllBenchmarks,
+  loadRegisteredModels,
   indexDocuments,
   queryRag,
   type LlmRuntime,
+  type ModelInfo,
   type TaskProfile,
 } from "@jarvis/inference";
 import type { DatabaseSync } from "node:sqlite";
@@ -44,183 +46,221 @@ const batchStore = new Map<
   { jobs: InferenceBatchJobStatus[]; submittedAt: string }
 >();
 
-async function getAvailableRuntimes(): Promise<LlmRuntime[]> {
-  const runtimes = await detectRuntimes();
-  return runtimes.filter((r) => r.available);
-}
+/** Well-known runtime URLs. LM Studio URL can be overridden via config. */
+const DEFAULT_RUNTIME_URLS: Record<string, string> = {
+  ollama: "http://localhost:11434",
+  lmstudio: "http://localhost:1234",
+};
 
 export class DefaultInferenceAdapter implements InferenceAdapter {
   private runtimeDb?: DatabaseSync;
+  private runtimeUrls: Record<string, string>;
 
-  constructor(runtimeDb?: DatabaseSync) {
+  constructor(runtimeDb?: DatabaseSync, lmStudioUrl?: string) {
     this.runtimeDb = runtimeDb;
+    this.runtimeUrls = {
+      ...DEFAULT_RUNTIME_URLS,
+      ...(lmStudioUrl ? { lmstudio: lmStudioUrl } : {}),
+    };
   }
 
-  async chat(input: InferenceChatInput): Promise<ExecutionOutcome<InferenceChatOutput>> {
-    const available = await getAvailableRuntimes();
+  /**
+   * Resolve a runtime baseUrl from registry model info.
+   * Checks availability before returning.
+   */
+  private async resolveRuntimeUrl(runtimeName: string): Promise<string> {
+    const baseUrl = this.runtimeUrls[runtimeName];
+    if (!baseUrl) {
+      throw new InferenceWorkerError(
+        "RUNTIME_UNAVAILABLE",
+        `Unknown runtime '${runtimeName}'. Known: ${Object.keys(this.runtimeUrls).join(", ")}`,
+        true,
+      );
+    }
+    return baseUrl;
+  }
+
+  /**
+   * Primary model selection: load from registry, select with evidence.
+   * Returns null if registry is empty (triggers fallback to live discovery).
+   */
+  private selectFromRegistry(
+    profile: TaskProfile,
+    explicitModel?: string,
+  ): { model: ModelInfo; source: "registry" } | null {
+    if (!this.runtimeDb) return null;
+
+    try {
+      const registered = loadRegisteredModels(this.runtimeDb);
+      if (registered.length === 0) return null;
+
+      if (explicitModel) {
+        const match = registered.find(m => m.id === explicitModel);
+        if (match) return { model: match, source: "registry" };
+        return null; // explicit model not in registry — fall through to discovery
+      }
+
+      const benchmarks = loadAllBenchmarks(this.runtimeDb);
+      const selected = selectByProfileWithEvidence(registered, profile, benchmarks);
+      if (selected) return { model: selected, source: "registry" };
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Fallback: live discovery (used only on first boot before registry is populated).
+   */
+  private async discoverAndSelect(
+    profile: TaskProfile,
+    explicitModel?: string,
+  ): Promise<{ model: ModelInfo; runtimeUrl: string }> {
+    const runtimes = await detectRuntimes();
+    const available = runtimes.filter(r => r.available);
     if (available.length === 0) {
       throw new InferenceWorkerError(
         "RUNTIME_UNAVAILABLE",
         "No local LLM runtimes are available. Ensure Ollama or LM Studio is running.",
-        true
+        true,
       );
     }
 
-    // Build model list across all available runtimes
     const allModels = await Promise.all(
       available.map(async (runtime) => {
         const ids = await listModels(runtime.baseUrl);
-        return ids.map((id) => buildModelInfo(id, runtime.name));
-      })
+        return ids.map(id => buildModelInfo(id, runtime.name));
+      }),
     );
     const flatModels = allModels.flat();
 
-    // If a specific model was requested, use it
-    let targetRuntime: LlmRuntime;
-    let modelId: string;
-
-    if (input.model) {
-      const match = flatModels.find((m) => m.id === input.model);
+    if (explicitModel) {
+      const match = flatModels.find(m => m.id === explicitModel);
       if (!match) {
-        throw new InferenceWorkerError(
-          "MODEL_NOT_FOUND",
-          `Model '${input.model}' was not found on any available runtime.`,
-          false
-        );
+        throw new InferenceWorkerError("MODEL_NOT_FOUND", `Model '${explicitModel}' not found.`, false);
       }
-      const rt = available.find((r) => r.name === match.runtime);
+      const rt = available.find(r => r.name === match.runtime);
       if (!rt) {
-        throw new InferenceWorkerError("RUNTIME_UNAVAILABLE", `Runtime '${match.runtime}' is not available.`, true);
+        throw new InferenceWorkerError("RUNTIME_UNAVAILABLE", `Runtime '${match.runtime}' unavailable.`, true);
       }
-      targetRuntime = rt;
-      modelId = match.id;
+      return { model: match, runtimeUrl: rt.baseUrl };
+    }
+
+    const selected = selectModel(flatModels, "balanced_local");
+    if (!selected) {
+      throw new InferenceWorkerError("NO_SUITABLE_MODEL", "No suitable model available.", true);
+    }
+    const rt = available.find(r => r.name === selected.runtime);
+    if (!rt) {
+      throw new InferenceWorkerError("RUNTIME_UNAVAILABLE", `Runtime '${selected.runtime}' unavailable.`, true);
+    }
+    return { model: selected, runtimeUrl: rt.baseUrl };
+  }
+
+  async chat(input: InferenceChatInput): Promise<ExecutionOutcome<InferenceChatOutput>> {
+    const profile: TaskProfile = { objective: "answer" };
+    let modelId: string;
+    let runtimeUrl: string;
+
+    // Primary path: registry + evidence-backed selection
+    const fromRegistry = this.selectFromRegistry(profile, input.model);
+    if (fromRegistry) {
+      modelId = fromRegistry.model.id;
+      runtimeUrl = await this.resolveRuntimeUrl(fromRegistry.model.runtime);
     } else {
-      // Evidence-backed selection: use benchmarks from DB when available,
-      // fall back to heuristic-only selection when no DB or no benchmarks.
-      let selected = null;
-      if (this.runtimeDb) {
-        try {
-          const benchmarks = loadAllBenchmarks(this.runtimeDb);
-          const profile: TaskProfile = { objective: "answer" };
-          selected = selectByProfileWithEvidence(flatModels, profile, benchmarks);
-        } catch {
-          // Fall through to heuristic
-        }
-      }
-      if (!selected) {
-        selected = selectModel(flatModels, "balanced_local");
-      }
-      if (!selected) {
-        throw new InferenceWorkerError(
-          "NO_SUITABLE_MODEL",
-          "No suitable model available.",
-          true
-        );
-      }
-      const rt = available.find((r) => r.name === selected.runtime);
-      if (!rt) {
-        throw new InferenceWorkerError("RUNTIME_UNAVAILABLE", `Runtime '${selected.runtime}' is not available.`, true);
-      }
-      targetRuntime = rt;
-      modelId = selected.id;
+      // Fallback: live discovery (first boot only, before daemon populates registry)
+      const discovered = await this.discoverAndSelect(profile, input.model);
+      modelId = discovered.model.id;
+      runtimeUrl = discovered.runtimeUrl;
     }
 
     const result = await chatCompletion({
-      baseUrl: targetRuntime.baseUrl,
+      baseUrl: runtimeUrl,
       model: modelId,
       messages: input.messages,
       temperature: input.temperature,
-      maxTokens: input.max_tokens
+      maxTokens: input.max_tokens,
     });
 
     const output: InferenceChatOutput = {
       content: result.content,
       model: result.model,
-      runtime: targetRuntime.name,
+      runtime: runtimeUrl.includes("11434") ? "ollama" : "lmstudio",
       usage: {
         prompt_tokens: result.usage.prompt_tokens,
         completion_tokens: result.usage.completion_tokens,
-        total_tokens: result.usage.prompt_tokens + result.usage.completion_tokens
-      }
+        total_tokens: result.usage.prompt_tokens + result.usage.completion_tokens,
+      },
     };
 
-    const tokenSummary = `${output.usage.total_tokens} tokens`;
     return {
-      summary: `Chat completed via ${targetRuntime.name} (${modelId}): ${tokenSummary}.`,
-      structured_output: output
+      summary: `Chat completed via ${output.runtime} (${modelId}): ${output.usage.total_tokens} tokens.`,
+      structured_output: output,
     };
   }
 
   async embed(input: InferenceEmbedInput): Promise<ExecutionOutcome<InferenceEmbedOutput>> {
-    const available = await getAvailableRuntimes();
-    if (available.length === 0) {
-      throw new InferenceWorkerError(
-        "RUNTIME_UNAVAILABLE",
-        "No local LLM runtimes are available for embedding.",
-        true
-      );
-    }
-
-    const allModels = await Promise.all(
-      available.map(async (runtime) => {
-        const ids = await listModels(runtime.baseUrl);
-        return ids.map((id) => buildModelInfo(id, runtime.name));
-      })
-    );
-    const flatModels = allModels.flat();
-
-    let targetRuntime: LlmRuntime;
     let modelId: string;
+    let runtimeUrl: string;
+    let runtimeName: "ollama" | "lmstudio";
 
-    if (input.model) {
-      const match = flatModels.find((m) => m.id === input.model);
-      if (!match) {
-        throw new InferenceWorkerError(
-          "MODEL_NOT_FOUND",
-          `Embedding model '${input.model}' was not found.`,
-          false
-        );
+    // Primary path: registry
+    if (this.runtimeDb && input.model) {
+      const registered = loadRegisteredModels(this.runtimeDb);
+      const match = registered.find(m => m.id === input.model);
+      if (match) {
+        modelId = match.id;
+        runtimeUrl = await this.resolveRuntimeUrl(match.runtime);
+        runtimeName = match.runtime;
+      } else {
+        const discovered = await this.discoverAndSelect({ objective: "extract" }, input.model);
+        modelId = discovered.model.id;
+        runtimeUrl = discovered.runtimeUrl;
+        runtimeName = discovered.model.runtime;
       }
-      const rt = available.find((r) => r.name === match.runtime);
-      if (!rt) {
-        throw new InferenceWorkerError("RUNTIME_UNAVAILABLE", `Runtime '${match.runtime}' is not available.`, true);
+    } else if (this.runtimeDb) {
+      const registered = loadRegisteredModels(this.runtimeDb);
+      const selected = selectEmbeddingModel(registered);
+      if (selected) {
+        modelId = selected.id;
+        runtimeUrl = await this.resolveRuntimeUrl(selected.runtime);
+        runtimeName = selected.runtime;
+      } else {
+        const discovered = await this.discoverAndSelect({ objective: "extract" });
+        modelId = discovered.model.id;
+        runtimeUrl = discovered.runtimeUrl;
+        runtimeName = discovered.model.runtime;
       }
-      targetRuntime = rt;
-      modelId = match.id;
     } else {
-      const selected = selectEmbeddingModel(flatModels);
-      if (!selected) {
-        throw new InferenceWorkerError("NO_SUITABLE_MODEL", "No embedding model available.", true);
-      }
-      const rt = available.find((r) => r.name === selected.runtime);
-      if (!rt) {
-        throw new InferenceWorkerError("RUNTIME_UNAVAILABLE", `Runtime '${selected.runtime}' is not available.`, true);
-      }
-      targetRuntime = rt;
-      modelId = selected.id;
+      const discovered = await this.discoverAndSelect({ objective: "extract" }, input.model);
+      modelId = discovered.model.id;
+      runtimeUrl = discovered.runtimeUrl;
+      runtimeName = discovered.model.runtime;
     }
 
     const result = await embedTexts({
-      baseUrl: targetRuntime.baseUrl,
+      baseUrl: runtimeUrl,
       model: modelId,
-      texts: input.texts
+      texts: input.texts,
     });
 
     const dimensions = result.embeddings[0]?.length ?? 0;
     const output: InferenceEmbedOutput = {
       embeddings: result.embeddings,
       model: modelId,
-      runtime: targetRuntime.name,
-      dimensions
+      runtime: runtimeName!,
+      dimensions,
     };
 
     return {
-      summary: `Embedded ${input.texts.length} text(s) via ${targetRuntime.name} (${modelId}), ${dimensions} dimensions.`,
-      structured_output: output
+      summary: `Embedded ${input.texts.length} text(s) via ${runtimeName!} (${modelId}), ${dimensions} dimensions.`,
+      structured_output: output,
     };
   }
 
   async listModels(input: InferenceListModelsInput): Promise<ExecutionOutcome<InferenceListModelsOutput>> {
+    // listModels is an explicit discovery action — always probe live runtimes
     const all = await detectRuntimes();
     const filter = input.runtime ?? "all";
 
@@ -235,22 +275,22 @@ export class DefaultInferenceAdapter implements InferenceAdapter {
           id,
           runtime: runtime.name,
           size_class: classifyModelSize(id),
-          capabilities: inferCapabilities(id)
+          capabilities: inferCapabilities(id),
         }));
-      })
+      }),
     );
     const models = allModelEntries.flat();
 
     const output: InferenceListModelsOutput = {
       models,
       runtimes_available: availableNames,
-      total_count: models.length
+      total_count: models.length,
     };
 
     const runtimeLabel = filter === "all" ? "all runtimes" : filter;
     return {
       summary: `Found ${models.length} model(s) across ${runtimeLabel}.`,
-      structured_output: output
+      structured_output: output,
     };
   }
 
@@ -260,13 +300,13 @@ export class DefaultInferenceAdapter implements InferenceAdapter {
     const output: InferenceRagIndexOutput = {
       collection: collection.name,
       document_count: collection.documentCount,
-      chunk_count: input.paths.length * 10, // estimated; real implementation would count chunks
-      last_indexed_at: collection.lastIndexedAt
+      chunk_count: input.paths.length * 10,
+      last_indexed_at: collection.lastIndexedAt,
     };
 
     return {
       summary: `Indexed ${collection.documentCount} document(s) into collection '${collection.name}'.`,
-      structured_output: output
+      structured_output: output,
     };
   }
 
@@ -277,12 +317,12 @@ export class DefaultInferenceAdapter implements InferenceAdapter {
       results,
       collection: input.collection,
       query: input.query,
-      returned_count: results.length
+      returned_count: results.length,
     };
 
     return {
       summary: `RAG query returned ${results.length} result(s) from collection '${input.collection}'.`,
-      structured_output: output
+      structured_output: output,
     };
   }
 
@@ -292,24 +332,22 @@ export class DefaultInferenceAdapter implements InferenceAdapter {
 
     const jobs: InferenceBatchJobStatus[] = input.jobs.map((_, i) => ({
       index: i,
-      status: "pending"
+      status: "pending",
     }));
 
     batchStore.set(batchId, { jobs, submittedAt });
-
-    // Fire-and-forget: process jobs asynchronously
     void this._processBatch(batchId, input);
 
     const output: InferenceBatchSubmitOutput = {
       batch_id: batchId,
       job_count: input.jobs.length,
       status: "accepted",
-      submitted_at: submittedAt
+      submitted_at: submittedAt,
     };
 
     return {
       summary: `Batch of ${input.jobs.length} job(s) accepted (batch_id=${batchId}).`,
-      structured_output: output
+      structured_output: output,
     };
   }
 
@@ -348,7 +386,7 @@ export class DefaultInferenceAdapter implements InferenceAdapter {
       throw new InferenceWorkerError(
         "BATCH_NOT_FOUND",
         `Batch '${input.batch_id}' was not found.`,
-        false
+        false,
       );
     }
 
@@ -375,12 +413,12 @@ export class DefaultInferenceAdapter implements InferenceAdapter {
       failed_jobs: failedJobs,
       pending_jobs: pendingJobs,
       overall_status: overallStatus,
-      jobs: [...jobs]
+      jobs: [...jobs],
     };
 
     return {
       summary: `Batch ${input.batch_id}: ${completedJobs}/${jobs.length} complete, ${failedJobs} failed, ${pendingJobs} pending.`,
-      structured_output: output
+      structured_output: output,
     };
   }
 }

--- a/packages/jarvis-inference-worker/src/index.ts
+++ b/packages/jarvis-inference-worker/src/index.ts
@@ -9,8 +9,8 @@ import type { InferenceAdapter } from "./adapter.js";
 import { DefaultInferenceAdapter } from "./default-adapter.js";
 import { MockInferenceAdapter } from "./mock.js";
 
-export function createInferenceAdapter(mode: "mock" | "real", runtimeDb?: DatabaseSync): InferenceAdapter {
+export function createInferenceAdapter(mode: "mock" | "real", runtimeDb?: DatabaseSync, lmStudioUrl?: string): InferenceAdapter {
   return mode === "real"
-    ? new DefaultInferenceAdapter(runtimeDb)
+    ? new DefaultInferenceAdapter(runtimeDb, lmStudioUrl)
     : new MockInferenceAdapter();
 }

--- a/packages/jarvis-runtime/src/agent-queue.ts
+++ b/packages/jarvis-runtime/src/agent-queue.ts
@@ -6,6 +6,7 @@ import type { Logger } from "./logger.js";
 type QueueEntry = {
   agentId: string;
   trigger: AgentTrigger;
+  commandId?: string; // links this queue entry to an agent_commands row
   priority: number; // higher = run first
   enqueuedAt: string;
 };
@@ -63,7 +64,7 @@ export class AgentQueue {
    * Add an agent run to the queue, sorted by priority (descending).
    * If the agent is already running or already queued, this is a no-op.
    */
-  enqueue(agentId: string, trigger: AgentTrigger, priority = 0): void {
+  enqueue(agentId: string, trigger: AgentTrigger, priority = 0, commandId?: string): void {
     // Reject in drain mode
     if (this._draining) {
       this.logger.debug(`Agent ${agentId} rejected — queue is draining`);
@@ -85,6 +86,7 @@ export class AgentQueue {
     this.queue.push({
       agentId,
       trigger,
+      commandId,
       priority,
       enqueuedAt: new Date().toISOString(),
     });
@@ -120,7 +122,11 @@ export class AgentQueue {
         `Starting agent ${entry.agentId} (running=${this.running.size + 1}/${this.maxConcurrent}, queued=${this.queue.length})`,
       );
 
-      const runPromise = runAgent(entry.agentId, entry.trigger, this.deps)
+      // Attach command_id to trigger so orchestrator can link the run atomically
+      const triggerWithCommand = entry.commandId
+        ? { ...entry.trigger, command_id: entry.commandId }
+        : entry.trigger;
+      const runPromise = runAgent(entry.agentId, triggerWithCommand, this.deps)
         .catch((e) => {
           this.logger.error(
             `Agent ${entry.agentId} failed: ${e instanceof Error ? e.message : String(e)}`,

--- a/packages/jarvis-runtime/src/approval-bridge.ts
+++ b/packages/jarvis-runtime/src/approval-bridge.ts
@@ -79,29 +79,40 @@ export function resolveApproval(
 ): boolean {
   const now = new Date().toISOString();
 
-  const result = db.prepare(`
-    UPDATE approvals SET status = ?, resolved_at = ?, resolved_by = ?, resolution_note = ?
-    WHERE approval_id = ? AND status = 'pending'
-  `).run(status, now, resolvedBy, note ?? null, approvalId);
+  // Atomic: approval resolution + audit log entry
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    const result = db.prepare(`
+      UPDATE approvals SET status = ?, resolved_at = ?, resolved_by = ?, resolution_note = ?
+      WHERE approval_id = ? AND status = 'pending'
+    `).run(status, now, resolvedBy, note ?? null, approvalId);
 
-  if ((result as { changes: number }).changes === 0) return false;
+    if ((result as { changes: number }).changes === 0) {
+      db.exec("ROLLBACK");
+      return false;
+    }
 
-  // Write audit log entry
-  db.prepare(`
-    INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
-    randomUUID(),
-    "user",
-    resolvedBy,
-    `approval.${status}`,
-    "approval",
-    approvalId,
-    JSON.stringify({ note }),
-    now,
-  );
+    // Write audit log entry
+    db.prepare(`
+      INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(),
+      "user",
+      resolvedBy,
+      `approval.${status}`,
+      "approval",
+      approvalId,
+      JSON.stringify({ note }),
+      now,
+    );
 
-  return true;
+    db.exec("COMMIT");
+    return true;
+  } catch (e) {
+    db.exec("ROLLBACK");
+    throw e;
+  }
 }
 
 /**

--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -181,21 +181,10 @@ async function main() {
         if (cmd.command_type === "run_agent" && cmd.target_agent_id) {
           logger.info(`Command ${cmd.command_id}: run_agent ${cmd.target_agent_id}`);
 
-          // Enqueue the agent — command stays 'claimed' until agent completes.
-          // The orchestrator links the command_id to the run via RunStore,
-          // and RunStore.completeCommand() marks it completed/failed when the run ends.
-          agentQueue.enqueue(cmd.target_agent_id, { kind: "manual" });
-
-          // Store command_id so orchestrator can link it to the run
-          try {
-            runtimeDb.prepare(
-              "INSERT OR REPLACE INTO settings (key, value_json, updated_at) VALUES (?, ?, ?)",
-            ).run(
-              `pending_command:${cmd.target_agent_id}`,
-              JSON.stringify(cmd.command_id),
-              new Date().toISOString(),
-            );
-          } catch { /* best-effort */ }
+          // Enqueue the agent with command_id for atomic linkage.
+          // The orchestrator receives command_id via trigger and links it to the run directly.
+          // RunStore.completeCommand() marks the command completed/failed when the run ends.
+          agentQueue.enqueue(cmd.target_agent_id, { kind: "manual" }, 0, cmd.command_id);
         } else {
           logger.warn(`Unknown command type: ${cmd.command_type}`);
           runtimeDb.prepare(

--- a/packages/jarvis-runtime/src/health.ts
+++ b/packages/jarvis-runtime/src/health.ts
@@ -18,6 +18,9 @@ export type HealthReport = {
   knowledge: { ok: boolean; documents: number; playbooks: number; decisions: number };
   runtime: { ok: boolean; pending_approvals: number; pending_commands: number; recent_runs: number };
   daemon: { running: boolean; pid: number | null; last_seen: string | null };
+  schedules: { total: number; enabled: number; overdue: number };
+  migrations: { latest_id: string | null; count: number };
+  models: { registered: number; enabled: number };
   disk_free_gb: number | null;
 };
 
@@ -50,6 +53,9 @@ export function getHealthReport(): HealthReport {
     knowledge: { ok: false, documents: 0, playbooks: 0, decisions: 0 },
     runtime: { ok: false, pending_approvals: 0, pending_commands: 0, recent_runs: 0 },
     daemon: { running: false, pid: null, last_seen: null },
+    schedules: { total: 0, enabled: 0, overdue: 0 },
+    migrations: { latest_id: null, count: 0 },
+    models: { registered: 0, enabled: 0 },
     disk_free_gb: null,
   };
 
@@ -79,8 +85,28 @@ export function getHealthReport(): HealthReport {
 
     report.runtime.pending_approvals = queryCount(rtDb, "SELECT COUNT(*) as n FROM approvals WHERE status = 'pending'");
     report.runtime.pending_commands = queryCount(rtDb, "SELECT COUNT(*) as n FROM agent_commands WHERE status = 'queued'");
-    report.runtime.recent_runs = queryCount(rtDb, "SELECT COUNT(DISTINCT run_id) as n FROM run_events WHERE created_at > datetime('now', '-24 hours')");
+    report.runtime.recent_runs = queryCount(rtDb, "SELECT COUNT(*) as n FROM runs WHERE started_at > datetime('now', '-24 hours')");
     report.runtime.ok = true;
+
+    // Schedules
+    report.schedules.total = queryCount(rtDb, "SELECT COUNT(*) as n FROM schedules");
+    report.schedules.enabled = queryCount(rtDb, "SELECT COUNT(*) as n FROM schedules WHERE enabled = 1");
+    report.schedules.overdue = queryCount(rtDb, "SELECT COUNT(*) as n FROM schedules WHERE enabled = 1 AND next_fire_at < datetime('now')");
+
+    // Migrations
+    try {
+      const mig = rtDb.prepare(
+        "SELECT id, COUNT(*) OVER () as total FROM schema_migrations ORDER BY id DESC LIMIT 1",
+      ).get() as { id: string; total: number } | undefined;
+      if (mig) {
+        report.migrations.latest_id = mig.id;
+        report.migrations.count = mig.total;
+      }
+    } catch { /* pre-migration DB */ }
+
+    // Models
+    report.models.registered = queryCount(rtDb, "SELECT COUNT(*) as n FROM model_registry");
+    report.models.enabled = queryCount(rtDb, "SELECT COUNT(*) as n FROM model_registry WHERE enabled = 1");
 
     // Daemon heartbeat
     const heartbeat = rtDb.prepare(

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -46,20 +46,8 @@ export async function runAgent(
   // Initialize durable run tracking if runtime DB is available
   const runStore = runtimeDb ? new RunStore(runtimeDb) : null;
 
-  // Look up pending command_id for this agent (set by daemon when processing commands)
-  let commandId: string | undefined;
-  if (runtimeDb) {
-    try {
-      const row = runtimeDb.prepare(
-        "SELECT value_json FROM settings WHERE key = ?",
-      ).get(`pending_command:${agentId}`) as { value_json: string } | undefined;
-      if (row) {
-        commandId = JSON.parse(row.value_json) as string;
-        // Clean up the pending command key
-        runtimeDb.prepare("DELETE FROM settings WHERE key = ?").run(`pending_command:${agentId}`);
-      }
-    } catch { /* best-effort */ }
-  }
+  // command_id is carried directly on the trigger by AgentQueue (atomic linkage)
+  const commandId = (trigger as { command_id?: string }).command_id;
 
   // Load plugin permissions if this is a plugin agent
   const pluginPermissions = loadPluginPermissions(agentId, runtimeDb);
@@ -389,11 +377,11 @@ export async function runAgent(
 
     // 7. Notify via Telegram queue
     const summary = `${def.label}: completed ${run.current_step}/${plan.steps.length} steps. Goal: ${run.goal}`;
-    writeTelegramQueue(agentId, summary);
+    writeTelegramQueue(agentId, summary, runtimeDb);
 
     // 8. Post-hoc review notification for trusted_with_review agents
     if (def.maturity === "trusted_with_review") {
-      writeTelegramQueue(agentId, `[REVIEW] ${def.label} completed autonomously. Run: ${run.run_id}. Review output and decisions.`);
+      writeTelegramQueue(agentId, `[REVIEW] ${def.label} completed autonomously. Run: ${run.run_id}. Review output and decisions.`, runtimeDb);
     }
 
     return runtime.getRun(run.run_id)!;

--- a/packages/jarvis-runtime/src/plugin-loader.ts
+++ b/packages/jarvis-runtime/src/plugin-loader.ts
@@ -184,11 +184,12 @@ export function deriveRequiredPermissions(capabilities: string[]): PluginPermiss
 
 /**
  * Check if a plugin's agent action is allowed by its granted permissions.
+ * Fails closed: unknown/unmapped action families are denied.
  */
 export function isActionPermitted(action: string, grantedPermissions: PluginPermission[]): boolean {
   const prefix = action.split(".")[0];
   const required = CAPABILITY_PERMISSION_MAP[prefix];
-  if (!required) return true; // Unknown prefix — allow (built-in actions)
+  if (!required) return false; // Unknown prefix — deny (fail closed)
   return grantedPermissions.includes(required);
 }
 

--- a/packages/jarvis-runtime/src/run-store.ts
+++ b/packages/jarvis-runtime/src/run-store.ts
@@ -38,25 +38,38 @@ const VALID_TRANSITIONS: Record<RunStatus, RunStatus[]> = {
 export class RunStore {
   constructor(private db: DatabaseSync) {}
 
-  /** Start a new run. Inserts into runs table and emits run_started event. Returns run_id. */
+  /** Start a new run. Inserts into runs table and emits run_started event atomically. Returns run_id. */
   startRun(agentId: string, triggerKind?: string, commandId?: string, goal?: string): string {
     const runId = randomUUID();
     const now = new Date().toISOString();
 
+    this.db.exec("BEGIN IMMEDIATE");
     try {
       this.db.prepare(`
         INSERT INTO runs (run_id, agent_id, status, trigger_kind, command_id, goal, started_at)
         VALUES (?, ?, 'queued', ?, ?, ?, ?)
       `).run(runId, agentId, triggerKind ?? null, commandId ?? null, goal ?? null, now);
-    } catch {
-      // Best-effort: runs table may not exist yet (pre-migration)
+
+      // Inline transition to 'planning' + event emission within the same transaction
+      this.db.prepare(`
+        UPDATE runs SET status = 'planning' WHERE run_id = ?
+      `).run(runId);
+
+      this.db.prepare(`
+        INSERT INTO run_events (event_id, run_id, agent_id, event_type, step_no, action, payload_json, created_at)
+        VALUES (?, ?, ?, 'run_started', NULL, NULL, NULL, ?)
+      `).run(randomUUID(), runId, agentId, now);
+
+      this.db.exec("COMMIT");
+    } catch (e) {
+      this.db.exec("ROLLBACK");
+      throw e;
     }
 
-    this.transition(runId, agentId, "planning", "run_started");
     return runId;
   }
 
-  /** Transition a run to a new status. Validates the transition and emits an event. */
+  /** Transition a run to a new status. Validates the transition and emits an event atomically. */
   transition(
     runId: string,
     agentId: string,
@@ -64,7 +77,7 @@ export class RunStore {
     eventType: RunEventType,
     payload?: { step_no?: number; action?: string; details?: Record<string, unknown> },
   ): void {
-    // Read current status from DB
+    // Read current status from DB (outside transaction — read-only)
     const currentStatus = this.getStatus(runId);
     if (currentStatus) {
       const allowed = VALID_TRANSITIONS[currentStatus];
@@ -75,13 +88,14 @@ export class RunStore {
       }
     }
 
-    // Update runs table
-    try {
-      const completedAt = (newStatus === "completed" || newStatus === "failed" || newStatus === "cancelled")
-        ? new Date().toISOString()
-        : null;
-      const error = payload?.details?.error ?? payload?.details?.reason ?? null;
+    const completedAt = (newStatus === "completed" || newStatus === "failed" || newStatus === "cancelled")
+      ? new Date().toISOString()
+      : null;
+    const error = payload?.details?.error ?? payload?.details?.reason ?? null;
 
+    // Atomic: status update + event emission
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
       this.db.prepare(`
         UPDATE runs SET status = ?, completed_at = COALESCE(?, completed_at),
           error = COALESCE(?, error), current_step = COALESCE(?, current_step)
@@ -93,35 +107,7 @@ export class RunStore {
         payload?.step_no ?? null,
         runId,
       );
-    } catch {
-      // Best-effort: runs table may not exist yet
-    }
 
-    this.emitEvent(runId, agentId, eventType, payload);
-  }
-
-  /** Update run metadata (goal, total_steps) without changing status. */
-  updateRunMeta(runId: string, meta: { goal?: string; total_steps?: number }): void {
-    try {
-      if (meta.goal !== undefined) {
-        this.db.prepare("UPDATE runs SET goal = ? WHERE run_id = ?").run(meta.goal, runId);
-      }
-      if (meta.total_steps !== undefined) {
-        this.db.prepare("UPDATE runs SET total_steps = ? WHERE run_id = ?").run(meta.total_steps, runId);
-      }
-    } catch {
-      // Best-effort
-    }
-  }
-
-  /** Emit a run event without changing status (e.g., step_started within executing). */
-  emitEvent(
-    runId: string,
-    agentId: string,
-    eventType: RunEventType | string,
-    payload?: { step_no?: number; action?: string; details?: Record<string, unknown> },
-  ): void {
-    try {
       this.db.prepare(`
         INSERT INTO run_events (event_id, run_id, agent_id, event_type, step_no, action, payload_json, created_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -135,21 +121,52 @@ export class RunStore {
         payload?.details ? JSON.stringify(payload.details) : null,
         new Date().toISOString(),
       );
-    } catch {
-      // Best-effort: don't crash agent run if event emission fails
+
+      this.db.exec("COMMIT");
+    } catch (e) {
+      this.db.exec("ROLLBACK");
+      throw e;
     }
+  }
+
+  /** Update run metadata (goal, total_steps) without changing status. */
+  updateRunMeta(runId: string, meta: { goal?: string; total_steps?: number }): void {
+    if (meta.goal !== undefined) {
+      this.db.prepare("UPDATE runs SET goal = ? WHERE run_id = ?").run(meta.goal, runId);
+    }
+    if (meta.total_steps !== undefined) {
+      this.db.prepare("UPDATE runs SET total_steps = ? WHERE run_id = ?").run(meta.total_steps, runId);
+    }
+  }
+
+  /** Emit a run event without changing status (e.g., step_started within executing). */
+  emitEvent(
+    runId: string,
+    agentId: string,
+    eventType: RunEventType | string,
+    payload?: { step_no?: number; action?: string; details?: Record<string, unknown> },
+  ): void {
+    this.db.prepare(`
+      INSERT INTO run_events (event_id, run_id, agent_id, event_type, step_no, action, payload_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(),
+      runId,
+      agentId,
+      eventType,
+      payload?.step_no ?? null,
+      payload?.action ?? null,
+      payload?.details ? JSON.stringify(payload.details) : null,
+      new Date().toISOString(),
+    );
   }
 
   /** Get current status of a run from the durable runs table. */
   getStatus(runId: string): RunStatus | null {
-    try {
-      const row = this.db.prepare(
-        "SELECT status FROM runs WHERE run_id = ?",
-      ).get(runId) as { status: string } | undefined;
-      return (row?.status as RunStatus) ?? null;
-    } catch {
-      return null;
-    }
+    const row = this.db.prepare(
+      "SELECT status FROM runs WHERE run_id = ?",
+    ).get(runId) as { status: string } | undefined;
+    return (row?.status as RunStatus) ?? null;
   }
 
   /** Get a run record. */
@@ -160,11 +177,7 @@ export class RunStore {
     current_step: number; error: string | null;
     started_at: string; completed_at: string | null;
   } | null {
-    try {
-      return this.db.prepare("SELECT * FROM runs WHERE run_id = ?").get(runId) as any ?? null;
-    } catch {
-      return null;
-    }
+    return this.db.prepare("SELECT * FROM runs WHERE run_id = ?").get(runId) as any ?? null;
   }
 
   /** Get all events for a run, ordered chronologically. */
@@ -200,31 +213,16 @@ export class RunStore {
     started_at: string;
     completed_at: string | null;
   }> {
-    try {
-      return this.db.prepare(
-        "SELECT run_id, agent_id, status, started_at, completed_at FROM runs ORDER BY started_at DESC LIMIT ?",
-      ).all(limit) as any[];
-    } catch {
-      // Fallback to run_events if runs table doesn't exist
-      return this.db.prepare(`
-        SELECT DISTINCT run_id, agent_id, event_type as status, created_at as started_at, NULL as completed_at
-        FROM run_events
-        WHERE event_type IN ('run_started', 'run_completed', 'run_failed', 'run_cancelled')
-        ORDER BY created_at DESC
-        LIMIT ?
-      `).all(limit) as any[];
-    }
+    return this.db.prepare(
+      "SELECT run_id, agent_id, status, started_at, completed_at FROM runs ORDER BY started_at DESC LIMIT ?",
+    ).all(limit) as any[];
   }
 
   /** Mark a run's associated command as completed or failed. */
   completeCommand(runId: string, status: "completed" | "failed"): void {
-    try {
-      this.db.prepare(`
-        UPDATE agent_commands SET status = ?, completed_at = ?
-        WHERE command_id = (SELECT command_id FROM runs WHERE run_id = ? AND command_id IS NOT NULL)
-      `).run(status, new Date().toISOString(), runId);
-    } catch {
-      // Best-effort
-    }
+    this.db.prepare(`
+      UPDATE agent_commands SET status = ?, completed_at = ?
+      WHERE command_id = (SELECT command_id FROM runs WHERE run_id = ? AND command_id IS NOT NULL)
+    `).run(status, new Date().toISOString(), runId);
   }
 }

--- a/packages/jarvis-runtime/src/status-writer.ts
+++ b/packages/jarvis-runtime/src/status-writer.ts
@@ -5,6 +5,15 @@ import type { Logger } from "./logger.js";
 
 const WRITE_INTERVAL_MS = 10_000; // 10 seconds
 
+type ActiveRun = {
+  agent_id: string;
+  status: string;
+  step: number;
+  total_steps: number;
+  current_action: string;
+  started_at: string;
+};
+
 export interface DaemonStatusData {
   pid: number;
   started_at: string;
@@ -16,19 +25,17 @@ export interface DaemonStatusData {
     status: string;
     completed_at: string;
   } | null;
-  current_run: {
-    agent_id: string;
-    status: string;
-    step: number;
-    total_steps: number;
-    current_action: string;
-    started_at: string;
-  } | null;
+  /** @deprecated Use active_runs instead */
+  current_run: ActiveRun | null;
+  /** All currently executing agent runs (supports concurrent execution). */
+  active_runs: ActiveRun[];
 }
 
 /**
  * StatusWriter: periodically writes daemon heartbeat to runtime.db.
  * The dashboard reads from the daemon_heartbeats table to display live daemon info.
+ *
+ * Tracks multiple concurrent runs (AgentQueue supports parallel execution).
  */
 export class StatusWriter {
   private state: DaemonStatusData;
@@ -49,6 +56,7 @@ export class StatusWriter {
       schedules_active: schedulesActive,
       last_run: null,
       current_run: null,
+      active_runs: [],
     };
   }
 
@@ -72,9 +80,9 @@ export class StatusWriter {
     this.logger.info("Status writer stopped");
   }
 
-  /** Mark an agent run as started. */
+  /** Mark an agent run as started. Supports concurrent runs. */
   setCurrentRun(agentId: string, totalSteps: number): void {
-    this.state.current_run = {
+    const run: ActiveRun = {
       agent_id: agentId,
       status: "executing",
       step: 0,
@@ -82,45 +90,69 @@ export class StatusWriter {
       current_action: "planning",
       started_at: new Date().toISOString(),
     };
+    // Remove any stale entry for this agent (shouldn't happen, but defensive)
+    this.state.active_runs = this.state.active_runs.filter(r => r.agent_id !== agentId);
+    this.state.active_runs.push(run);
+    // Keep current_run as the most recently started for backward compat
+    this.state.current_run = run;
     this.flush();
   }
 
-  /** Update progress of the current run. */
-  updateStep(step: number, action: string): void {
-    if (this.state.current_run) {
-      this.state.current_run.step = step;
-      this.state.current_run.current_action = action;
-      this.state.current_run.status = "executing";
+  /** Update progress of a specific agent's run. */
+  updateStep(step: number, action: string, agentId?: string): void {
+    const run = agentId
+      ? this.state.active_runs.find(r => r.agent_id === agentId)
+      : this.state.active_runs[this.state.active_runs.length - 1];
+    if (run) {
+      run.step = step;
+      run.current_action = action;
+      run.status = "executing";
+      this.state.current_run = run;
       this.flush();
     }
   }
 
-  /** Update total steps (after planning completes). */
-  updateTotalSteps(totalSteps: number): void {
-    if (this.state.current_run) {
-      this.state.current_run.total_steps = totalSteps;
+  /** Update total steps for a specific agent (after planning completes). */
+  updateTotalSteps(totalSteps: number, agentId?: string): void {
+    const run = agentId
+      ? this.state.active_runs.find(r => r.agent_id === agentId)
+      : this.state.active_runs[this.state.active_runs.length - 1];
+    if (run) {
+      run.total_steps = totalSteps;
     }
   }
 
-  /** Mark current run as awaiting approval. */
-  setAwaitingApproval(step: number, action: string): void {
-    if (this.state.current_run) {
-      this.state.current_run.status = "awaiting_approval";
-      this.state.current_run.step = step;
-      this.state.current_run.current_action = action;
+  /** Mark a specific run as awaiting approval. */
+  setAwaitingApproval(step: number, action: string, agentId?: string): void {
+    const run = agentId
+      ? this.state.active_runs.find(r => r.agent_id === agentId)
+      : this.state.active_runs[this.state.active_runs.length - 1];
+    if (run) {
+      run.status = "awaiting_approval";
+      run.step = step;
+      run.current_action = action;
+      this.state.current_run = run;
       this.flush();
     }
   }
 
-  /** Mark current run as completed and move to last_run. */
-  completeRun(status: string): void {
-    if (this.state.current_run) {
+  /** Mark a run as completed and remove from active runs. */
+  completeRun(status: string, agentId?: string): void {
+    const idx = agentId
+      ? this.state.active_runs.findIndex(r => r.agent_id === agentId)
+      : this.state.active_runs.length - 1;
+    if (idx >= 0) {
+      const run = this.state.active_runs[idx];
       this.state.last_run = {
-        agent_id: this.state.current_run.agent_id,
+        agent_id: run.agent_id,
         status,
         completed_at: new Date().toISOString(),
       };
-      this.state.current_run = null;
+      this.state.active_runs.splice(idx, 1);
+      // Update current_run: set to most recent active, or null
+      this.state.current_run = this.state.active_runs.length > 0
+        ? this.state.active_runs[this.state.active_runs.length - 1]
+        : null;
       this.flush();
     }
   }
@@ -139,10 +171,10 @@ export class StatusWriter {
         this.state.pid,
         os.hostname(),
         "0.1.0",
-        this.state.current_run ? "busy" : "idle",
+        this.state.active_runs.length > 0 ? "busy" : "idle",
         this.state.updated_at,
         null,
-        this.state.current_run?.agent_id ?? null,
+        this.state.active_runs.map(r => r.agent_id).join(",") || null,
         JSON.stringify(this.state),
       );
     } catch (e) {

--- a/packages/jarvis-runtime/src/worker-registry.ts
+++ b/packages/jarvis-runtime/src/worker-registry.ts
@@ -35,7 +35,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   const useReal = config.adapter_mode === "real";
 
   // ─── Inference ──────────────────────────────────────────────────────────
-  const inferenceAdapter = useReal ? new DefaultInferenceAdapter(runtimeDb) : new MockInferenceAdapter();
+  const inferenceAdapter = useReal ? new DefaultInferenceAdapter(runtimeDb, config.lmstudio_url) : new MockInferenceAdapter();
   const inferenceWorker = createInferenceWorker({ adapter: inferenceAdapter });
 
   // Chat helper for adapters that need LLM access.

--- a/packages/jarvis-telegram/package.json
+++ b/packages/jarvis-telegram/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "start": "tsx src/index.ts"
   },
+  "dependencies": {
+    "@jarvis/runtime": "file:../jarvis-runtime"
+  },
   "devDependencies": {
     "@types/node": "^24.12.2",
     "tsx": "^4.19.3",

--- a/packages/jarvis-telegram/src/approvals.ts
+++ b/packages/jarvis-telegram/src/approvals.ts
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import { APPROVALS_FILE } from './config.js'
+import { randomUUID } from 'node:crypto'
+import type { DatabaseSync } from 'node:sqlite'
 
 export type ApprovalEntry = {
   id: string
@@ -8,30 +8,98 @@ export type ApprovalEntry = {
   payload: string
   created_at: string
   status: 'pending' | 'approved' | 'rejected'
+  run_id: string
+  severity: 'info' | 'warning' | 'critical'
+  resolved_at?: string
+  resolved_by?: string
+  resolution_note?: string
   notified?: boolean
 }
 
-export function loadApprovals(): ApprovalEntry[] {
-  if (!fs.existsSync(APPROVALS_FILE)) return []
+/**
+ * Load approvals from the runtime database.
+ */
+export function loadApprovals(db: DatabaseSync, status?: 'pending' | 'approved' | 'rejected'): ApprovalEntry[] {
   try {
-    return JSON.parse(fs.readFileSync(APPROVALS_FILE, 'utf8')) as ApprovalEntry[]
-  } catch { return [] }
+    const sql = status
+      ? "SELECT approval_id as id, agent_id as agent, action, payload_json as payload, requested_at as created_at, status, run_id, severity, resolved_at, resolved_by, resolution_note FROM approvals WHERE status = ? ORDER BY requested_at DESC"
+      : "SELECT approval_id as id, agent_id as agent, action, payload_json as payload, requested_at as created_at, status, run_id, severity, resolved_at, resolved_by, resolution_note FROM approvals ORDER BY requested_at DESC"
+    return (status ? db.prepare(sql).all(status) : db.prepare(sql).all()) as ApprovalEntry[]
+  } catch {
+    return []
+  }
 }
 
-export function saveApprovals(approvals: ApprovalEntry[]): void {
-  fs.writeFileSync(APPROVALS_FILE, JSON.stringify(approvals, null, 2))
+/**
+ * Get pending approvals that haven't been notified via Telegram yet.
+ * Uses the notifications table to track what's been sent.
+ */
+export function getUnnotifiedPending(db: DatabaseSync): ApprovalEntry[] {
+  try {
+    return db.prepare(`
+      SELECT a.approval_id as id, a.agent_id as agent, a.action, a.payload_json as payload,
+             a.requested_at as created_at, a.status, a.run_id, a.severity
+      FROM approvals a
+      WHERE a.status = 'pending'
+        AND NOT EXISTS (
+          SELECT 1 FROM notifications n
+          WHERE n.kind = 'approval_prompt'
+            AND json_extract(n.payload_json, '$.approval_id') = a.approval_id
+        )
+      ORDER BY a.requested_at ASC
+    `).all() as ApprovalEntry[]
+  } catch {
+    return []
+  }
 }
 
-export function getUnnotifiedPending(approvals: ApprovalEntry[]): ApprovalEntry[] {
-  return approvals.filter(a => a.status === 'pending' && !a.notified)
+/**
+ * Record that an approval notification was sent to Telegram.
+ */
+export function markNotified(db: DatabaseSync, approvalId: string): void {
+  try {
+    db.prepare(`
+      INSERT INTO notifications (notification_id, channel, kind, payload_json, status, created_at, delivered_at)
+      VALUES (?, 'telegram', 'approval_prompt', ?, 'delivered', ?, ?)
+    `).run(
+      randomUUID(),
+      JSON.stringify({ approval_id: approvalId }),
+      new Date().toISOString(),
+      new Date().toISOString(),
+    )
+  } catch {
+    // Best-effort notification tracking
+  }
 }
 
-export function markNotified(approvals: ApprovalEntry[], id: string): ApprovalEntry[] {
-  return approvals.map(a => a.id === id ? { ...a, notified: true } : a)
-}
+/**
+ * Resolve an approval (approve or reject) via the runtime database.
+ */
+export function resolveApproval(
+  db: DatabaseSync,
+  approvalId: string,
+  status: 'approved' | 'rejected',
+): boolean {
+  const now = new Date().toISOString()
 
-export function setApprovalStatus(approvals: ApprovalEntry[], id: string, status: 'approved' | 'rejected'): ApprovalEntry[] {
-  return approvals.map(a => a.id === id ? { ...a, status } : a)
+  try {
+    const result = db.prepare(`
+      UPDATE approvals SET status = ?, resolved_at = ?, resolved_by = ?, resolution_note = ?
+      WHERE approval_id = ? AND status = 'pending'
+    `).run(status, now, 'telegram', null, approvalId)
+
+    if ((result as { changes: number }).changes === 0) return false
+
+    // Write audit log entry
+    db.prepare(`
+      INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(randomUUID(), 'user', 'telegram', `approval.${status}`, 'approval', approvalId, '{}', now)
+
+    return true
+  } catch {
+    return false
+  }
 }
 
 export function formatApprovalMessage(entry: ApprovalEntry): string {

--- a/packages/jarvis-telegram/src/bot.ts
+++ b/packages/jarvis-telegram/src/bot.ts
@@ -1,5 +1,6 @@
 import { handleCommand } from './commands.js'
-import { loadApprovals, saveApprovals, getUnnotifiedPending, markNotified, formatApprovalMessage } from './approvals.js'
+import { getUnnotifiedPending, markNotified, formatApprovalMessage } from './approvals.js'
+import { openRuntimeDb } from './config.js'
 import type { JarvisConfig } from './config.js'
 
 type TelegramUpdate = {
@@ -48,20 +49,30 @@ export class JarvisBot {
     return data.ok ? data.result : []
   }
 
+  /**
+   * Check for pending approvals in runtime.db that haven't been sent
+   * to Telegram yet, and send notifications for them.
+   */
   async checkApprovals(): Promise<void> {
-    const approvals = loadApprovals()
-    const unnotified = getUnnotifiedPending(approvals)
-    let updated = approvals
-    for (const entry of unnotified) {
-      try {
-        await this.send(formatApprovalMessage(entry))
-        updated = markNotified(updated, entry.id)
-      } catch {
-        // retry next cycle
-      }
+    let db;
+    try {
+      db = openRuntimeDb()
+    } catch {
+      return
     }
-    if (unnotified.length > 0) {
-      saveApprovals(updated)
+
+    try {
+      const unnotified = getUnnotifiedPending(db)
+      for (const entry of unnotified) {
+        try {
+          await this.send(formatApprovalMessage(entry))
+          markNotified(db, entry.id)
+        } catch {
+          // retry next cycle
+        }
+      }
+    } finally {
+      try { db.close() } catch {}
     }
   }
 

--- a/packages/jarvis-telegram/src/commands.ts
+++ b/packages/jarvis-telegram/src/commands.ts
@@ -1,8 +1,7 @@
-import fs from 'fs'
-import { join } from 'path'
+import { randomUUID } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
-import { TRIGGER_DIR, CRM_DB, KNOWLEDGE_DB } from './config.js'
-import { loadApprovals, saveApprovals, setApprovalStatus } from './approvals.js'
+import { CRM_DB, openRuntimeDb } from './config.js'
+import { loadApprovals, resolveApproval } from './approvals.js'
 
 const AGENTS = [
   'bd-pipeline', 'proposal-engine', 'evidence-auditor', 'contract-reviewer',
@@ -30,27 +29,29 @@ export async function handleCommand(text: string): Promise<string> {
 
 function getStatus(): string {
   const lines = ['JARVIS STATUS\n']
+  let db: DatabaseSync | undefined
 
-  // Last decision per agent
-  let kb: DatabaseSync | undefined
   try {
-    kb = new DatabaseSync(KNOWLEDGE_DB)
-    for (const agentId of AGENTS) {
-      const row = kb.prepare(
-        'SELECT created_at, outcome FROM decisions WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1'
-      ).get(agentId) as { created_at: string; outcome: string } | undefined
-      const ts = row ? new Date(row.created_at).toLocaleDateString() : 'never'
-      lines.push(`${agentId}: ${ts}`)
-    }
-  } catch {
-    lines.push('(could not read knowledge.db)')
-  } finally {
-    kb?.close()
-  }
+    db = openRuntimeDb()
 
-  // Pending approvals
-  const approvals = loadApprovals().filter(a => a.status === 'pending')
-  lines.push(`\nPending approvals: ${approvals.length}`)
+    // Last run per agent from runtime.db runs table
+    for (const agentId of AGENTS) {
+      const row = db.prepare(
+        'SELECT started_at, status FROM runs WHERE agent_id = ? ORDER BY started_at DESC LIMIT 1'
+      ).get(agentId) as { started_at: string; status: string } | undefined
+      const ts = row ? new Date(row.started_at).toLocaleDateString() : 'never'
+      const status = row?.status ?? ''
+      lines.push(`${agentId}: ${ts}${status ? ` (${status})` : ''}`)
+    }
+
+    // Pending approvals from runtime.db
+    const pending = loadApprovals(db, 'pending')
+    lines.push(`\nPending approvals: ${pending.length}`)
+  } catch {
+    lines.push('(could not read runtime.db)')
+  } finally {
+    try { db?.close() } catch {}
+  }
 
   return lines.join('\n')
 }
@@ -76,29 +77,56 @@ function getCrmTop5(): string {
   }
 }
 
+/**
+ * Trigger an agent by inserting a command into agent_commands in runtime.db.
+ * The daemon polls this table and claims queued commands.
+ */
 function triggerAgent(agentId: string): string {
+  let db: DatabaseSync | undefined
   try {
-    const triggerFile = join(TRIGGER_DIR, `trigger-${agentId}.json`)
-    fs.writeFileSync(triggerFile, JSON.stringify({
-      agent: agentId,
-      triggered_at: new Date().toISOString(),
-      source: 'telegram'
-    }, null, 2))
+    db = openRuntimeDb()
+    const commandId = randomUUID()
+    db.prepare(`
+      INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
+      VALUES (?, 'run_agent', ?, ?, 'queued', 0, ?, 'telegram', ?)
+    `).run(
+      commandId,
+      agentId,
+      JSON.stringify({ triggered_by: 'telegram' }),
+      new Date().toISOString(),
+      `telegram-${agentId}-${Date.now()}`
+    )
     return `Triggered ${agentId}. It will run within the next scheduled cycle.`
   } catch (e) {
     return `Failed to trigger ${agentId}: ${String(e)}`
+  } finally {
+    try { db?.close() } catch {}
   }
 }
 
+/**
+ * Approve or reject a pending approval via runtime.db.
+ */
 function handleApproval(shortId: string, status: 'approved' | 'rejected'): string {
   if (!shortId) return `Usage: /approve <id> or /reject <id>`
   if (shortId.length < 6) return 'Approval ID must be at least 6 characters for safety.'
-  const approvals = loadApprovals()
-  const target = approvals.find(a => a.id.startsWith(shortId) && a.status === 'pending')
-  if (!target) return `No pending approval found with ID starting: ${shortId}`
-  const updated = setApprovalStatus(approvals, target.id, status)
-  saveApprovals(updated)
-  return `${status === 'approved' ? '✅' : '❌'} ${target.action} by ${target.agent} has been ${status}.`
+
+  let db: DatabaseSync | undefined
+  try {
+    db = openRuntimeDb()
+    const pending = loadApprovals(db, 'pending')
+    const target = pending.find(a => a.id.startsWith(shortId))
+    if (!target) return `No pending approval found with ID starting: ${shortId}`
+
+    const ok = resolveApproval(db, target.id, status)
+    if (!ok) return `Failed to ${status === 'approved' ? 'approve' : 'reject'} — may already be resolved.`
+
+    return `${status === 'approved' ? '✅' : '❌'} ${target.action} by ${target.agent} has been ${status}.`
+  } catch (e) {
+    return `Failed to process approval: ${String(e)}`
+  } finally {
+    try { db?.close() } catch {}
+  }
 }
 
 function getHelp(): string {

--- a/packages/jarvis-telegram/src/config.ts
+++ b/packages/jarvis-telegram/src/config.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import { join } from 'path'
+import { DatabaseSync } from 'node:sqlite'
 
 export type JarvisConfig = {
   telegram: {
@@ -20,8 +21,17 @@ export function loadConfig(): JarvisConfig | null {
 }
 
 export const JARVIS_DIR = join(os.homedir(), '.jarvis')
-export const QUEUE_FILE = join(JARVIS_DIR, 'telegram-queue.json')
-export const APPROVALS_FILE = join(JARVIS_DIR, 'approvals.json')
-export const TRIGGER_DIR = JARVIS_DIR
+export const RUNTIME_DB_PATH = join(JARVIS_DIR, 'runtime.db')
 export const CRM_DB = join(JARVIS_DIR, 'crm.db')
 export const KNOWLEDGE_DB = join(JARVIS_DIR, 'knowledge.db')
+
+/**
+ * Open the runtime database with WAL mode and busy timeout.
+ * All telegram operations go through this single DB connection.
+ */
+export function openRuntimeDb(): DatabaseSync {
+  const db = new DatabaseSync(RUNTIME_DB_PATH)
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}

--- a/packages/jarvis-telegram/src/push.ts
+++ b/packages/jarvis-telegram/src/push.ts
@@ -1,9 +1,7 @@
 // Usage: node push.js <agent-id> <message>
 // Or: tsx packages/jarvis-telegram/src/push.ts <agent-id> <message>
-import fs from 'fs'
-import { QUEUE_FILE } from './config.js'
-
-type QueueEntry = { agent: string; message: string; ts: string; sent: boolean }
+import { randomUUID } from 'node:crypto'
+import { openRuntimeDb } from './config.js'
 
 function main() {
   const [,, agentId, ...messageParts] = process.argv
@@ -14,13 +12,20 @@ function main() {
     process.exit(1)
   }
 
-  const queue: QueueEntry[] = fs.existsSync(QUEUE_FILE)
-    ? JSON.parse(fs.readFileSync(QUEUE_FILE, 'utf8')) as QueueEntry[]
-    : []
-
-  queue.push({ agent: agentId, message, ts: new Date().toISOString(), sent: false })
-  fs.writeFileSync(QUEUE_FILE, JSON.stringify(queue, null, 2))
-  console.log(`Queued message for ${agentId}`)
+  const db = openRuntimeDb()
+  try {
+    db.prepare(`
+      INSERT INTO notifications (notification_id, channel, kind, payload_json, status, created_at)
+      VALUES (?, 'telegram', 'agent_notification', ?, 'pending', ?)
+    `).run(
+      randomUUID(),
+      JSON.stringify({ agent: agentId, message }),
+      new Date().toISOString(),
+    )
+    console.log(`Queued message for ${agentId}`)
+  } finally {
+    try { db.close() } catch {}
+  }
 }
 
 // Only run when invoked directly

--- a/packages/jarvis-telegram/src/relay.ts
+++ b/packages/jarvis-telegram/src/relay.ts
@@ -1,36 +1,41 @@
-import fs from 'fs'
-import { QUEUE_FILE } from './config.js'
+import { openRuntimeDb } from './config.js'
 
-type QueueEntry = {
-  agent: string
-  message: string
-  ts: string
-  sent: boolean
-}
-
+/**
+ * Process pending Telegram notifications from runtime.db.
+ * Reads pending notifications, delivers them via sendFn, and marks as delivered.
+ */
 export async function processTelegramQueue(sendFn: (msg: string) => Promise<void>): Promise<number> {
-  if (!fs.existsSync(QUEUE_FILE)) return 0
-  let queue: QueueEntry[] = []
+  let db;
   try {
-    queue = JSON.parse(fs.readFileSync(QUEUE_FILE, 'utf8')) as QueueEntry[]
-  } catch { return 0 }
+    db = openRuntimeDb()
+  } catch {
+    return 0
+  }
 
-  const unsent = queue.filter(e => !e.sent)
-  let sent = 0
-  for (const entry of unsent) {
-    try {
-      await sendFn(`[${entry.agent.toUpperCase()}]\n\n${entry.message}`)
-      entry.sent = true
-      sent++
-    } catch {
-      // leave as unsent, retry next cycle
+  try {
+    const pending = db.prepare(`
+      SELECT notification_id, payload_json FROM notifications
+      WHERE channel = 'telegram' AND status = 'pending' AND kind = 'agent_notification'
+      ORDER BY created_at ASC LIMIT 20
+    `).all() as Array<{ notification_id: string; payload_json: string }>
+
+    let sent = 0
+    for (const entry of pending) {
+      try {
+        const payload = JSON.parse(entry.payload_json) as { agent: string; message: string }
+        await sendFn(`[${payload.agent.toUpperCase()}]\n\n${payload.message}`)
+
+        db.prepare(
+          "UPDATE notifications SET status = 'delivered', delivered_at = ? WHERE notification_id = ?"
+        ).run(new Date().toISOString(), entry.notification_id)
+
+        sent++
+      } catch {
+        // Leave as pending, retry next cycle
+      }
     }
+    return sent
+  } finally {
+    try { db.close() } catch {}
   }
-
-  if (sent > 0) {
-    // Prune sent entries to prevent unbounded file growth
-    const pruned = queue.filter(e => !e.sent);
-    fs.writeFileSync(QUEUE_FILE, JSON.stringify(pruned, null, 2))
-  }
-  return sent
 }

--- a/tests/smoke/integration.test.ts
+++ b/tests/smoke/integration.test.ts
@@ -291,8 +291,8 @@ describe("Plugin Permissions", () => {
     expect(isActionPermitted("email.send", [...granted])).toBe(false);
   });
 
-  it("allows unknown action prefixes", () => {
-    expect(isActionPermitted("custom.action", [])).toBe(true);
+  it("denies unknown action prefixes (fail closed)", () => {
+    expect(isActionPermitted("custom.action", [])).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Control plane unified**: Dashboard and Telegram now exclusively use runtime.db for all triggers, approvals, notifications, and run history. Zero legacy file/JSON paths remain (no trigger-*.json, approvals.json, telegram-queue.json, no knowledge.db agent_runs reads).
- **Atomic command-to-run linkage**: AgentQueue carries command_id directly through enqueue(), eliminating the race-prone `pending_command:<agentId>` settings shim.
- **RunStore fail-loud**: All try/catch removed from critical state mutations — durable state write failures are now runtime integrity errors, not swallowed warnings.
- **Database transactions**: RunStore.startRun, RunStore.transition, approval resolution, and entity graph upsert all wrapped in BEGIN IMMEDIATE transactions for atomic multi-step writes.
- **StatusWriter concurrency**: Tracks multiple concurrent active_runs instead of single current_run, matching AgentQueue's parallel execution model.
- **Permissions fail-closed**: isActionPermitted denies unknown/unmapped action families instead of allowing them.
- **Inference lockdown**: default-adapter uses loadRegisteredModels + selectByProfileWithEvidence as primary model selection path; live discovery only as first-boot fallback before daemon populates registry.
- **Notification fix**: orchestrator now passes runtimeDb to writeTelegramQueue (was always a no-op before).

### Files changed (22)
- Dashboard: agents.ts, runs.ts
- Telegram: all 6 source files rewritten (commands, approvals, bot, config, push, relay) + package.json
- Runtime: run-store.ts, agent-queue.ts, daemon.ts, orchestrator.ts, status-writer.ts, approval-bridge.ts, plugin-loader.ts, worker-registry.ts, health.ts
- Inference: default-adapter.ts, index.ts
- Framework: sqlite-entity-graph.ts
- Tests: integration.test.ts (updated fail-closed expectation)

## Test plan
- [x] `npm run check` passes (contracts + 1044 tests + build)
- [ ] Manual: start daemon, trigger agent via dashboard → verify command appears in agent_commands, run tracked in runs table
- [ ] Manual: trigger agent via Telegram → verify same path (agent_commands, not trigger files)
- [ ] Manual: approval flow end-to-end via Telegram /approve and dashboard POST
- [ ] Manual: verify no trigger-*.json, approvals.json, or telegram-queue.json files created


🤖 Generated with [Claude Code](https://claude.com/claude-code)