### PR TITLE
Harden shutdown and doctor checks

### DIFF
--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -213,6 +213,28 @@ async function main() {
     // Drain: wait for running agents to complete (30s timeout)
     await agentQueue.drain(30_000);
 
+    // Mark any still-running runs as failed (shouldn't happen after drain, but defensive)
+    try {
+      const staleRuns = runtimeDb.prepare(
+        "UPDATE runs SET status = 'failed', completed_at = ?, error = 'daemon_shutdown' WHERE status IN ('queued','planning','executing','awaiting_approval')",
+      ).run(new Date().toISOString());
+      const changes = (staleRuns as { changes: number }).changes;
+      if (changes > 0) {
+        logger.warn(`Marked ${changes} in-flight run(s) as failed on shutdown`);
+      }
+    } catch { /* best-effort */ }
+
+    // Release any claimed commands back to queued
+    try {
+      const staleCmds = runtimeDb.prepare(
+        "UPDATE agent_commands SET status = 'queued', claimed_at = NULL WHERE status = 'claimed'",
+      ).run();
+      const changes = (staleCmds as { changes: number }).changes;
+      if (changes > 0) {
+        logger.warn(`Released ${changes} claimed command(s) back to queue on shutdown`);
+      }
+    } catch { /* best-effort */ }
+
     // Stop heartbeat writer
     statusWriter.stop();
 

--- a/packages/jarvis-runtime/src/doctor.ts
+++ b/packages/jarvis-runtime/src/doctor.ts
@@ -134,7 +134,7 @@ function checkDatabases() {
   checkDatabase("CRM", CRM_DB_PATH, ["contacts", "notes", "stage_history"]);
   checkDatabase("Knowledge", KNOWLEDGE_DB_PATH, ["documents", "playbooks", "entities", "relations", "decisions"]);
   checkDatabase("Runtime", RUNTIME_DB_PATH, [
-    "schema_migrations", "approvals", "agent_commands", "run_events",
+    "schema_migrations", "approvals", "agent_commands", "runs", "run_events",
     "daemon_heartbeats", "notifications", "plugin_installs", "audit_log",
     "settings", "model_registry", "model_benchmarks", "schedules", "agent_memory",
   ]);


### PR DESCRIPTION
## Summary
- Daemon shutdown marks in-flight runs as failed and releases claimed commands back to queue
- Doctor validates `runs` table exists in runtime DB table checks

## Test plan
- [x] `npm run check` passes (1044 tests)
- [x] Build succeeds


🤖 Generated with [Claude Code](https://claude.com/claude-code)