### PR TITLE
E2E tests for migrations, restart recovery, and readiness observability

### DIFF
--- a/packages/jarvis-runtime/src/health.ts
+++ b/packages/jarvis-runtime/src/health.ts
@@ -33,6 +33,13 @@ export type ReadinessReport = {
     runtime_db: boolean;
     daemon_running: boolean;
   };
+  details: {
+    migrations: { runtime: string | null; crm: string | null; knowledge: string | null };
+    pending_approvals: number;
+    pending_commands: number;
+    stale_claims: number;
+    overdue_schedules: number;
+  };
 };
 
 const startTime = Date.now();
@@ -141,6 +148,22 @@ export function getHealthReport(): HealthReport {
   return report;
 }
 
+function latestMigration(dbPath: string): string | null {
+  if (!fs.existsSync(dbPath)) return null;
+  try {
+    const db = new DatabaseSync(dbPath);
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA busy_timeout = 5000;");
+    const row = db.prepare(
+      "SELECT id FROM schema_migrations ORDER BY id DESC LIMIT 1",
+    ).get() as { id: string } | undefined;
+    db.close();
+    return row?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function getReadinessReport(): ReadinessReport {
   const checks = {
     jarvis_dir: fs.existsSync(JARVIS_DIR),
@@ -150,25 +173,45 @@ export function getReadinessReport(): ReadinessReport {
     daemon_running: false,
   };
 
-  // Check daemon heartbeat
+  const details = {
+    migrations: {
+      runtime: latestMigration(RUNTIME_DB_PATH),
+      crm: latestMigration(CRM_DB_PATH),
+      knowledge: latestMigration(KNOWLEDGE_DB_PATH),
+    },
+    pending_approvals: 0,
+    pending_commands: 0,
+    stale_claims: 0,
+    overdue_schedules: 0,
+  };
+
+  // Check daemon heartbeat + operational metrics
   if (checks.runtime_db) {
     try {
       const rtDb = new DatabaseSync(RUNTIME_DB_PATH);
       rtDb.exec("PRAGMA journal_mode = WAL;");
       rtDb.exec("PRAGMA busy_timeout = 5000;");
+
       const row = rtDb.prepare(
         "SELECT last_seen_at FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1",
       ).get() as { last_seen_at: string } | undefined;
-      rtDb.close();
 
       if (row) {
         checks.daemon_running = Date.now() - new Date(row.last_seen_at).getTime() < 30_000;
       }
+
+      details.pending_approvals = queryCount(rtDb, "SELECT COUNT(*) as n FROM approvals WHERE status = 'pending'");
+      details.pending_commands = queryCount(rtDb, "SELECT COUNT(*) as n FROM agent_commands WHERE status = 'queued'");
+      details.stale_claims = queryCount(rtDb, "SELECT COUNT(*) as n FROM agent_commands WHERE status = 'claimed' AND claimed_at < datetime('now', '-10 minutes')");
+      details.overdue_schedules = queryCount(rtDb, "SELECT COUNT(*) as n FROM schedules WHERE enabled = 1 AND next_fire_at < datetime('now')");
+
+      rtDb.close();
     } catch { /* can't check */ }
   }
 
   return {
     ready: checks.jarvis_dir && checks.crm_db && checks.knowledge_db && checks.runtime_db && checks.daemon_running,
     checks,
+    details,
   };
 }

--- a/tests/runtime-db.test.ts
+++ b/tests/runtime-db.test.ts
@@ -3,7 +3,7 @@ import { DatabaseSync } from "node:sqlite";
 import fs from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { runMigrations } from "@jarvis/runtime";
+import { runMigrations, CRM_MIGRATIONS, KNOWLEDGE_MIGRATIONS } from "@jarvis/runtime";
 
 describe("Runtime DB and Migration Framework", () => {
   let dbPath: string;
@@ -194,6 +194,167 @@ describe("Runtime DB and Migration Framework", () => {
       const row = db.prepare("SELECT * FROM schedules WHERE schedule_id = ?").get("s1") as Record<string, unknown>;
       expect(row.cron_expression).toBe("0 7 * * 1");
       expect(row.enabled).toBe(1);
+    });
+  });
+
+  // ─── CRM Migration Tests ──────────────────────────────────────────────────
+
+  describe("CRM migrations (crm_0001_core)", () => {
+    let crmDb: DatabaseSync;
+    let crmDbPath: string;
+
+    beforeEach(() => {
+      crmDbPath = join(os.tmpdir(), `jarvis-test-crm-${Date.now()}.db`);
+      crmDb = new DatabaseSync(crmDbPath);
+      crmDb.exec("PRAGMA journal_mode = WAL;");
+      crmDb.exec("PRAGMA foreign_keys = ON;");
+      runMigrations(crmDb, CRM_MIGRATIONS);
+    });
+
+    afterEach(() => {
+      try { crmDb.close(); } catch { /* ok */ }
+      try { fs.unlinkSync(crmDbPath); } catch { /* ok */ }
+    });
+
+    it("creates all CRM tables", () => {
+      const tables = crmDb.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name != 'schema_migrations' ORDER BY name",
+      ).all() as Array<{ name: string }>;
+      const names = tables.map(t => t.name);
+      expect(names).toContain("contacts");
+      expect(names).toContain("notes");
+      expect(names).toContain("stage_history");
+      expect(names).toContain("campaigns");
+      expect(names).toContain("campaign_recipients");
+    });
+
+    it("records CRM migration", () => {
+      const rows = crmDb.prepare("SELECT id, name FROM schema_migrations").all() as Array<{ id: string; name: string }>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.id).toBe("0001");
+      expect(rows[0]!.name).toBe("crm_core");
+    });
+
+    it("contacts table accepts and queries rows", () => {
+      crmDb.prepare(`
+        INSERT INTO contacts (id, name, company, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `).run("c1", "Test User", "Test Corp", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z");
+
+      const row = crmDb.prepare("SELECT * FROM contacts WHERE id = ?").get("c1") as Record<string, unknown>;
+      expect(row.stage).toBe("prospect");
+      expect(row.score).toBe(0);
+    });
+
+    it("campaign_recipients has composite primary key", () => {
+      crmDb.prepare(`INSERT INTO campaigns (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`).run("camp1", "Cold", "2026-01-01", "2026-01-01");
+      crmDb.prepare(`INSERT INTO campaign_recipients (campaign_id, contact_id, email, enrolled_at, last_status_at) VALUES (?, ?, ?, ?, ?)`).run("camp1", "c1", "test@test.com", "2026-01-01", "2026-01-01");
+
+      expect(() => {
+        crmDb.prepare(`INSERT INTO campaign_recipients (campaign_id, contact_id, email, enrolled_at, last_status_at) VALUES (?, ?, ?, ?, ?)`).run("camp1", "c1", "test@test.com", "2026-01-01", "2026-01-01");
+      }).toThrow();
+    });
+
+    it("is idempotent", () => {
+      runMigrations(crmDb, CRM_MIGRATIONS);
+      const rows = crmDb.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number };
+      expect(rows.n).toBe(1);
+    });
+  });
+
+  // ─── Knowledge Migration Tests ────────────────────────────────────────────
+
+  describe("Knowledge migrations (knowledge_0001_core)", () => {
+    let kbDb: DatabaseSync;
+    let kbDbPath: string;
+
+    beforeEach(() => {
+      kbDbPath = join(os.tmpdir(), `jarvis-test-kb-${Date.now()}.db`);
+      kbDb = new DatabaseSync(kbDbPath);
+      kbDb.exec("PRAGMA journal_mode = WAL;");
+      kbDb.exec("PRAGMA foreign_keys = ON;");
+      runMigrations(kbDb, KNOWLEDGE_MIGRATIONS);
+    });
+
+    afterEach(() => {
+      try { kbDb.close(); } catch { /* ok */ }
+      try { fs.unlinkSync(kbDbPath); } catch { /* ok */ }
+    });
+
+    const EXPECTED_TABLES = [
+      "documents", "playbooks", "entities", "relations", "decisions",
+      "entity_provenance", "memory", "agent_runs", "embedding_chunks",
+    ];
+
+    it("creates all knowledge tables", () => {
+      const tables = kbDb.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name != 'schema_migrations' ORDER BY name",
+      ).all() as Array<{ name: string }>;
+      const names = tables.map(t => t.name);
+      for (const expected of EXPECTED_TABLES) {
+        expect(names, `Missing table: ${expected}`).toContain(expected);
+      }
+    });
+
+    it("records knowledge migration", () => {
+      const rows = kbDb.prepare("SELECT id, name FROM schema_migrations").all() as Array<{ id: string; name: string }>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.id).toBe("0001");
+      expect(rows[0]!.name).toBe("knowledge_core");
+    });
+
+    it("creates indexes for knowledge tables", () => {
+      const indexes = kbDb.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name",
+      ).all() as Array<{ name: string }>;
+      const indexNames = indexes.map(i => i.name);
+      expect(indexNames).toContain("idx_decisions_agent");
+      expect(indexNames).toContain("idx_decisions_run");
+      expect(indexNames).toContain("idx_prov_entity");
+      expect(indexNames).toContain("idx_prov_agent");
+      expect(indexNames).toContain("idx_memory_agent");
+      expect(indexNames).toContain("idx_runs_agent");
+      expect(indexNames).toContain("idx_chunks_doc");
+    });
+
+    it("entities enforces canonical_key uniqueness", () => {
+      kbDb.prepare(`
+        INSERT INTO entities (entity_id, entity_type, name, canonical_key, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run("e1", "company", "Volvo", "company:volvo", "2026-01-01", "2026-01-01");
+
+      expect(() => {
+        kbDb.prepare(`
+          INSERT INTO entities (entity_id, entity_type, name, canonical_key, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `).run("e2", "company", "Volvo Duplicate", "company:volvo", "2026-01-01", "2026-01-01");
+      }).toThrow();
+    });
+
+    it("memory enforces kind CHECK constraint", () => {
+      expect(() => {
+        kbDb.prepare(`
+          INSERT INTO memory (entry_id, agent_id, run_id, kind, content, created_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+        `).run("m1", "bd-pipeline", "r1", "invalid_kind", "test", "2026-01-01");
+      }).toThrow();
+    });
+
+    it("documents table stores and retrieves knowledge base entries", () => {
+      kbDb.prepare(`
+        INSERT INTO documents (doc_id, collection, title, content, tags, source_agent_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run("d1", "lessons", "Test lesson", "Content here", '["test"]', "bd-pipeline", "2026-01-01", "2026-01-01");
+
+      const row = kbDb.prepare("SELECT * FROM documents WHERE doc_id = ?").get("d1") as Record<string, unknown>;
+      expect(row.collection).toBe("lessons");
+      expect(row.source_agent_id).toBe("bd-pipeline");
+    });
+
+    it("is idempotent", () => {
+      runMigrations(kbDb, KNOWLEDGE_MIGRATIONS);
+      const rows = kbDb.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number };
+      expect(rows.n).toBe(1);
     });
   });
 });

