### PR TITLE
Consolidate all database schemas under migration runner

### DIFF
--- a/packages/jarvis-runtime/src/doctor.ts
+++ b/packages/jarvis-runtime/src/doctor.ts
@@ -131,8 +131,14 @@ function checkDatabase(name: string, dbPath: string, tables: string[]) {
 }
 
 function checkDatabases() {
-  checkDatabase("CRM", CRM_DB_PATH, ["contacts", "notes", "stage_history"]);
-  checkDatabase("Knowledge", KNOWLEDGE_DB_PATH, ["documents", "playbooks", "entities", "relations", "decisions"]);
+  checkDatabase("CRM", CRM_DB_PATH, [
+    "schema_migrations", "contacts", "notes", "stage_history",
+    "campaigns", "campaign_recipients",
+  ]);
+  checkDatabase("Knowledge", KNOWLEDGE_DB_PATH, [
+    "schema_migrations", "documents", "playbooks", "entities", "relations",
+    "decisions", "entity_provenance", "memory", "agent_runs", "embedding_chunks",
+  ]);
   checkDatabase("Runtime", RUNTIME_DB_PATH, [
     "schema_migrations", "approvals", "agent_commands", "runs", "run_events",
     "daemon_heartbeats", "notifications", "plugin_installs", "audit_log",

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -1,6 +1,6 @@
 export { loadConfig, validateConfig, type JarvisRuntimeConfig, type ConfigCheckResult } from "./config.js";
 export { openRuntimeDb } from "./runtime-db.js";
-export { runMigrations } from "./migrations/runner.js";
+export { runMigrations, RUNTIME_MIGRATIONS, CRM_MIGRATIONS, KNOWLEDGE_MIGRATIONS, type Migration } from "./migrations/runner.js";
 export { Logger, type LogContext } from "./logger.js";
 export { createWorkerRegistry, buildEnvelope, type WorkerRegistry } from "./worker-registry.js";
 export { buildPlanWithInference } from "./planner-real.js";

--- a/packages/jarvis-runtime/src/migrations/crm_0001_core.ts
+++ b/packages/jarvis-runtime/src/migrations/crm_0001_core.ts
@@ -1,0 +1,71 @@
+import type { Migration } from "./runner.js";
+
+export const crmMigration0001: Migration = {
+  id: "0001",
+  name: "crm_core",
+  sql: `
+-- ============================================================
+-- CRM database schema — contacts, notes, stage history, campaigns
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS contacts (
+  id          TEXT PRIMARY KEY,
+  name        TEXT NOT NULL,
+  company     TEXT NOT NULL,
+  role        TEXT,
+  email       TEXT,
+  linkedin_url TEXT,
+  source      TEXT,
+  score       INTEGER DEFAULT 0,
+  stage       TEXT DEFAULT 'prospect',
+  tags        TEXT,
+  created_at  TEXT NOT NULL,
+  updated_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS notes (
+  id          TEXT PRIMARY KEY,
+  contact_id  TEXT REFERENCES contacts(id),
+  note        TEXT,
+  note_type   TEXT DEFAULT 'general',
+  created_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stage_history (
+  id          TEXT PRIMARY KEY,
+  contact_id  TEXT REFERENCES contacts(id),
+  from_stage  TEXT,
+  to_stage    TEXT,
+  moved_at    TEXT NOT NULL,
+  note        TEXT
+);
+
+-- Campaigns (email drip sequences)
+CREATE TABLE IF NOT EXISTS campaigns (
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL,
+  type            TEXT NOT NULL DEFAULT 'cold_outreach',
+  status          TEXT NOT NULL DEFAULT 'draft',
+  sequence_count  INTEGER NOT NULL DEFAULT 3,
+  delay_days      INTEGER NOT NULL DEFAULT 4,
+  subject_template TEXT NOT NULL DEFAULT '',
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS campaign_recipients (
+  campaign_id   TEXT NOT NULL,
+  contact_id    TEXT NOT NULL,
+  email         TEXT NOT NULL,
+  current_step  INTEGER NOT NULL DEFAULT 0,
+  status        TEXT NOT NULL DEFAULT 'enrolled',
+  enrolled_at   TEXT NOT NULL,
+  last_sent_at  TEXT,
+  last_status_at TEXT NOT NULL,
+  PRIMARY KEY (campaign_id, contact_id),
+  FOREIGN KEY (campaign_id) REFERENCES campaigns(id)
+);
+CREATE INDEX IF NOT EXISTS idx_recipients_campaign ON campaign_recipients(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_recipients_status ON campaign_recipients(status);
+`,
+};

--- a/packages/jarvis-runtime/src/migrations/knowledge_0001_core.ts
+++ b/packages/jarvis-runtime/src/migrations/knowledge_0001_core.ts
@@ -1,0 +1,125 @@
+import type { Migration } from "./runner.js";
+
+export const knowledgeMigration0001: Migration = {
+  id: "0001",
+  name: "knowledge_core",
+  sql: `
+-- ============================================================
+-- Knowledge database schema — documents, playbooks, entities,
+-- decisions, provenance, memory, runs, vector embeddings
+-- ============================================================
+
+-- Documents and playbooks (knowledge base)
+CREATE TABLE IF NOT EXISTS documents (
+  doc_id          TEXT PRIMARY KEY,
+  collection      TEXT NOT NULL,
+  title           TEXT NOT NULL,
+  content         TEXT NOT NULL,
+  tags            TEXT,
+  source_agent_id TEXT,
+  source_run_id   TEXT,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS playbooks (
+  playbook_id   TEXT PRIMARY KEY,
+  title         TEXT NOT NULL,
+  category      TEXT NOT NULL,
+  body          TEXT NOT NULL,
+  tags          TEXT,
+  use_count     INTEGER DEFAULT 0,
+  last_used_at  TEXT,
+  created_at    TEXT NOT NULL
+);
+
+-- Entity graph
+CREATE TABLE IF NOT EXISTS entities (
+  entity_id     TEXT PRIMARY KEY,
+  entity_type   TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  canonical_key TEXT UNIQUE,
+  attributes    TEXT,
+  seen_by       TEXT,
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS relations (
+  relation_id     TEXT PRIMARY KEY,
+  from_entity_id  TEXT NOT NULL,
+  to_entity_id    TEXT NOT NULL,
+  kind            TEXT NOT NULL,
+  attributes      TEXT,
+  created_at      TEXT NOT NULL
+);
+
+-- Decision log
+CREATE TABLE IF NOT EXISTS decisions (
+  decision_id TEXT PRIMARY KEY,
+  agent_id    TEXT NOT NULL,
+  run_id      TEXT NOT NULL,
+  step        INTEGER NOT NULL,
+  action      TEXT NOT NULL,
+  reasoning   TEXT NOT NULL,
+  outcome     TEXT NOT NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_decisions_agent ON decisions(agent_id);
+CREATE INDEX IF NOT EXISTS idx_decisions_run ON decisions(agent_id, run_id);
+
+-- Entity provenance (audit trail for entity changes)
+CREATE TABLE IF NOT EXISTS entity_provenance (
+  provenance_id TEXT PRIMARY KEY,
+  entity_id     TEXT NOT NULL,
+  change_type   TEXT NOT NULL,
+  agent_id      TEXT NOT NULL,
+  run_id        TEXT,
+  step_no       INTEGER,
+  action        TEXT,
+  changed_at    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_prov_entity ON entity_provenance(entity_id);
+CREATE INDEX IF NOT EXISTS idx_prov_agent ON entity_provenance(agent_id);
+
+-- Agent memory (short-term and long-term)
+CREATE TABLE IF NOT EXISTS memory (
+  entry_id    TEXT PRIMARY KEY,
+  agent_id    TEXT NOT NULL,
+  run_id      TEXT NOT NULL,
+  kind        TEXT NOT NULL CHECK(kind IN ('short_term', 'long_term')),
+  content     TEXT NOT NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_memory_agent ON memory(agent_id, kind);
+
+-- Legacy agent runs (kept for backward compat; runtime.db runs table is authoritative)
+CREATE TABLE IF NOT EXISTS agent_runs (
+  run_id        TEXT PRIMARY KEY,
+  agent_id      TEXT NOT NULL,
+  trigger_kind  TEXT NOT NULL,
+  trigger_data  TEXT,
+  goal          TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  current_step  INTEGER DEFAULT 0,
+  total_steps   INTEGER DEFAULT 0,
+  plan_json     TEXT,
+  started_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL,
+  completed_at  TEXT,
+  error         TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_runs_agent ON agent_runs(agent_id);
+
+-- Vector embedding chunks (for RAG)
+CREATE TABLE IF NOT EXISTS embedding_chunks (
+  chunk_id    TEXT PRIMARY KEY,
+  doc_id      TEXT NOT NULL,
+  chunk_text  TEXT NOT NULL,
+  embedding   BLOB NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_chunks_doc ON embedding_chunks(doc_id);
+`,
+};

--- a/packages/jarvis-runtime/src/migrations/runner.ts
+++ b/packages/jarvis-runtime/src/migrations/runner.ts
@@ -1,6 +1,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { migration0001 } from "./0001_runtime_core.js";
 import { migration0002 } from "./0002_production_fixes.js";
+import { crmMigration0001 } from "./crm_0001_core.js";
+import { knowledgeMigration0001 } from "./knowledge_0001_core.js";
 
 export type Migration = {
   id: string;        // e.g. "0001"
@@ -8,10 +10,20 @@ export type Migration = {
   sql: string;       // DDL statements
 };
 
-/** All registered migrations in order. Add new migrations to this array. */
-const ALL_MIGRATIONS: Migration[] = [
+/** Runtime DB migrations — control plane tables. */
+export const RUNTIME_MIGRATIONS: Migration[] = [
   migration0001,
   migration0002,
+];
+
+/** CRM DB migrations — contacts, notes, stages, campaigns. */
+export const CRM_MIGRATIONS: Migration[] = [
+  crmMigration0001,
+];
+
+/** Knowledge DB migrations — documents, playbooks, entities, decisions, memory, vectors. */
+export const KNOWLEDGE_MIGRATIONS: Migration[] = [
+  knowledgeMigration0001,
 ];
 
 /**
@@ -22,8 +34,11 @@ const ALL_MIGRATIONS: Migration[] = [
  * transaction is rolled back and startup is aborted.
  *
  * Migrations are idempotent: already-applied migrations are skipped.
+ *
+ * @param db - The database to migrate.
+ * @param migrations - Migration list to apply. Defaults to RUNTIME_MIGRATIONS for backward compat.
  */
-export function runMigrations(db: DatabaseSync): void {
+export function runMigrations(db: DatabaseSync, migrations: Migration[] = RUNTIME_MIGRATIONS): void {
   // Create tracking table
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -40,7 +55,7 @@ export function runMigrations(db: DatabaseSync): void {
     applied.add(row.id);
   }
 
-  for (const migration of ALL_MIGRATIONS) {
+  for (const migration of migrations) {
     if (applied.has(migration.id)) continue;
 
     try {

--- a/scripts/init-jarvis.ts
+++ b/scripts/init-jarvis.ts
@@ -1,8 +1,10 @@
 /**
  * Jarvis initialization script.
  *
- * Creates ~/.jarvis/ directory and seeds the CRM and Knowledge SQLite databases.
- * Idempotent — if databases already exist, reports their presence and skips creation.
+ * Creates ~/.jarvis/ directory and initializes the CRM, Knowledge, and Runtime
+ * SQLite databases via the migration runner. Seeds initial data on first creation.
+ *
+ * Idempotent — if databases already exist, applies any pending migrations and skips seeding.
  *
  * Usage:
  *   npx tsx scripts/init-jarvis.ts
@@ -13,7 +15,12 @@ import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { runMigrations } from "../packages/jarvis-runtime/src/migrations/runner.js";
+import {
+  runMigrations,
+  RUNTIME_MIGRATIONS,
+  CRM_MIGRATIONS,
+  KNOWLEDGE_MIGRATIONS,
+} from "../packages/jarvis-runtime/src/migrations/runner.js";
 
 // ─── Paths ──────────────────────────────────────────────────────────────────
 
@@ -28,385 +35,250 @@ function now(): string {
 
 // ─── CRM Database ───────────────────────────────────────────────────────────
 
-function initCrmDatabase(): boolean {
-  const isNew = !existsSync(CRM_DB_PATH);
+function seedCrmData(db: DatabaseSync): void {
+  const ts = now();
+  const contacts = [
+    {
+      id: randomUUID(),
+      name: "François Sagnely",
+      company: "Bertrandt",
+      role: "AUTOSAR Architect",
+      email: "f.sagnely@bertrandt.com",
+      linkedin_url: "https://linkedin.com/in/francois-sagnely",
+      source: "linkedin_scrape",
+      score: 75,
+      stage: "qualified",
+      tags: JSON.stringify(["autosar", "tier1", "germany"]),
+    },
+    {
+      id: randomUUID(),
+      name: "Anna Lindström",
+      company: "Volvo Cars",
+      role: "Safety Lead",
+      email: "anna.lindstrom@volvocars.com",
+      linkedin_url: "https://linkedin.com/in/anna-lindstrom-safety",
+      source: "referral",
+      score: 90,
+      stage: "proposal",
+      tags: JSON.stringify(["iso26262", "oem", "sweden", "asil-d"]),
+    },
+    {
+      id: randomUUID(),
+      name: "Thomas Keller",
+      company: "EDAG Engineering",
+      role: "Project Manager",
+      email: "t.keller@edag.com",
+      linkedin_url: "https://linkedin.com/in/thomas-keller-edag",
+      source: "web_intel",
+      score: 55,
+      stage: "prospect",
+      tags: JSON.stringify(["aspice", "tier1", "germany"]),
+    },
+    {
+      id: randomUUID(),
+      name: "Radu Ionescu",
+      company: "Continental",
+      role: "SW Team Lead",
+      email: "radu.ionescu@continental.com",
+      linkedin_url: "https://linkedin.com/in/radu-ionescu-conti",
+      source: "linkedin_scrape",
+      score: 40,
+      stage: "contacted",
+      tags: JSON.stringify(["autosar", "tier1", "romania"]),
+    },
+    {
+      id: randomUUID(),
+      name: "Marie Chen",
+      company: "Garrett Motion",
+      role: "Safety Manager",
+      email: "marie.chen@garrettmotion.com",
+      linkedin_url: "https://linkedin.com/in/marie-chen-garrett",
+      source: "direct",
+      score: 65,
+      stage: "meeting",
+      tags: JSON.stringify(["iso26262", "cybersecurity", "france"]),
+    },
+  ];
 
-  const db = new DatabaseSync(CRM_DB_PATH);
-  try {
-    db.exec("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+  const insertContact = db.prepare(`
+    INSERT INTO contacts (id, name, company, role, email, linkedin_url, source, score, stage, tags, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
 
-    // Schema creation runs on every init (idempotent).
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS contacts (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        company TEXT NOT NULL,
-        role TEXT,
-        email TEXT,
-        linkedin_url TEXT,
-        source TEXT,
-        score INTEGER DEFAULT 0,
-        stage TEXT DEFAULT 'prospect',
-        tags TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS notes (
-        id TEXT PRIMARY KEY,
-        contact_id TEXT REFERENCES contacts(id),
-        note TEXT,
-        note_type TEXT DEFAULT 'general',
-        created_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS stage_history (
-        id TEXT PRIMARY KEY,
-        contact_id TEXT REFERENCES contacts(id),
-        from_stage TEXT,
-        to_stage TEXT,
-        moved_at TEXT NOT NULL,
-        note TEXT
-      );
-    `);
-
-    if (!isNew) {
-      console.log(`  [schema] CRM database schema updated: ${CRM_DB_PATH}`);
-      return false;
-    }
-
-    // ── Seed contacts (only on first creation) ────────────────────────────
-
-    const ts = now();
-    const contacts = [
-      {
-        id: randomUUID(),
-        name: "François Sagnely",
-        company: "Bertrandt",
-        role: "AUTOSAR Architect",
-        email: "f.sagnely@bertrandt.com",
-        linkedin_url: "https://linkedin.com/in/francois-sagnely",
-        source: "linkedin_scrape",
-        score: 75,
-        stage: "qualified",
-        tags: JSON.stringify(["autosar", "tier1", "germany"]),
-      },
-      {
-        id: randomUUID(),
-        name: "Anna Lindström",
-        company: "Volvo Cars",
-        role: "Safety Lead",
-        email: "anna.lindstrom@volvocars.com",
-        linkedin_url: "https://linkedin.com/in/anna-lindstrom-safety",
-        source: "referral",
-        score: 90,
-        stage: "proposal",
-        tags: JSON.stringify(["iso26262", "oem", "sweden", "asil-d"]),
-      },
-      {
-        id: randomUUID(),
-        name: "Thomas Keller",
-        company: "EDAG Engineering",
-        role: "Project Manager",
-        email: "t.keller@edag.com",
-        linkedin_url: "https://linkedin.com/in/thomas-keller-edag",
-        source: "web_intel",
-        score: 55,
-        stage: "prospect",
-        tags: JSON.stringify(["aspice", "tier1", "germany"]),
-      },
-      {
-        id: randomUUID(),
-        name: "Radu Ionescu",
-        company: "Continental",
-        role: "SW Team Lead",
-        email: "radu.ionescu@continental.com",
-        linkedin_url: "https://linkedin.com/in/radu-ionescu-conti",
-        source: "linkedin_scrape",
-        score: 40,
-        stage: "contacted",
-        tags: JSON.stringify(["autosar", "tier1", "romania"]),
-      },
-      {
-        id: randomUUID(),
-        name: "Marie Chen",
-        company: "Garrett Motion",
-        role: "Safety Manager",
-        email: "marie.chen@garrettmotion.com",
-        linkedin_url: "https://linkedin.com/in/marie-chen-garrett",
-        source: "direct",
-        score: 65,
-        stage: "meeting",
-        tags: JSON.stringify(["iso26262", "cybersecurity", "france"]),
-      },
-    ];
-
-    const insertContact = db.prepare(`
-      INSERT INTO contacts (id, name, company, role, email, linkedin_url, source, score, stage, tags, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    for (const c of contacts) {
-      insertContact.run(
-        c.id, c.name, c.company, c.role, c.email, c.linkedin_url,
-        c.source, c.score, c.stage, c.tags, ts, ts,
-      );
-    }
-
-    console.log(`  [created] CRM database: ${CRM_DB_PATH}`);
-    console.log(`            Seeded ${contacts.length} contacts`);
-  } finally {
-    db.close();
+  for (const c of contacts) {
+    insertContact.run(
+      c.id, c.name, c.company, c.role, c.email, c.linkedin_url,
+      c.source, c.score, c.stage, c.tags, ts, ts,
+    );
   }
-  return true;
+
+  console.log(`            Seeded ${contacts.length} contacts`);
 }
 
 // ─── Knowledge Database ─────────────────────────────────────────────────────
 
-function initKnowledgeDatabase(): boolean {
-  const isNew = !existsSync(KNOWLEDGE_DB_PATH);
+function seedKnowledgeData(db: DatabaseSync): void {
+  const ts = now();
 
-  const db = new DatabaseSync(KNOWLEDGE_DB_PATH);
-  try {
-    db.exec("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+  const docs = [
+    {
+      collection: "lessons",
+      title: "Early signal: automotive Tier-1s post AUTOSAR safety roles 4-6 weeks before RFQ",
+      content:
+        "Hiring signals on LinkedIn (AUTOSAR, ISO 26262, Cyber Security roles) at Tier-1 suppliers reliably precede formal RFQs by 4-6 weeks. Monitor job boards weekly. When a supplier posts 2+ safety-critical openings simultaneously, treat as strong intent signal and move to immediate outreach.",
+      tags: JSON.stringify(["bd", "signal", "autosar", "rfq", "tier1"]),
+      source_agent_id: "bd-pipeline",
+    },
+    {
+      collection: "lessons",
+      title: "Proposals without explicit exclusion scope are renegotiated at delivery",
+      content:
+        "Every proposal that omitted explicit out-of-scope statements led to scope creep disputes. Include a dedicated EXCLUSIONS section listing at minimum: validation of third-party components, tool qualification, production software delivery, and acceptance testing unless specified. Use ISO 26262 scope boundary language.",
+      tags: JSON.stringify(["proposal", "scope", "exclusions", "risk"]),
+      source_agent_id: "proposal-engine",
+    },
+    {
+      collection: "lessons",
+      title: "ASPICE SWE.1 gaps are the most common blocker at supplier gate reviews",
+      content:
+        "Across 14 gate reviews audited, SWE.1 (Software Requirements Analysis) work product completeness was the most common gap causing gate delays. Prioritize: traceability matrix from HSR to SSR, review records with stakeholder sign-off, change management log. Clients underestimate SWE.1 depth required for ASPICE Level 2.",
+      tags: JSON.stringify(["aspice", "swe1", "gate-review", "requirements", "traceability"]),
+      source_agent_id: "evidence-auditor",
+    },
+    {
+      collection: "case-studies",
+      title: "Volvo: ASIL-D E/E architecture safety analysis — 12-week engagement",
+      content:
+        "Scope: HARA + FSC + TSR for full vehicle E/E architecture. Team: 2 senior safety engineers. Deliverables: HARA report, FSC, TSR document set, DIA with 3 Tier-1s. Key challenges: late requirement changes from powertrain team, conflicting ASIL decomposition between domains. Resolution: weekly alignment calls with system architect, formal change request process with traceability tags.",
+      tags: JSON.stringify(["volvo", "asil-d", "hara", "fsc", "tsr", "case-study"]),
+      source_agent_id: "evidence-auditor",
+    },
+    {
+      collection: "proposals",
+      title: "Standard rate card — Thinking in Code 2026",
+      content:
+        "Senior Safety Engineer (ISO 26262 / ASPICE): \u20AC130-180/h. Safety Architect (ASIL-D, system level): \u20AC160-200/h. Cyber Security Engineer (UN R155, ISO 21434): \u20AC120-160/h. AUTOSAR Architect: \u20AC140-180/h. Project Lead (technical): \u20AC110-140/h. Standard engagement: T&M with 3-month minimum. Fixed-price only for well-scoped work products (e.g., single HARA, single FMEA). Never T&M for safety-critical delivery milestones.",
+      tags: JSON.stringify(["rate-card", "pricing", "engagement-model"]),
+      source_agent_id: "proposal-engine",
+    },
+    {
+      collection: "iso26262",
+      title: "ISO 26262 Part 6 — Required work products by ASIL level",
+      content:
+        "ASIL A/B: Software safety plan (6-5), software design specification (6-8), unit implementation (6-9), unit verification (6-10). ASIL C adds: formal review of unit tests, MC/DC coverage evidence. ASIL D adds: independent review, structural coverage 100% statement + branch + MC/DC, formal inspection records. All ASILs: software requirements spec (6-7), integration test spec+report (6-11), software safety validation report (6-12), configuration management records.",
+      tags: JSON.stringify(["iso26262", "part6", "asil", "work-products", "checklist"]),
+      source_agent_id: "evidence-auditor",
+    },
+    {
+      collection: "contracts",
+      title: "NDA baseline — Thinking in Code preferred terms",
+      content:
+        "Jurisdiction: Romania or EU member state (not US/UK). Confidentiality term: 3 years post-engagement (not indefinite). IP: assign only specific deliverables explicitly listed in SOW, not background IP. Liability cap: total fees paid in preceding 3 months. Indemnity: mutual and symmetric. Non-compete: geographic scope limited to direct competitors, max 12 months. Payment: Net 30 from invoice date. Governing language: English.",
+      tags: JSON.stringify(["nda", "contract", "terms", "ip", "liability", "jurisdiction"]),
+      source_agent_id: "contract-reviewer",
+    },
+    {
+      collection: "playbooks",
+      title: "AUTOSAR migration outreach wedge",
+      content:
+        "Use when target is posting AUTOSAR Classic\u2192Adaptive migration roles. Opening line: 'Saw you\u2019re expanding into Adaptive AUTOSAR \u2014 we\u2019ve led 3 ARA migrations from scratch at Tier-1 level, including timing analysis and service-oriented communication for safety domains. Happy to share what derailed the first two and how we stabilized them.' Follow with 1 specific technical challenge they\u2019ll face. Offer: 30-minute architecture call, no pitch.",
+      tags: JSON.stringify(["outreach", "autosar", "adaptive", "wedge", "bd"]),
+      source_agent_id: "bd-pipeline",
+    },
+    {
+      collection: "garden",
+      title: "Ia\u0219i zone 6b — historical frost dates and growing season",
+      content:
+        "Last spring frost: April 15 (average), safe transplant after April 20. First fall frost: October 15 (average). Growing season: ~178 days. Risk dates: late frost risk until May 1, early frost risk from October 1. Warm season crops (tomatoes, peppers, cucumbers): transplant after May 1 for safety. Cool season crops (lettuce, spinach, kale): direct sow March-April, again August-September.",
+      tags: JSON.stringify(["zone6b", "iasi", "frost", "growing-season", "planting"]),
+      source_agent_id: "garden-calendar",
+    },
+  ];
 
-    // Schema creation runs on every init (CREATE TABLE IF NOT EXISTS is idempotent).
-    // This ensures schema additions (e.g. entity_provenance) are applied to existing DBs.
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS documents (
-        doc_id TEXT PRIMARY KEY,
-        collection TEXT NOT NULL,
-        title TEXT NOT NULL,
-        content TEXT NOT NULL,
-        tags TEXT,
-        source_agent_id TEXT,
-        source_run_id TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
+  const insertDoc = db.prepare(`
+    INSERT INTO documents (doc_id, collection, title, content, tags, source_agent_id, source_run_id, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
 
-      CREATE TABLE IF NOT EXISTS playbooks (
-        playbook_id TEXT PRIMARY KEY,
-        title TEXT NOT NULL,
-        category TEXT NOT NULL,
-        body TEXT NOT NULL,
-        tags TEXT,
-        use_count INTEGER DEFAULT 0,
-        last_used_at TEXT,
-        created_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS entities (
-        entity_id TEXT PRIMARY KEY,
-        entity_type TEXT NOT NULL,
-        name TEXT NOT NULL,
-        canonical_key TEXT UNIQUE,
-        attributes TEXT,
-        seen_by TEXT,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS relations (
-        relation_id TEXT PRIMARY KEY,
-        from_entity_id TEXT NOT NULL,
-        to_entity_id TEXT NOT NULL,
-        kind TEXT NOT NULL,
-        attributes TEXT,
-        created_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS decisions (
-        decision_id TEXT PRIMARY KEY,
-        agent_id TEXT,
-        run_id TEXT,
-        step INTEGER,
-        action TEXT,
-        reasoning TEXT,
-        outcome TEXT,
-        created_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS entity_provenance (
-        provenance_id TEXT PRIMARY KEY,
-        entity_id TEXT NOT NULL,
-        change_type TEXT NOT NULL,
-        agent_id TEXT NOT NULL,
-        run_id TEXT,
-        step_no INTEGER,
-        action TEXT,
-        changed_at TEXT NOT NULL
-      );
-      CREATE INDEX IF NOT EXISTS idx_prov_entity ON entity_provenance(entity_id);
-      CREATE INDEX IF NOT EXISTS idx_prov_agent ON entity_provenance(agent_id);
-    `);
-
-    if (!isNew) {
-      console.log(`  [schema] Knowledge database schema updated: ${KNOWLEDGE_DB_PATH}`);
-      return false;
-    }
-
-    // ── Seed documents (only on first creation) ───────────────────────────
-
-    const ts = now();
-
-    const docs = [
-      {
-        collection: "lessons",
-        title: "Early signal: automotive Tier-1s post AUTOSAR safety roles 4-6 weeks before RFQ",
-        content:
-          "Hiring signals on LinkedIn (AUTOSAR, ISO 26262, Cyber Security roles) at Tier-1 suppliers reliably precede formal RFQs by 4-6 weeks. Monitor job boards weekly. When a supplier posts 2+ safety-critical openings simultaneously, treat as strong intent signal and move to immediate outreach.",
-        tags: JSON.stringify(["bd", "signal", "autosar", "rfq", "tier1"]),
-        source_agent_id: "bd-pipeline",
-      },
-      {
-        collection: "lessons",
-        title: "Proposals without explicit exclusion scope are renegotiated at delivery",
-        content:
-          "Every proposal that omitted explicit out-of-scope statements led to scope creep disputes. Include a dedicated EXCLUSIONS section listing at minimum: validation of third-party components, tool qualification, production software delivery, and acceptance testing unless specified. Use ISO 26262 scope boundary language.",
-        tags: JSON.stringify(["proposal", "scope", "exclusions", "risk"]),
-        source_agent_id: "proposal-engine",
-      },
-      {
-        collection: "lessons",
-        title: "ASPICE SWE.1 gaps are the most common blocker at supplier gate reviews",
-        content:
-          "Across 14 gate reviews audited, SWE.1 (Software Requirements Analysis) work product completeness was the most common gap causing gate delays. Prioritize: traceability matrix from HSR to SSR, review records with stakeholder sign-off, change management log. Clients underestimate SWE.1 depth required for ASPICE Level 2.",
-        tags: JSON.stringify(["aspice", "swe1", "gate-review", "requirements", "traceability"]),
-        source_agent_id: "evidence-auditor",
-      },
-      {
-        collection: "case-studies",
-        title: "Volvo: ASIL-D E/E architecture safety analysis — 12-week engagement",
-        content:
-          "Scope: HARA + FSC + TSR for full vehicle E/E architecture. Team: 2 senior safety engineers. Deliverables: HARA report, FSC, TSR document set, DIA with 3 Tier-1s. Key challenges: late requirement changes from powertrain team, conflicting ASIL decomposition between domains. Resolution: weekly alignment calls with system architect, formal change request process with traceability tags.",
-        tags: JSON.stringify(["volvo", "asil-d", "hara", "fsc", "tsr", "case-study"]),
-        source_agent_id: "evidence-auditor",
-      },
-      {
-        collection: "proposals",
-        title: "Standard rate card — Thinking in Code 2026",
-        content:
-          "Senior Safety Engineer (ISO 26262 / ASPICE): \u20AC130-180/h. Safety Architect (ASIL-D, system level): \u20AC160-200/h. Cyber Security Engineer (UN R155, ISO 21434): \u20AC120-160/h. AUTOSAR Architect: \u20AC140-180/h. Project Lead (technical): \u20AC110-140/h. Standard engagement: T&M with 3-month minimum. Fixed-price only for well-scoped work products (e.g., single HARA, single FMEA). Never T&M for safety-critical delivery milestones.",
-        tags: JSON.stringify(["rate-card", "pricing", "engagement-model"]),
-        source_agent_id: "proposal-engine",
-      },
-      {
-        collection: "iso26262",
-        title: "ISO 26262 Part 6 — Required work products by ASIL level",
-        content:
-          "ASIL A/B: Software safety plan (6-5), software design specification (6-8), unit implementation (6-9), unit verification (6-10). ASIL C adds: formal review of unit tests, MC/DC coverage evidence. ASIL D adds: independent review, structural coverage 100% statement + branch + MC/DC, formal inspection records. All ASILs: software requirements spec (6-7), integration test spec+report (6-11), software safety validation report (6-12), configuration management records.",
-        tags: JSON.stringify(["iso26262", "part6", "asil", "work-products", "checklist"]),
-        source_agent_id: "evidence-auditor",
-      },
-      {
-        collection: "contracts",
-        title: "NDA baseline — Thinking in Code preferred terms",
-        content:
-          "Jurisdiction: Romania or EU member state (not US/UK). Confidentiality term: 3 years post-engagement (not indefinite). IP: assign only specific deliverables explicitly listed in SOW, not background IP. Liability cap: total fees paid in preceding 3 months. Indemnity: mutual and symmetric. Non-compete: geographic scope limited to direct competitors, max 12 months. Payment: Net 30 from invoice date. Governing language: English.",
-        tags: JSON.stringify(["nda", "contract", "terms", "ip", "liability", "jurisdiction"]),
-        source_agent_id: "contract-reviewer",
-      },
-      {
-        collection: "playbooks",
-        title: "AUTOSAR migration outreach wedge",
-        content:
-          "Use when target is posting AUTOSAR Classic\u2192Adaptive migration roles. Opening line: 'Saw you\u2019re expanding into Adaptive AUTOSAR \u2014 we\u2019ve led 3 ARA migrations from scratch at Tier-1 level, including timing analysis and service-oriented communication for safety domains. Happy to share what derailed the first two and how we stabilized them.' Follow with 1 specific technical challenge they\u2019ll face. Offer: 30-minute architecture call, no pitch.",
-        tags: JSON.stringify(["outreach", "autosar", "adaptive", "wedge", "bd"]),
-        source_agent_id: "bd-pipeline",
-      },
-      {
-        collection: "garden",
-        title: "Ia\u0219i zone 6b — historical frost dates and growing season",
-        content:
-          "Last spring frost: April 15 (average), safe transplant after April 20. First fall frost: October 15 (average). Growing season: ~178 days. Risk dates: late frost risk until May 1, early frost risk from October 1. Warm season crops (tomatoes, peppers, cucumbers): transplant after May 1 for safety. Cool season crops (lettuce, spinach, kale): direct sow March-April, again August-September.",
-        tags: JSON.stringify(["zone6b", "iasi", "frost", "growing-season", "planting"]),
-        source_agent_id: "garden-calendar",
-      },
-    ];
-
-    const insertDoc = db.prepare(`
-      INSERT INTO documents (doc_id, collection, title, content, tags, source_agent_id, source_run_id, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    for (const d of docs) {
-      insertDoc.run(
-        randomUUID(), d.collection, d.title, d.content, d.tags,
-        d.source_agent_id ?? null, null, ts, ts,
-      );
-    }
-
-    // ── Seed playbooks ──────────────────────────────────────────────────────
-
-    const playbooks = [
-      {
-        title: "ASIL-D senior-only staffing rule",
-        category: "delivery",
-        body: "Never assign engineers with <5 years ISO 26262 experience as primary on ASIL-D work products. ASIL-D gate reviews require independently verifiable records; junior mistakes are expensive to correct and delay client programs.",
-        tags: JSON.stringify(["asil-d", "staffing", "quality"]),
-      },
-      {
-        title: "Fixed-price proposal trigger conditions",
-        category: "proposal",
-        body: "Offer fixed-price only when: (1) scope is a single bounded work product, (2) client provides complete input artifacts upfront, (3) no external dependency blockers exist, (4) 20% buffer built into estimate. Otherwise use T&M with monthly cap.",
-        tags: JSON.stringify(["fixed-price", "proposal", "risk"]),
-      },
-      {
-        title: "Handling 'we have internal safety team' objection",
-        category: "objection",
-        body: "Acknowledge strength of internal team. Pivot to: 'We typically work alongside internal teams \u2014 we bring independence (required by ISO 26262 for ASIL-C/D), plus we\u2019ve done this specific type of analysis across 8 OEM programs so we front-load the learning curve.' Ask: what\u2019s the ASIL level and what\u2019s the gate date?",
-        tags: JSON.stringify(["objection", "internal-team", "independence", "asil"]),
-      },
-      {
-        title: "Delivery gate discipline playbook",
-        category: "delivery",
-        body: "Never slip a gate without a signed change request. Gate slip triggers: (1) notify PM within 24h, (2) root cause in writing, (3) revised plan with buffer analysis, (4) formal re-baseline if >2 weeks. Clients who experience one slipped gate without formal process lose confidence permanently.",
-        tags: JSON.stringify(["gate", "delivery", "change-management", "process"]),
-      },
-      {
-        title: "Proposal cover email template — RFQ response",
-        category: "sales",
-        body: "Subject: [Company] \u00d7 Thinking in Code \u2014 Response to [RFQ Title]\n\nHi [Name],\n\nAttached is our response to your RFQ for [scope area].\n\nThree things worth noting:\n1. [Specific technical differentiator for their context]\n2. We\u2019ve included a phased option so you can validate approach before committing to full scope.\n3. [Specific team member / past project relevance]\n\nHappy to walk through the approach on a call \u2014 what does your schedule look like this week?\n\nDaniel",
-        tags: JSON.stringify(["email", "rfq", "template", "cover-letter"]),
-      },
-    ];
-
-    const insertPlaybook = db.prepare(`
-      INSERT INTO playbooks (playbook_id, title, category, body, tags, use_count, last_used_at, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    for (const p of playbooks) {
-      insertPlaybook.run(
-        randomUUID(), p.title, p.category, p.body, p.tags, 0, null, ts,
-      );
-    }
-
-    console.log(`  [created] Knowledge database: ${KNOWLEDGE_DB_PATH}`);
-    console.log(`            Seeded ${docs.length} documents, ${playbooks.length} playbooks`);
-  } finally {
-    db.close();
+  for (const d of docs) {
+    insertDoc.run(
+      randomUUID(), d.collection, d.title, d.content, d.tags,
+      d.source_agent_id ?? null, null, ts, ts,
+    );
   }
-  return true;
+
+  const playbooks = [
+    {
+      title: "ASIL-D senior-only staffing rule",
+      category: "delivery",
+      body: "Never assign engineers with <5 years ISO 26262 experience as primary on ASIL-D work products. ASIL-D gate reviews require independently verifiable records; junior mistakes are expensive to correct and delay client programs.",
+      tags: JSON.stringify(["asil-d", "staffing", "quality"]),
+    },
+    {
+      title: "Fixed-price proposal trigger conditions",
+      category: "proposal",
+      body: "Offer fixed-price only when: (1) scope is a single bounded work product, (2) client provides complete input artifacts upfront, (3) no external dependency blockers exist, (4) 20% buffer built into estimate. Otherwise use T&M with monthly cap.",
+      tags: JSON.stringify(["fixed-price", "proposal", "risk"]),
+    },
+    {
+      title: "Handling 'we have internal safety team' objection",
+      category: "objection",
+      body: "Acknowledge strength of internal team. Pivot to: 'We typically work alongside internal teams \u2014 we bring independence (required by ISO 26262 for ASIL-C/D), plus we\u2019ve done this specific type of analysis across 8 OEM programs so we front-load the learning curve.' Ask: what\u2019s the ASIL level and what\u2019s the gate date?",
+      tags: JSON.stringify(["objection", "internal-team", "independence", "asil"]),
+    },
+    {
+      title: "Delivery gate discipline playbook",
+      category: "delivery",
+      body: "Never slip a gate without a signed change request. Gate slip triggers: (1) notify PM within 24h, (2) root cause in writing, (3) revised plan with buffer analysis, (4) formal re-baseline if >2 weeks. Clients who experience one slipped gate without formal process lose confidence permanently.",
+      tags: JSON.stringify(["gate", "delivery", "change-management", "process"]),
+    },
+    {
+      title: "Proposal cover email template — RFQ response",
+      category: "sales",
+      body: "Subject: [Company] \u00d7 Thinking in Code \u2014 Response to [RFQ Title]\n\nHi [Name],\n\nAttached is our response to your RFQ for [scope area].\n\nThree things worth noting:\n1. [Specific technical differentiator for their context]\n2. We\u2019ve included a phased option so you can validate approach before committing to full scope.\n3. [Specific team member / past project relevance]\n\nHappy to walk through the approach on a call \u2014 what does your schedule look like this week?\n\nDaniel",
+      tags: JSON.stringify(["email", "rfq", "template", "cover-letter"]),
+    },
+  ];
+
+  const insertPlaybook = db.prepare(`
+    INSERT INTO playbooks (playbook_id, title, category, body, tags, use_count, last_used_at, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  for (const p of playbooks) {
+    insertPlaybook.run(
+      randomUUID(), p.title, p.category, p.body, p.tags, 0, null, ts,
+    );
+  }
+
+  console.log(`            Seeded ${docs.length} documents, ${playbooks.length} playbooks`);
 }
 
-// ─── Runtime Database ──────────────────────────────────────────────────────
+// ─── Database Initialization ────────────────────────────────────────────────
 
-function initRuntimeDatabase(): boolean {
-  const isNew = !existsSync(RUNTIME_DB_PATH);
+function initDatabase(
+  label: string,
+  dbPath: string,
+  migrations: import("../packages/jarvis-runtime/src/migrations/runner.js").Migration[],
+  seedFn?: (db: DatabaseSync) => void,
+): boolean {
+  const isNew = !existsSync(dbPath);
 
-  const db = new DatabaseSync(RUNTIME_DB_PATH);
+  const db = new DatabaseSync(dbPath);
   try {
     db.exec("PRAGMA journal_mode = WAL;");
     db.exec("PRAGMA foreign_keys = ON;");
     db.exec("PRAGMA busy_timeout = 5000;");
 
-    // Run all pending migrations immediately — deterministic bootstrap
-    runMigrations(db);
+    runMigrations(db, migrations);
 
     const applied = db.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number };
-    console.log(`  [${isNew ? "created" : "updated"}] Runtime database: ${RUNTIME_DB_PATH} (${applied.n} migration(s) applied)`);
+
+    if (isNew && seedFn) {
+      seedFn(db);
+    }
+
+    console.log(`  [${isNew ? "created" : "updated"}] ${label} database: ${dbPath} (${applied.n} migration(s))`);
   } finally {
     db.close();
   }
@@ -427,9 +299,9 @@ function main(): void {
     console.log(`  [exists]  ${JARVIS_DIR}\n`);
   }
 
-  const crmCreated = initCrmDatabase();
-  const knowledgeCreated = initKnowledgeDatabase();
-  const runtimeCreated = initRuntimeDatabase();
+  const crmCreated = initDatabase("CRM", CRM_DB_PATH, CRM_MIGRATIONS, seedCrmData);
+  const knowledgeCreated = initDatabase("Knowledge", KNOWLEDGE_DB_PATH, KNOWLEDGE_MIGRATIONS, seedKnowledgeData);
+  const runtimeCreated = initDatabase("Runtime", RUNTIME_DB_PATH, RUNTIME_MIGRATIONS);
 
   console.log("\n── Summary ──────────────────────────────────────────────");
   console.log(`  Directory:    ${JARVIS_DIR}`);


### PR DESCRIPTION
## Summary
- All three databases (CRM, Knowledge, Runtime) now use the migration runner for schema management
- `init-jarvis.ts` delegates to migrations and only handles seed data on first creation
- Created `crm_0001_core` migration covering contacts, notes, stage_history, campaigns, campaign_recipients
- Created `knowledge_0001_core` migration covering documents, playbooks, entities, relations, decisions, entity_provenance, memory, agent_runs, embedding_chunks
- `runMigrations()` now accepts per-database migration lists (defaults to runtime for backward compat)
- Doctor validates migration-managed tables for all three databases

## Test plan
- [x] `npm run check` passes (1044 tests)
- [x] Build succeeds
- [x] All existing `runMigrations(db)` callers unchanged (backward compatible default)


🤖 Generated with [Claude Code](https://claude.com/claude-code)