--- a/tests/smoke/e2e-lifecycle.test.ts
+++ b/tests/smoke/e2e-lifecycle.test.ts
@@ -695,3 +695,111 @@ describe("E2E: Multi-Run Concurrency", () => {
     expect(recent[2].run_id).toBe(r1);
   });
 });
+
+// ── Daemon Restart: Stale Claim Recovery ─────────────────────────────────────
+
+describe("E2E: Daemon Restart — Stale Claim Recovery", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createTestDb());
+  });
+
+  afterEach(() => cleanup(db, dbPath));
+
+  it("recovers stale claims older than threshold", () => {
+    // Simulate daemon A claiming commands, then crashing
+    const staleTime = new Date(Date.now() - 15 * 60 * 1000).toISOString(); // 15 min ago
+    const recentTime = new Date(Date.now() - 2 * 60 * 1000).toISOString(); // 2 min ago (not stale)
+
+    db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, created_at, claimed_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+      "cmd-stale-1", "run_agent", "garden-calendar", "claimed", staleTime, staleTime,
+    );
+    db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, created_at, claimed_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+      "cmd-stale-2", "run_agent", "bd-pipeline", "claimed", staleTime, staleTime,
+    );
+    db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, created_at, claimed_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+      "cmd-recent", "run_agent", "evidence-auditor", "claimed", recentTime, recentTime,
+    );
+
+    // Daemon B restarts — recover stale claims (same logic as daemon.ts startup)
+    const staleThreshold = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 min threshold
+    const result = db.prepare(
+      "UPDATE agent_commands SET status = 'queued', claimed_at = NULL WHERE status = 'claimed' AND claimed_at < ?",
+    ).run(staleThreshold);
+    const changes = (result as { changes: number }).changes;
+
+    expect(changes).toBe(2); // Only the two stale ones
+
+    // Verify state
+    const stale1 = db.prepare("SELECT status, claimed_at FROM agent_commands WHERE command_id = ?").get("cmd-stale-1") as Record<string, unknown>;
+    expect(stale1.status).toBe("queued");
+    expect(stale1.claimed_at).toBeNull();
+
+    const stale2 = db.prepare("SELECT status FROM agent_commands WHERE command_id = ?").get("cmd-stale-2") as Record<string, unknown>;
+    expect(stale2.status).toBe("queued");
+
+    const recent = db.prepare("SELECT status FROM agent_commands WHERE command_id = ?").get("cmd-recent") as Record<string, unknown>;
+    expect(recent.status).toBe("claimed"); // Not recovered — still active
+  });
+
+  it("recovered commands can be re-claimed without duplicates", () => {
+    const staleTime = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+
+    db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, created_at, claimed_at, idempotency_key) VALUES (?, ?, ?, ?, ?, ?, ?)`).run(
+      "cmd-recover", "run_agent", "garden-calendar", "claimed", staleTime, staleTime, "idem-garden-1",
+    );
+
+    // Recover
+    db.prepare("UPDATE agent_commands SET status = 'queued', claimed_at = NULL WHERE status = 'claimed' AND claimed_at < ?").run(
+      new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    );
+
+    // Re-claim
+    const claimResult = db.prepare(
+      "UPDATE agent_commands SET status = 'claimed', claimed_at = ? WHERE command_id = ? AND status = 'queued'",
+    ).run(new Date().toISOString(), "cmd-recover");
+    expect((claimResult as { changes: number }).changes).toBe(1);
+
+    // Idempotency key prevents second insert of same command
+    expect(() => {
+      db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, created_at, idempotency_key) VALUES (?, ?, ?, ?, ?, ?)`).run(
+        "cmd-recover-2", "run_agent", "garden-calendar", "queued", new Date().toISOString(), "idem-garden-1",
+      );
+    }).toThrow();
+  });
+
+  it("shutdown marks in-flight runs as failed and releases claims", () => {
+    const store = new RunStore(db);
+    const r1 = store.startRun("agent-a", "schedule");
+    store.transition(r1, "agent-a", "executing", "step_started");
+    const r2 = store.startRun("agent-b", "manual");
+    // r2 stays in planning
+    const r3 = store.startRun("agent-c", "schedule");
+    store.transition(r3, "agent-c", "executing", "step_started");
+    store.transition(r3, "agent-c", "completed", "run_completed");
+
+    // Simulate claimed commands
+    db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, created_at, claimed_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+      "cmd-shutdown", "run_agent", "agent-a", "claimed", new Date().toISOString(), new Date().toISOString(),
+    );
+
+    // Shutdown sequence (same as daemon.ts shutdown)
+    const runResult = db.prepare(
+      "UPDATE runs SET status = 'failed', completed_at = ?, error = 'daemon_shutdown' WHERE status IN ('queued','planning','executing','awaiting_approval')",
+    ).run(new Date().toISOString());
+    const runChanges = (runResult as { changes: number }).changes;
+    expect(runChanges).toBe(2); // r1 (executing) and r2 (planning) — r3 already completed
+
+    const cmdResult = db.prepare(
+      "UPDATE agent_commands SET status = 'queued', claimed_at = NULL WHERE status = 'claimed'",
+    ).run();
+    expect((cmdResult as { changes: number }).changes).toBe(1);
+
+    // Verify
+    expect(store.getStatus(r1)).toBe("failed");
+    expect(store.getStatus(r2)).toBe("failed");
+    expect(store.getStatus(r3)).toBe("completed"); // Untouched
+  });
+});


### PR DESCRIPTION
## Summary
- Added CRM migration tests: table creation, composite PK enforcement, idempotency
- Added Knowledge migration tests: table creation, indexes, constraints (canonical_key uniqueness, memory kind CHECK), idempotency
- Added daemon restart recovery tests: stale claim recovery (>10 min threshold), re-claim without duplicates via idempotency key, shutdown marks in-flight runs as failed and releases claims
- Enriched `/api/ready` with operational details: migration versions per DB, pending approvals, pending commands, stale claims, overdue schedules

## Test plan
- [x] `npm run check` passes (1059 tests, up from 1044)
- [x] Build succeeds
- [x] 15 new tests covering migration schema, restart recovery, and shutdown cleanup


🤖 Generated with [Claude Code](https://claude.com/claude-code)