### PR TITLE
Sprints 2-6: Operator console, workflows, setup, models, starter packs

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"62d243d1-096e-4c6e-bfc9-f5928f2e314f","pid":31468,"acquiredAt":1775498270693}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages/*/*.tsbuildinfo
 .artifacts/runtime-smoke/
 .claude/plans/
 ~/
+.claude/scheduled_tasks.lock

--- a/packages/jarvis-dashboard/src/api/approvals.ts
+++ b/packages/jarvis-dashboard/src/api/approvals.ts
@@ -3,6 +3,7 @@ import { DatabaseSync } from 'node:sqlite'
 import os from 'os'
 import { join } from 'path'
 import { listApprovals, resolveApproval } from '@jarvis/runtime'
+import type { ApprovalEntry } from '@jarvis/runtime'
 import { writeAuditLog, getActor } from './middleware/audit.js'
 import type { AuthenticatedRequest } from './middleware/auth.js'
 
@@ -11,6 +12,56 @@ function getDb(): DatabaseSync {
   db.exec("PRAGMA journal_mode = WAL;")
   db.exec("PRAGMA busy_timeout = 5000;")
   return db
+}
+
+const APPROVAL_TIMEOUT_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const riskMap: Record<string, { level: string; label: string; reversible: boolean }> = {
+  info: { level: 'low', label: 'Low risk — informational', reversible: true },
+  warning: { level: 'medium', label: 'Review recommended', reversible: true },
+  critical: { level: 'high', label: 'Irreversible action', reversible: false },
+};
+
+type LinkedRun = {
+  run_id: string;
+  agent_id: string;
+  status: string;
+  goal: string;
+  current_step: number | null;
+  total_steps: number | null;
+};
+
+function enrichApprovals(db: DatabaseSync, approvals: ApprovalEntry[]) {
+  const runStmt = db.prepare(
+    'SELECT run_id, agent_id, status, goal, current_step, total_steps FROM runs WHERE run_id = ?'
+  );
+
+  return approvals.map(approval => {
+    // a) Risk assessment from severity
+    const risk = riskMap[approval.severity] ?? riskMap['info'];
+
+    // b) Linked run info
+    let linked_run: LinkedRun | null = null;
+    if (approval.run_id) {
+      try {
+        linked_run = (runStmt.get(approval.run_id) as LinkedRun | undefined) ?? null;
+      } catch { /* best-effort */ }
+    }
+
+    // c) Timeout info
+    const createdAt = new Date(approval.created_at);
+    const timeoutAt = new Date(createdAt.getTime() + APPROVAL_TIMEOUT_MS);
+    const timeRemaining = Math.max(0, timeoutAt.getTime() - Date.now());
+
+    return {
+      ...approval,
+      risk,
+      linked_run,
+      timeout_at: timeoutAt.toISOString(),
+      time_remaining_ms: timeRemaining,
+      what_happens_if_nothing: 'Will expire after 4 hours. The step will be skipped and the run will fail.',
+    };
+  });
 }
 
 export const approvalsRouter = Router()
@@ -24,7 +75,8 @@ approvalsRouter.get('/', (req, res) => {
     const filter = validStatuses.includes(status as typeof validStatuses[number])
       ? (status as 'pending' | 'approved' | 'rejected')
       : undefined
-    res.json(listApprovals(db, filter))
+    const approvals = listApprovals(db, filter)
+    res.json(enrichApprovals(db, approvals))
   } finally {
     try { db.close() } catch { /* best-effort */ }
   }

--- a/packages/jarvis-dashboard/src/api/approvals.ts
+++ b/packages/jarvis-dashboard/src/api/approvals.ts
@@ -91,8 +91,7 @@ approvalsRouter.post('/:id/approve', (req, res) => {
       res.status(404).json({ error: 'Approval not found or already resolved' })
       return
     }
-    const actor = getActor(req as AuthenticatedRequest)
-    writeAuditLog(actor.type, actor.id, 'approval.approved', 'approval', req.params.id!, {})
+    // Note: resolveApproval() already writes an audit_log entry atomically — no duplicate here
     const approvals = listApprovals(db)
     const entry = approvals.find(a => a.id === req.params.id)
     res.json(entry)
@@ -110,8 +109,7 @@ approvalsRouter.post('/:id/reject', (req, res) => {
       res.status(404).json({ error: 'Approval not found or already resolved' })
       return
     }
-    const actor = getActor(req as AuthenticatedRequest)
-    writeAuditLog(actor.type, actor.id, 'approval.rejected', 'approval', req.params.id!, {})
+    // Note: resolveApproval() already writes an audit_log entry atomically — no duplicate here
     const approvals = listApprovals(db)
     const entry = approvals.find(a => a.id === req.params.id)
     res.json(entry)

--- a/packages/jarvis-dashboard/src/api/approvals.ts
+++ b/packages/jarvis-dashboard/src/api/approvals.ts
@@ -59,7 +59,7 @@ function enrichApprovals(db: DatabaseSync, approvals: ApprovalEntry[]) {
       linked_run,
       timeout_at: timeoutAt.toISOString(),
       time_remaining_ms: timeRemaining,
-      what_happens_if_nothing: 'Will expire after 4 hours. The step will be skipped and the run will fail.',
+      what_happens_if_nothing: 'Will expire after 4 hours. The run will fail immediately.',
     };
   });
 }

--- a/packages/jarvis-dashboard/src/api/attention.ts
+++ b/packages/jarvis-dashboard/src/api/attention.ts
@@ -1,0 +1,94 @@
+import { Router } from 'express'
+import { DatabaseSync } from 'node:sqlite'
+import os from 'os'
+import { join } from 'path'
+
+function getRuntimeDb() {
+  const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}
+
+export const attentionRouter = Router()
+
+// GET / — needs-attention summary for the operator dashboard
+attentionRouter.get('/', (_req, res) => {
+  let db: DatabaseSync | undefined
+  try {
+    db = getRuntimeDb()
+
+    // Counts
+    const pendingApprovals = (db.prepare(
+      "SELECT COUNT(*) as cnt FROM approvals WHERE status = 'pending'"
+    ).get() as { cnt: number }).cnt
+
+    const failedRuns = (db.prepare(
+      "SELECT COUNT(*) as cnt FROM runs WHERE status = 'failed' AND completed_at > datetime('now', '-24 hours')"
+    ).get() as { cnt: number }).cnt
+
+    const overdueSchedules = (db.prepare(
+      "SELECT COUNT(*) as cnt FROM schedules WHERE enabled = 1 AND next_fire_at < datetime('now')"
+    ).get() as { cnt: number }).cnt
+
+    // Active work
+    const activeWork = db.prepare(
+      "SELECT run_id, agent_id, status, current_step, total_steps, started_at FROM runs WHERE status IN ('planning','executing','awaiting_approval') ORDER BY started_at DESC"
+    ).all() as Record<string, unknown>[]
+
+    // Recent completions
+    const recentCompletions = db.prepare(
+      "SELECT run_id, agent_id, status, completed_at, current_step FROM runs WHERE status = 'completed' ORDER BY completed_at DESC LIMIT 5"
+    ).all() as Record<string, unknown>[]
+
+    // Recommended actions
+    const recommendedActions: string[] = []
+    if (pendingApprovals > 0) {
+      recommendedActions.push(`Review ${pendingApprovals} pending approval${pendingApprovals > 1 ? 's' : ''}`)
+    }
+    if (failedRuns > 0) {
+      recommendedActions.push(`${failedRuns} failed run${failedRuns > 1 ? 's' : ''} need${failedRuns === 1 ? 's' : ''} retry`)
+    }
+    if (overdueSchedules > 0) {
+      recommendedActions.push(`${overdueSchedules} overdue schedule${overdueSchedules > 1 ? 's' : ''}`)
+    }
+
+    // System status
+    const systemStatus = (pendingApprovals > 0 || failedRuns > 0) ? 'needs_attention' : 'healthy'
+
+    res.json({
+      needs_attention: {
+        pending_approvals: pendingApprovals,
+        failed_runs: failedRuns,
+        overdue_schedules: overdueSchedules,
+      },
+      active_work: activeWork,
+      recent_completions: recentCompletions,
+      recommended_actions: recommendedActions,
+      system_status: systemStatus,
+    })
+  } catch {
+    res.json({
+      needs_attention: { pending_approvals: 0, failed_runs: 0, overdue_schedules: 0 },
+      active_work: [],
+      recent_completions: [],
+      recommended_actions: [],
+      system_status: 'unknown',
+    })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+})
+
+// GET /statuses — plain-English status descriptions
+attentionRouter.get('/statuses', (_req, res) => {
+  res.json({
+    queued: { label: 'Waiting to start', action: 'Will begin when a slot is available' },
+    planning: { label: 'Figuring out what to do', action: 'Building a plan of action' },
+    executing: { label: 'Working on it', action: 'Running through planned steps' },
+    awaiting_approval: { label: 'Needs your approval', action: 'Check the approval inbox' },
+    completed: { label: 'Done', action: 'Review the results' },
+    failed: { label: 'Something went wrong', action: 'Review the error and retry if needed' },
+    cancelled: { label: 'Stopped', action: 'Was cancelled by you or the system' },
+  })
+})

--- a/packages/jarvis-dashboard/src/api/attention.ts
+++ b/packages/jarvis-dashboard/src/api/attention.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express'
 import { DatabaseSync } from 'node:sqlite'
+import { existsSync } from 'node:fs'
 import os from 'os'
 import { join } from 'path'
 
-function getRuntimeDb() {
-  const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
+function getRuntimeDb(): DatabaseSync {
+  const dbPath = join(os.homedir(), '.jarvis', 'runtime.db')
+  if (!existsSync(dbPath)) throw new Error('runtime.db not found')
+  const db = new DatabaseSync(dbPath)
   db.exec("PRAGMA journal_mode = WAL;")
   db.exec("PRAGMA busy_timeout = 5000;")
   return db

--- a/packages/jarvis-dashboard/src/api/attention.ts
+++ b/packages/jarvis-dashboard/src/api/attention.ts
@@ -23,13 +23,17 @@ attentionRouter.get('/', (_req, res) => {
       "SELECT COUNT(*) as cnt FROM approvals WHERE status = 'pending'"
     ).get() as { cnt: number }).cnt
 
+    // Use ISO timestamps for comparison (completed_at and next_fire_at are stored as ISO strings)
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    const nowIso = new Date().toISOString()
+
     const failedRuns = (db.prepare(
-      "SELECT COUNT(*) as cnt FROM runs WHERE status = 'failed' AND completed_at > datetime('now', '-24 hours')"
-    ).get() as { cnt: number }).cnt
+      "SELECT COUNT(*) as cnt FROM runs WHERE status = 'failed' AND completed_at > ?"
+    ).get(twentyFourHoursAgo) as { cnt: number }).cnt
 
     const overdueSchedules = (db.prepare(
-      "SELECT COUNT(*) as cnt FROM schedules WHERE enabled = 1 AND next_fire_at < datetime('now')"
-    ).get() as { cnt: number }).cnt
+      "SELECT COUNT(*) as cnt FROM schedules WHERE enabled = 1 AND next_fire_at < ?"
+    ).get(nowIso) as { cnt: number }).cnt
 
     // Active work
     const activeWork = db.prepare(

--- a/packages/jarvis-dashboard/src/api/backup.ts
+++ b/packages/jarvis-dashboard/src/api/backup.ts
@@ -9,8 +9,9 @@ const JARVIS_DIR = join(os.homedir(), '.jarvis')
 const BACKUPS_DIR = join(JARVIS_DIR, 'backups')
 const CONFIG_PATH = join(JARVIS_DIR, 'config.json')
 
-// Files to include in backup
+// Files to include in backup. Include WAL/SHM sidecars for SQLite consistency.
 const BACKUP_FILES = ['config.json', 'crm.db', 'knowledge.db', 'runtime.db']
+const WAL_SIDECARS = ['runtime.db-wal', 'runtime.db-shm', 'crm.db-wal', 'crm.db-shm', 'knowledge.db-wal', 'knowledge.db-shm']
 
 export const backupRouter = Router()
 
@@ -27,13 +28,20 @@ backupRouter.post('/', (req, res) => {
     fs.mkdirSync(backupDir, { recursive: true })
 
     const files: Array<{ name: string; size: number }> = []
+    // Copy main files
     for (const name of BACKUP_FILES) {
       const src = join(JARVIS_DIR, name)
       if (fs.existsSync(src)) {
-        const dest = join(backupDir, name)
-        fs.copyFileSync(src, dest)
-        const stat = fs.statSync(dest)
-        files.push({ name, size: stat.size })
+        fs.copyFileSync(src, join(backupDir, name))
+        files.push({ name, size: fs.statSync(join(backupDir, name)).size })
+      }
+    }
+    // Copy WAL/SHM sidecars (optional — only exist when DB is in WAL mode)
+    for (const name of WAL_SIDECARS) {
+      const src = join(JARVIS_DIR, name)
+      if (fs.existsSync(src)) {
+        fs.copyFileSync(src, join(backupDir, name))
+        files.push({ name, size: fs.statSync(join(backupDir, name)).size })
       }
     }
 
@@ -136,9 +144,18 @@ backupRouter.post('/restore', (req, res) => {
       files: Array<{ name: string; size: number }>
     }
 
-    // Validate all files exist in the backup before restoring
+    // Allowlist of files that can be restored (prevents path traversal)
+    const ALLOWED_RESTORE = new Set([...BACKUP_FILES, ...WAL_SIDECARS])
+
+    // Validate: only restore allowed filenames (no path separators, no ..)
+    const safeFiles = manifest.files.filter(f => {
+      const name = f.name
+      return ALLOWED_RESTORE.has(name) && !name.includes('/') && !name.includes('\\') && !name.includes('..')
+    })
+
+    // Validate all safe files exist in the backup
     const missing: string[] = []
-    for (const file of manifest.files) {
+    for (const file of safeFiles) {
       if (!fs.existsSync(join(resolvedPath, file.name))) {
         missing.push(file.name)
       }
@@ -152,9 +169,9 @@ backupRouter.post('/restore', (req, res) => {
       return
     }
 
-    // Copy each file back to ~/.jarvis/
+    // Copy each safe file back to ~/.jarvis/
     const restored: string[] = []
-    for (const file of manifest.files) {
+    for (const file of safeFiles) {
       const src = join(resolvedPath, file.name)
       const dest = join(JARVIS_DIR, file.name)
       fs.copyFileSync(src, dest)

--- a/packages/jarvis-dashboard/src/api/backup.ts
+++ b/packages/jarvis-dashboard/src/api/backup.ts
@@ -1,0 +1,174 @@
+import { Router } from 'express'
+import os from 'os'
+import { join } from 'path'
+import fs from 'fs'
+import { writeAuditLog, getActor } from './middleware/audit.js'
+import type { AuthenticatedRequest } from './middleware/auth.js'
+
+const JARVIS_DIR = join(os.homedir(), '.jarvis')
+const BACKUPS_DIR = join(JARVIS_DIR, 'backups')
+const CONFIG_PATH = join(JARVIS_DIR, 'config.json')
+
+// Files to include in backup
+const BACKUP_FILES = ['config.json', 'crm.db', 'knowledge.db', 'runtime.db']
+
+export const backupRouter = Router()
+
+// POST / — trigger a new backup
+backupRouter.post('/', (req, res) => {
+  try {
+    const now = new Date()
+    const ts = now.toISOString()
+      .replace(/[T]/g, '-')
+      .replace(/[:]/g, '')
+      .replace(/\.\d+Z$/, '')
+    const backupDir = join(BACKUPS_DIR, `backup-${ts}`)
+
+    fs.mkdirSync(backupDir, { recursive: true })
+
+    const files: Array<{ name: string; size: number }> = []
+    for (const name of BACKUP_FILES) {
+      const src = join(JARVIS_DIR, name)
+      if (fs.existsSync(src)) {
+        const dest = join(backupDir, name)
+        fs.copyFileSync(src, dest)
+        const stat = fs.statSync(dest)
+        files.push({ name, size: stat.size })
+      }
+    }
+
+    if (files.length === 0) {
+      res.status(400).json({ ok: false, error: 'No files found to back up' })
+      return
+    }
+
+    const totalSize = files.reduce((sum, f) => sum + f.size, 0)
+    const manifest = {
+      timestamp: now.toISOString(),
+      files,
+      total_size: totalSize
+    }
+
+    fs.writeFileSync(join(backupDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
+
+    const actor = getActor(req as AuthenticatedRequest)
+    writeAuditLog(actor.type, actor.id, 'backup.created', 'backup', backupDir, {
+      files: files.map(f => f.name),
+      total_size: totalSize
+    })
+
+    res.json({
+      ok: true,
+      path: backupDir,
+      files,
+      total_size: totalSize
+    })
+  } catch (err) {
+    res.status(500).json({
+      ok: false,
+      error: `Backup failed: ${err instanceof Error ? err.message : String(err)}`
+    })
+  }
+})
+
+// GET /status — return last backup info
+backupRouter.get('/status', (_req, res) => {
+  try {
+    if (!fs.existsSync(BACKUPS_DIR)) {
+      res.json({ last_backup: null })
+      return
+    }
+
+    const entries = fs.readdirSync(BACKUPS_DIR)
+      .filter(e => e.startsWith('backup-'))
+      .sort()
+
+    if (entries.length === 0) {
+      res.json({ last_backup: null })
+      return
+    }
+
+    const latest = entries[entries.length - 1]
+    const manifestPath = join(BACKUPS_DIR, latest, 'manifest.json')
+
+    if (!fs.existsSync(manifestPath)) {
+      res.json({ last_backup: latest, files: [], size: 0 })
+      return
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      timestamp: string
+      files: Array<{ name: string; size: number }>
+      total_size: number
+    }
+
+    res.json({
+      last_backup: manifest.timestamp,
+      path: join(BACKUPS_DIR, latest),
+      files: manifest.files,
+      size: manifest.total_size
+    })
+  } catch {
+    res.json({ last_backup: null })
+  }
+})
+
+// POST /restore — restore from a backup
+backupRouter.post('/restore', (req, res) => {
+  const { backup_path } = req.body as { backup_path?: string }
+
+  if (!backup_path) {
+    res.status(400).json({ ok: false, error: 'backup_path is required' })
+    return
+  }
+
+  // Normalize the path: replace ~ with homedir
+  const resolvedPath = backup_path.replace(/^~/, os.homedir())
+
+  try {
+    const manifestPath = join(resolvedPath, 'manifest.json')
+    if (!fs.existsSync(manifestPath)) {
+      res.status(404).json({ ok: false, error: 'manifest.json not found in backup path' })
+      return
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      files: Array<{ name: string; size: number }>
+    }
+
+    // Validate all files exist in the backup before restoring
+    const missing: string[] = []
+    for (const file of manifest.files) {
+      if (!fs.existsSync(join(resolvedPath, file.name))) {
+        missing.push(file.name)
+      }
+    }
+
+    if (missing.length > 0) {
+      res.status(400).json({
+        ok: false,
+        error: `Missing files in backup: ${missing.join(', ')}`
+      })
+      return
+    }
+
+    // Copy each file back to ~/.jarvis/
+    const restored: string[] = []
+    for (const file of manifest.files) {
+      const src = join(resolvedPath, file.name)
+      const dest = join(JARVIS_DIR, file.name)
+      fs.copyFileSync(src, dest)
+      restored.push(file.name)
+    }
+
+    const actor = getActor(req as AuthenticatedRequest)
+    writeAuditLog(actor.type, actor.id, 'backup.restored', 'backup', resolvedPath, { restored })
+
+    res.json({ ok: true, restored })
+  } catch (err) {
+    res.status(500).json({
+      ok: false,
+      error: `Restore failed: ${err instanceof Error ? err.message : String(err)}`
+    })
+  }
+})

--- a/packages/jarvis-dashboard/src/api/models.ts
+++ b/packages/jarvis-dashboard/src/api/models.ts
@@ -267,27 +267,34 @@ modelsRouter.get("/:runtime/:modelId/benchmarks", (req, res) => {
   }
 });
 
-// POST /:runtime/:modelId/benchmark — trigger an on-demand benchmark
+// POST /:runtime/:modelId/benchmark — record a benchmark result directly
+// Note: actual inference benchmarking requires the daemon. This endpoint records
+// a latency measurement submitted by the client or a scheduled benchmark task.
 modelsRouter.post("/:runtime/:modelId/benchmark", (req, res) => {
   const { runtime, modelId } = req.params;
+  const { benchmark_type = "latency", latency_ms, tokens_per_sec, json_success, tool_call_success, notes } = req.body as {
+    benchmark_type?: string; latency_ms?: number; tokens_per_sec?: number;
+    json_success?: boolean; tool_call_success?: boolean; notes?: string;
+  };
+
   const db = getDb();
   try {
-    const commandId = randomUUID();
+    const benchmarkId = randomUUID();
     const now = new Date().toISOString();
     db.prepare(`
-      INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
-      VALUES (?, 'benchmark_model', 'system', ?, 'queued', 0, ?, 'dashboard', ?)
-    `).run(
-      commandId,
-      JSON.stringify({ runtime, model_id: modelId }),
-      now,
-      `benchmark-${runtime}-${modelId}-${Date.now()}`
-    );
+      INSERT INTO model_benchmarks (benchmark_id, runtime, model_id, benchmark_type, latency_ms, tokens_per_sec, json_success, tool_call_success, notes, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(benchmarkId, runtime, modelId, benchmark_type, latency_ms ?? null, tokens_per_sec ?? null,
+      json_success != null ? (json_success ? 1 : 0) : null,
+      tool_call_success != null ? (tool_call_success ? 1 : 0) : null,
+      notes ?? null, now);
 
     const actor = getActor(req as AuthenticatedRequest);
-    writeAuditLog(actor.type, actor.id, "model.benchmark_requested", "model", modelId!, { runtime });
+    writeAuditLog(actor.type, actor.id, "model.benchmark_recorded", "model", modelId!, { runtime, benchmark_type });
 
-    res.json({ ok: true, command_id: commandId, runtime, model_id: modelId });
+    res.json({ ok: true, benchmark_id: benchmarkId, runtime, model_id: modelId });
+  } catch (e) {
+    res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
   } finally {
     try { db.close(); } catch { /* best-effort */ }
   }

--- a/packages/jarvis-dashboard/src/api/models.ts
+++ b/packages/jarvis-dashboard/src/api/models.ts
@@ -29,14 +29,15 @@ const RUNTIME_ENDPOINTS: Array<{ name: string; url: string; probe: string }> = [
 
 /** Check if a runtime endpoint is reachable (3s timeout). */
 async function probeRuntime(probeUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
     const resp = await fetch(probeUrl, { signal: controller.signal });
-    clearTimeout(timer);
     return resp.ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -47,6 +48,7 @@ async function probeRuntime(probeUrl: string): Promise<boolean> {
  *   - "plan" with accuracy preference or complex multi-step → opus
  *   - "plan" standard → sonnet
  */
+// Only V1 workflows — aligned with V1_WORKFLOWS from @jarvis/runtime
 const WORKFLOW_MAPPING: Array<{
   workflow_id: string;
   agent_id: string;
@@ -54,18 +56,12 @@ const WORKFLOW_MAPPING: Array<{
 }> = [
   { workflow_id: "contract-review", agent_id: "contract-reviewer", inference_tier: "opus" },
   { workflow_id: "rfq-analysis", agent_id: "evidence-auditor", inference_tier: "sonnet" },
+  { workflow_id: "rfq-analysis", agent_id: "proposal-engine", inference_tier: "opus" },
   { workflow_id: "bd-pipeline", agent_id: "bd-pipeline", inference_tier: "sonnet" },
   { workflow_id: "staffing-check", agent_id: "staffing-monitor", inference_tier: "sonnet" },
-  { workflow_id: "proposal-generation", agent_id: "proposal-engine", inference_tier: "opus" },
-  { workflow_id: "content-creation", agent_id: "content-engine", inference_tier: "sonnet" },
-  { workflow_id: "portfolio-check", agent_id: "portfolio-monitor", inference_tier: "haiku" },
-  { workflow_id: "garden-brief", agent_id: "garden-calendar", inference_tier: "haiku" },
-  { workflow_id: "social-engagement", agent_id: "social-engagement", inference_tier: "sonnet" },
-  { workflow_id: "security-scan", agent_id: "security-monitor", inference_tier: "sonnet" },
-  { workflow_id: "invoice-generation", agent_id: "invoice-generator", inference_tier: "sonnet" },
-  { workflow_id: "email-campaign", agent_id: "email-campaign", inference_tier: "sonnet" },
-  { workflow_id: "meeting-transcription", agent_id: "meeting-transcriber", inference_tier: "sonnet" },
-  { workflow_id: "drive-watch", agent_id: "drive-watcher", inference_tier: "haiku" },
+  { workflow_id: "weekly-report", agent_id: "evidence-auditor", inference_tier: "sonnet" },
+  { workflow_id: "weekly-report", agent_id: "staffing-monitor", inference_tier: "sonnet" },
+  { workflow_id: "weekly-report", agent_id: "bd-pipeline", inference_tier: "sonnet" },
 ];
 
 /** Seven-day staleness threshold in milliseconds. */
@@ -86,16 +82,15 @@ modelsRouter.get("/health", async (_req, res) => {
       }))
     );
 
-    // Query all models from registry
+    // Query all models with tags in one query (avoids N+1)
     const models = db.prepare(`
-      SELECT model_id, runtime, enabled, last_seen_at
+      SELECT model_id, runtime, enabled, last_seen_at, tags_json
       FROM model_registry
       ORDER BY enabled DESC, last_seen_at DESC
     `).all() as Array<{
-      model_id: string; runtime: string; enabled: number; last_seen_at: string;
+      model_id: string; runtime: string; enabled: number; last_seen_at: string; tags_json: string | null;
     }>;
 
-    // Find the latest discovery timestamp
     const latestDiscovery = db.prepare(
       "SELECT MAX(discovered_at) as latest FROM model_registry"
     ).get() as { latest: string | null } | undefined;
@@ -103,16 +98,11 @@ modelsRouter.get("/health", async (_req, res) => {
     const enabledCount = models.filter(m => m.enabled === 1).length;
     const degraded = enabledCount === 0;
 
-    // Map to a model tier based on tags or a simple heuristic
     const modelSummaries = models.map(m => {
-      // Try to read tags to infer tier; fall back to "sonnet" default
       let tier = "sonnet";
       try {
-        const full = db.prepare(
-          "SELECT tags_json FROM model_registry WHERE model_id = ? AND runtime = ?"
-        ).get(m.model_id, m.runtime) as { tags_json: string } | undefined;
-        if (full?.tags_json) {
-          const tags = JSON.parse(full.tags_json) as string[];
+        if (m.tags_json) {
+          const tags = JSON.parse(m.tags_json) as string[];
           if (tags.includes("opus")) tier = "opus";
           else if (tags.includes("haiku")) tier = "haiku";
         }

--- a/packages/jarvis-dashboard/src/api/models.ts
+++ b/packages/jarvis-dashboard/src/api/models.ts
@@ -1,12 +1,14 @@
 /**
  * Model registry and benchmark API endpoints.
  *
- * Exposes model discovery results, benchmark summaries, and
- * per-model enable/disable controls.
+ * Exposes model discovery results, benchmark summaries,
+ * per-model enable/disable controls, health checks,
+ * workflow-mapping, and on-demand benchmark triggers.
  */
 
 import { Router } from "express";
 import { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import { join } from "node:path";
 import { writeAuditLog, getActor } from "./middleware/audit.js";
@@ -19,7 +21,127 @@ function getDb(): DatabaseSync {
   return db;
 }
 
+/** Runtime endpoints to probe for connectivity. */
+const RUNTIME_ENDPOINTS: Array<{ name: string; url: string; probe: string }> = [
+  { name: "lmstudio", url: "http://localhost:1234", probe: "http://localhost:1234/v1/models" },
+  { name: "ollama", url: "http://localhost:11434", probe: "http://localhost:11434/api/tags" },
+];
+
+/** Check if a runtime endpoint is reachable (3s timeout). */
+async function probeRuntime(probeUrl: string): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    const resp = await fetch(probeUrl, { signal: controller.signal });
+    clearTimeout(timer);
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Static workflow-to-tier mapping for V1 agents.
+ * Since @jarvis/agents is not a dependency of the dashboard, this is hardcoded.
+ * The inference tier is derived from each agent's task_profile.objective:
+ *   - "plan" with accuracy preference or complex multi-step → opus
+ *   - "plan" standard → sonnet
+ */
+const WORKFLOW_MAPPING: Array<{
+  workflow_id: string;
+  agent_id: string;
+  inference_tier: string;
+}> = [
+  { workflow_id: "contract-review", agent_id: "contract-reviewer", inference_tier: "opus" },
+  { workflow_id: "rfq-analysis", agent_id: "evidence-auditor", inference_tier: "sonnet" },
+  { workflow_id: "bd-pipeline", agent_id: "bd-pipeline", inference_tier: "sonnet" },
+  { workflow_id: "staffing-check", agent_id: "staffing-monitor", inference_tier: "sonnet" },
+  { workflow_id: "proposal-generation", agent_id: "proposal-engine", inference_tier: "opus" },
+  { workflow_id: "content-creation", agent_id: "content-engine", inference_tier: "sonnet" },
+  { workflow_id: "portfolio-check", agent_id: "portfolio-monitor", inference_tier: "haiku" },
+  { workflow_id: "garden-brief", agent_id: "garden-calendar", inference_tier: "haiku" },
+  { workflow_id: "social-engagement", agent_id: "social-engagement", inference_tier: "sonnet" },
+  { workflow_id: "security-scan", agent_id: "security-monitor", inference_tier: "sonnet" },
+  { workflow_id: "invoice-generation", agent_id: "invoice-generator", inference_tier: "sonnet" },
+  { workflow_id: "email-campaign", agent_id: "email-campaign", inference_tier: "sonnet" },
+  { workflow_id: "meeting-transcription", agent_id: "meeting-transcriber", inference_tier: "sonnet" },
+  { workflow_id: "drive-watch", agent_id: "drive-watcher", inference_tier: "haiku" },
+];
+
+/** Seven-day staleness threshold in milliseconds. */
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
 export const modelsRouter = Router();
+
+// GET /health — model runtime health summary
+modelsRouter.get("/health", async (_req, res) => {
+  const db = getDb();
+  try {
+    // Probe each runtime endpoint concurrently
+    const runtimeResults = await Promise.all(
+      RUNTIME_ENDPOINTS.map(async (rt) => ({
+        name: rt.name,
+        url: rt.url,
+        connected: await probeRuntime(rt.probe),
+      }))
+    );
+
+    // Query all models from registry
+    const models = db.prepare(`
+      SELECT model_id, runtime, enabled, last_seen_at
+      FROM model_registry
+      ORDER BY enabled DESC, last_seen_at DESC
+    `).all() as Array<{
+      model_id: string; runtime: string; enabled: number; last_seen_at: string;
+    }>;
+
+    // Find the latest discovery timestamp
+    const latestDiscovery = db.prepare(
+      "SELECT MAX(discovered_at) as latest FROM model_registry"
+    ).get() as { latest: string | null } | undefined;
+
+    const enabledCount = models.filter(m => m.enabled === 1).length;
+    const degraded = enabledCount === 0;
+
+    // Map to a model tier based on tags or a simple heuristic
+    const modelSummaries = models.map(m => {
+      // Try to read tags to infer tier; fall back to "sonnet" default
+      let tier = "sonnet";
+      try {
+        const full = db.prepare(
+          "SELECT tags_json FROM model_registry WHERE model_id = ? AND runtime = ?"
+        ).get(m.model_id, m.runtime) as { tags_json: string } | undefined;
+        if (full?.tags_json) {
+          const tags = JSON.parse(full.tags_json) as string[];
+          if (tags.includes("opus")) tier = "opus";
+          else if (tags.includes("haiku")) tier = "haiku";
+        }
+      } catch { /* best-effort tier detection */ }
+
+      return {
+        model_id: m.model_id,
+        runtime: m.runtime,
+        tier,
+        enabled: m.enabled === 1,
+        last_seen_at: m.last_seen_at,
+      };
+    });
+
+    res.json({
+      runtimes: runtimeResults,
+      models: modelSummaries,
+      degraded,
+      last_discovery_at: latestDiscovery?.latest ?? null,
+    });
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+});
+
+// GET /workflow-mapping — static tier mapping for V1 workflows
+modelsRouter.get("/workflow-mapping", (_req, res) => {
+  res.json(WORKFLOW_MAPPING);
+});
 
 // GET / — list all registered models with latest benchmark summary
 modelsRouter.get("/", (_req, res) => {
@@ -109,7 +231,69 @@ modelsRouter.patch("/:modelId", (req, res) => {
   }
 });
 
-// GET /:modelId/benchmarks — get detailed benchmark history (runtime via query param)
+// GET /:runtime/:modelId/benchmarks — benchmark history using composite key (runtime, model_id)
+modelsRouter.get("/:runtime/:modelId/benchmarks", (req, res) => {
+  const { runtime, modelId } = req.params;
+  const db = getDb();
+  try {
+    const rows = db.prepare(`
+      SELECT benchmark_type, latency_ms, tokens_per_sec, json_success, tool_call_success, notes_json, measured_at
+      FROM model_benchmarks WHERE model_id = ? AND runtime = ?
+      ORDER BY measured_at DESC LIMIT 50
+    `).all(modelId!, runtime!) as Array<{
+      benchmark_type: string; latency_ms: number;
+      tokens_per_sec: number | null;
+      json_success: number | null;
+      tool_call_success: number | null;
+      notes_json: string;
+      measured_at: string;
+    }>;
+
+    // Determine staleness: if most recent benchmark is >7 days old
+    const now = Date.now();
+    const latestMeasured = rows.length > 0 ? new Date(rows[0].measured_at).getTime() : 0;
+    const stale = rows.length === 0 || (now - latestMeasured) > STALE_THRESHOLD_MS;
+
+    res.json({
+      stale,
+      benchmarks: rows.map(r => ({
+        ...r,
+        notes: r.notes_json ? JSON.parse(r.notes_json) : null,
+        notes_json: undefined,
+      })),
+    });
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+});
+
+// POST /:runtime/:modelId/benchmark — trigger an on-demand benchmark
+modelsRouter.post("/:runtime/:modelId/benchmark", (req, res) => {
+  const { runtime, modelId } = req.params;
+  const db = getDb();
+  try {
+    const commandId = randomUUID();
+    const now = new Date().toISOString();
+    db.prepare(`
+      INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
+      VALUES (?, 'benchmark_model', 'system', ?, 'queued', 0, ?, 'dashboard', ?)
+    `).run(
+      commandId,
+      JSON.stringify({ runtime, model_id: modelId }),
+      now,
+      `benchmark-${runtime}-${modelId}-${Date.now()}`
+    );
+
+    const actor = getActor(req as AuthenticatedRequest);
+    writeAuditLog(actor.type, actor.id, "model.benchmark_requested", "model", modelId!, { runtime });
+
+    res.json({ ok: true, command_id: commandId, runtime, model_id: modelId });
+  } finally {
+    try { db.close(); } catch { /* best-effort */ }
+  }
+});
+
+// GET /:modelId/benchmarks — get detailed benchmark history (legacy route, runtime via query param)
 modelsRouter.get("/:modelId/benchmarks", (req, res) => {
   const { modelId } = req.params;
   const runtime = req.query.runtime as string | undefined;

--- a/packages/jarvis-dashboard/src/api/packs.ts
+++ b/packages/jarvis-dashboard/src/api/packs.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express'
+import { DatabaseSync } from 'node:sqlite'
+import os from 'os'
+import { join } from 'path'
+import fs from 'fs'
+import { STARTER_PACKS } from '@jarvis/runtime'
+import { writeAuditLog, getActor } from './middleware/audit.js'
+import type { AuthenticatedRequest } from './middleware/auth.js'
+
+function getDb(): DatabaseSync {
+  const dbPath = join(os.homedir(), '.jarvis', 'runtime.db')
+  if (!fs.existsSync(dbPath)) {
+    throw new Error('runtime.db not found')
+  }
+  const db = new DatabaseSync(dbPath)
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}
+
+export const packsRouter = Router()
+
+// GET / — list all starter packs
+packsRouter.get('/', (_req, res) => {
+  res.json(STARTER_PACKS)
+})
+
+// POST /:packId/apply — apply a starter pack
+packsRouter.post('/:packId/apply', (req, res) => {
+  const { packId } = req.params
+  const pack = STARTER_PACKS.find(p => p.pack_id === packId)
+
+  if (!pack) {
+    res.status(404).json({ error: `Unknown starter pack: ${packId}` })
+    return
+  }
+
+  let db: DatabaseSync | null = null
+  try {
+    db = getDb()
+    const now = new Date().toISOString()
+    const upsert = db.prepare(
+      "INSERT OR REPLACE INTO settings (key, value_json, updated_at) VALUES (?, ?, ?)"
+    )
+
+    upsert.run('enabled_agents', JSON.stringify(pack.enabled_agents), now)
+    upsert.run('adapter_mode', JSON.stringify(pack.adapter_mode), now)
+    upsert.run('approval_policy', JSON.stringify(pack.approval_policy), now)
+
+    const actor = getActor(req as AuthenticatedRequest)
+    writeAuditLog(actor.type, actor.id, 'pack.applied', 'pack', packId, {
+      enabled_agents: pack.enabled_agents,
+      adapter_mode: pack.adapter_mode,
+      approval_policy: pack.approval_policy,
+    })
+
+    res.json({ ok: true, applied: packId })
+  } catch (e) {
+    res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+})

--- a/packages/jarvis-dashboard/src/api/runs.ts
+++ b/packages/jarvis-dashboard/src/api/runs.ts
@@ -13,6 +13,57 @@ function getRuntimeDb() {
   return db
 }
 
+/** Human-readable agent labels for explanation summaries. */
+const AGENT_LABELS: Record<string, string> = {
+  'bd-pipeline': 'BD Pipeline',
+  'proposal-engine': 'Proposal Engine',
+  'evidence-auditor': 'Evidence Auditor',
+  'contract-reviewer': 'Contract Reviewer',
+  'staffing-monitor': 'Staffing Monitor',
+  'content-engine': 'Content Engine',
+  'portfolio-monitor': 'Portfolio Monitor',
+  'garden-calendar': 'Garden Calendar',
+  'social-engagement': 'Social Engagement',
+  'security-monitor': 'Security Monitor',
+  'invoice-generator': 'Invoice Generator',
+  'email-campaign': 'Email Campaign',
+  'meeting-transcriber': 'Meeting Transcriber',
+  'drive-watcher': 'Drive Watcher',
+}
+
+/** Build a human-readable trigger description from trigger_kind. */
+function describeTrigger(triggerKind: string | null): { kind: string; source: string; description: string } {
+  if (!triggerKind) {
+    return { kind: 'unknown', source: 'unknown', description: 'an unknown trigger' }
+  }
+  switch (triggerKind) {
+    case 'schedule':
+      return { kind: 'schedule', source: 'cron schedule', description: 'a scheduled job' }
+    case 'manual':
+      return { kind: 'manual', source: 'dashboard', description: 'a manual trigger from the dashboard' }
+    case 'event':
+      return { kind: 'event', source: 'event', description: 'an incoming event' }
+    case 'threshold':
+      return { kind: 'threshold', source: 'alert threshold', description: 'a threshold alert' }
+    default:
+      return { kind: triggerKind, source: triggerKind, description: `a ${triggerKind} trigger` }
+  }
+}
+
+/** Map run status to a plain-language outcome. */
+function describeOutcome(status: string): string {
+  switch (status) {
+    case 'completed': return 'Completed successfully'
+    case 'failed': return 'Failed with errors'
+    case 'cancelled': return 'Was cancelled by an operator'
+    case 'planning': return 'Currently planning'
+    case 'executing': return 'Currently executing'
+    case 'awaiting_approval': return 'Waiting for approval'
+    case 'queued': return 'Queued for execution'
+    default: return `Status: ${status}`
+  }
+}
+
 export const runsRouter = Router()
 
 // GET / — list recent runs from runtime.db, paginated, optional agent filter
@@ -93,6 +144,88 @@ runsRouter.get('/:runId', (req, res) => {
   }
 })
 
+// GET /:runId/explain — plain-language explanation of why and how a run executed
+runsRouter.get('/:runId/explain', (req, res) => {
+  let db: DatabaseSync | undefined
+  try {
+    db = getRuntimeDb()
+    const run = db.prepare('SELECT * FROM runs WHERE run_id = ?').get(req.params.runId) as {
+      run_id: string; agent_id: string; status: string;
+      trigger_kind: string | null; goal: string | null;
+      total_steps: number | null; current_step: number;
+      started_at: string; completed_at: string | null;
+      error: string | null;
+    } | undefined
+
+    if (!run) {
+      res.status(404).json({ error: 'Run not found' })
+      return
+    }
+
+    // Query all events for this run
+    const events = db.prepare(
+      'SELECT event_type, step_no, action, payload_json, created_at FROM run_events WHERE run_id = ? ORDER BY created_at ASC'
+    ).all(run.run_id) as Array<{
+      event_type: string; step_no: number | null;
+      action: string | null; payload_json: string | null;
+      created_at: string;
+    }>
+
+    // Count decisions (step_completed events)
+    const decisionsMade = events.filter(e => e.event_type === 'step_completed').length
+    // Count approvals requested
+    const approvalsRequired = events.filter(e => e.event_type === 'approval_requested').length
+    // Count completed steps vs total
+    const stepsCompleted = run.current_step ?? 0
+    const stepsTotal = run.total_steps ?? stepsCompleted
+
+    // Build trigger description
+    const trigger = describeTrigger(run.trigger_kind)
+
+    // Build data sources from event payloads (best-effort extraction)
+    const dataSources: string[] = []
+    for (const event of events) {
+      if (event.payload_json) {
+        try {
+          const payload = JSON.parse(event.payload_json) as Record<string, unknown>
+          if (payload.data_source && typeof payload.data_source === 'string') {
+            dataSources.push(payload.data_source)
+          }
+          if (payload.collection && typeof payload.collection === 'string') {
+            dataSources.push(`Knowledge: ${payload.collection}`)
+          }
+        } catch { /* skip unparseable payloads */ }
+      }
+    }
+
+    // Format the start time in a readable way
+    const startDate = new Date(run.started_at)
+    const timeStr = startDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+    const dateStr = startDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
+
+    // Agent label
+    const agentLabel = AGENT_LABELS[run.agent_id] ?? run.agent_id
+
+    // Build summary sentence
+    const summary = `This ${agentLabel} run was triggered by ${trigger.description} at ${timeStr} on ${dateStr}.`
+
+    res.json({
+      summary,
+      trigger: { kind: trigger.kind, source: trigger.source },
+      data_sources: dataSources.length > 0 ? dataSources : [],
+      decisions_made: decisionsMade,
+      approvals_required: approvalsRequired,
+      steps_completed: stepsCompleted,
+      steps_total: stepsTotal,
+      outcome: describeOutcome(run.status),
+    })
+  } catch {
+    res.status(500).json({ error: 'Failed to build run explanation' })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+})
+
 // POST /:runId/retry — retry a failed run by queuing a new command for the same agent
 runsRouter.post('/:runId/retry', (req, res) => {
   let db: DatabaseSync | undefined
@@ -113,10 +246,11 @@ runsRouter.post('/:runId/retry', (req, res) => {
     // Check if original run had outbound side effects (email, social, CRM moves)
     // to warn operators that retrying may re-trigger those actions
     const outboundActions = ['email.send', 'social.post', 'crm.move_stage', 'document.generate_report']
-    const completedSteps = db.prepare(
-      "SELECT action FROM run_events WHERE run_id = ? AND event_type = 'step_completed' AND action IS NOT NULL"
+    // Check both completed AND failed steps — a failed outbound step may have triggered side effects
+    const executedSteps = db.prepare(
+      "SELECT action FROM run_events WHERE run_id = ? AND event_type IN ('step_completed', 'step_failed') AND action IS NOT NULL"
     ).all(run.run_id) as Array<{ action: string }>
-    const hadOutbound = completedSteps.some(s => outboundActions.includes(s.action))
+    const hadOutbound = executedSteps.some(s => outboundActions.includes(s.action))
     const retrySafety = hadOutbound ? 'warn_outbound_effects' : 'safe'
 
     const commandId = randomUUID()

--- a/packages/jarvis-dashboard/src/api/safemode.ts
+++ b/packages/jarvis-dashboard/src/api/safemode.ts
@@ -91,7 +91,8 @@ safemodeRouter.get('/', (_req, res) => {
     if (!reason) reason = 'Cannot check daemon — database unavailable'
   }
 
-  const safeMode = !checks.databases_ok || !checks.config_ok
+  // Safe mode triggers on any critical failure — including stale daemon
+  const safeMode = !checks.databases_ok || !checks.config_ok || !checks.daemon_running
 
   res.json({
     safe_mode: safeMode,

--- a/packages/jarvis-dashboard/src/api/safemode.ts
+++ b/packages/jarvis-dashboard/src/api/safemode.ts
@@ -1,0 +1,101 @@
+import { Router } from 'express'
+import os from 'os'
+import { join } from 'path'
+import fs from 'fs'
+import { DatabaseSync } from 'node:sqlite'
+
+const JARVIS_DIR = join(os.homedir(), '.jarvis')
+const CONFIG_PATH = join(JARVIS_DIR, 'config.json')
+const RUNTIME_DB_PATH = join(JARVIS_DIR, 'runtime.db')
+
+export const safemodeRouter = Router()
+
+// GET / — check if system should boot in safe mode
+safemodeRouter.get('/', (_req, res) => {
+  const checks = {
+    databases_ok: true,
+    config_ok: true,
+    daemon_running: true
+  }
+  let reason: string | null = null
+
+  // Check if runtime.db exists and is readable
+  if (!fs.existsSync(RUNTIME_DB_PATH)) {
+    checks.databases_ok = false
+    reason = 'Runtime database missing'
+  } else {
+    let db: DatabaseSync | undefined
+    try {
+      db = new DatabaseSync(RUNTIME_DB_PATH)
+      db.exec('PRAGMA journal_mode = WAL;')
+      db.exec('PRAGMA busy_timeout = 5000;')
+      // Quick integrity check — verify key tables exist
+      const tables = db.prepare(
+        "SELECT COUNT(*) as n FROM sqlite_master WHERE type = 'table' AND name IN ('runs', 'approvals', 'daemon_heartbeats')"
+      ).get() as { n: number }
+      if (tables.n < 3) {
+        checks.databases_ok = false
+        reason = 'Runtime database is missing required tables'
+      }
+    } catch {
+      checks.databases_ok = false
+      reason = 'Runtime database cannot be opened'
+    } finally {
+      try { db?.close() } catch { /* best-effort */ }
+    }
+  }
+
+  // Check if config.json is valid
+  if (!fs.existsSync(CONFIG_PATH)) {
+    checks.config_ok = false
+    if (!reason) reason = 'Configuration file missing'
+  } else {
+    try {
+      JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'))
+    } catch {
+      checks.config_ok = false
+      if (!reason) reason = 'Configuration file is invalid JSON'
+    }
+  }
+
+  // Check daemon heartbeat staleness
+  if (checks.databases_ok && fs.existsSync(RUNTIME_DB_PATH)) {
+    let db: DatabaseSync | undefined
+    try {
+      db = new DatabaseSync(RUNTIME_DB_PATH)
+      db.exec('PRAGMA journal_mode = WAL;')
+      db.exec('PRAGMA busy_timeout = 5000;')
+      const heartbeat = db.prepare(
+        'SELECT last_seen_at FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1'
+      ).get() as { last_seen_at: string } | undefined
+
+      if (!heartbeat) {
+        checks.daemon_running = false
+        if (!reason) reason = 'No daemon heartbeat found'
+      } else {
+        const staleness = Date.now() - new Date(heartbeat.last_seen_at).getTime()
+        if (staleness > 30_000) {
+          checks.daemon_running = false
+          if (!reason) reason = 'Daemon heartbeat is stale'
+        }
+      }
+    } catch {
+      checks.daemon_running = false
+      if (!reason) reason = 'Cannot check daemon heartbeat'
+    } finally {
+      try { db?.close() } catch { /* best-effort */ }
+    }
+  } else {
+    // Can't check daemon if database is unavailable
+    checks.daemon_running = false
+    if (!reason) reason = 'Cannot check daemon — database unavailable'
+  }
+
+  const safeMode = !checks.databases_ok || !checks.config_ok
+
+  res.json({
+    safe_mode: safeMode,
+    reason: safeMode ? reason : null,
+    checks
+  })
+})

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -9,14 +9,21 @@ import { daemonRouter } from './daemon.js'
 import { webhookRouter } from './webhooks.js'
 import { pluginsRouter } from './plugins.js'
 import { runsRouter } from './runs.js'
+import { attentionRouter } from './attention.js'
 import { entitiesRouter } from './entities.js'
 import { analyticsRouter } from './analytics.js'
 import { settingsRouter } from './settings.js'
+import { backupRouter } from './backup.js'
+import { safemodeRouter } from './safemode.js'
 import { portalRouter } from './portal.js'
 import { godmodeRouter } from './godmode.js'
 import { modelsRouter } from './models.js'
 import { queueRouter } from './queue.js'
 import { policyRouter } from './policy.js'
+import { workflowsRouter } from './workflows.js'
+import { packsRouter } from './packs.js'
+import { serviceRouter } from './service.js'
+import { modeRouter } from './settings.js'
 import fs from 'fs'
 import { getHealthReport, getReadinessReport } from '@jarvis/runtime'
 import { createAuthMiddleware } from './middleware/auth.js'
@@ -60,14 +67,21 @@ app.use('/api/daemon', daemonRouter)
 app.use('/api/webhooks', webhookRouter)
 app.use('/api/plugins', pluginsRouter)
 app.use('/api/runs', runsRouter)
+app.use('/api/attention', attentionRouter)
 app.use('/api/entities', entitiesRouter)
 app.use('/api/analytics', analyticsRouter)
 app.use('/api/settings', settingsRouter)
+app.use('/api/backup', backupRouter)
+app.use('/api/safemode', safemodeRouter)
 app.use('/portal/api', portalRouter)
 app.use('/api/godmode', godmodeRouter)
 app.use('/api/models', modelsRouter)
 app.use('/api/queue', queueRouter)
 app.use('/api/policy', policyRouter)
+app.use('/api/workflows', workflowsRouter)
+app.use('/api/packs', packsRouter)
+app.use('/api/service', serviceRouter)
+app.use('/api/mode', modeRouter)
 
 app.get('/api/health', (_req, res) => {
   const report = getHealthReport()

--- a/packages/jarvis-dashboard/src/api/service.ts
+++ b/packages/jarvis-dashboard/src/api/service.ts
@@ -1,0 +1,81 @@
+import { Router } from 'express'
+import { DatabaseSync } from 'node:sqlite'
+import os from 'os'
+import { join } from 'path'
+import fs from 'fs'
+import { writeAuditLog, getActor } from './middleware/audit.js'
+import type { AuthenticatedRequest } from './middleware/auth.js'
+
+const PORT = Number(process.env.PORT ?? 4242)
+
+function readDaemonHeartbeat(): { running: boolean; pid: number | null; uptime_seconds: number | null } {
+  const disconnected = { running: false, pid: null, uptime_seconds: null }
+  const dbPath = join(os.homedir(), '.jarvis', 'runtime.db')
+  if (!fs.existsSync(dbPath)) return disconnected
+
+  let db: DatabaseSync | null = null
+  try {
+    db = new DatabaseSync(dbPath)
+    db.exec("PRAGMA journal_mode = WAL;")
+    db.exec("PRAGMA busy_timeout = 5000;")
+
+    const row = db.prepare(
+      "SELECT * FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1"
+    ).get() as Record<string, unknown> | undefined
+
+    if (!row) return disconnected
+
+    const lastSeen = row.last_seen_at as string
+    const age = Date.now() - new Date(lastSeen).getTime()
+    if (age > 30_000) return disconnected
+
+    let details: Record<string, unknown> = {}
+    try {
+      details = JSON.parse(row.details_json as string) as Record<string, unknown>
+    } catch { /* ok */ }
+
+    const startedAt = details.started_at as string | undefined
+    const uptimeSeconds = startedAt
+      ? Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000)
+      : null
+
+    return {
+      running: true,
+      pid: row.pid as number | null,
+      uptime_seconds: uptimeSeconds,
+    }
+  } catch {
+    return disconnected
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+}
+
+export const serviceRouter = Router()
+
+// GET /status — service status overview
+serviceRouter.get('/status', (_req, res) => {
+  const daemon = readDaemonHeartbeat()
+
+  res.json({
+    daemon: {
+      running: daemon.running,
+      pid: daemon.pid,
+      uptime_seconds: daemon.uptime_seconds,
+    },
+    dashboard: {
+      running: true,
+      port: PORT,
+    },
+  })
+})
+
+// POST /restart — placeholder restart signal
+serviceRouter.post('/restart', (req, res) => {
+  const actor = getActor(req as AuthenticatedRequest)
+  writeAuditLog(actor.type, actor.id, 'service.restart_requested', 'service', 'daemon', {
+    note: 'Restart signal recorded. Real restart requires OS-level service management.',
+  })
+
+  res.json({ ok: true, message: 'Restart signal sent' })
+})

--- a/packages/jarvis-dashboard/src/api/settings.ts
+++ b/packages/jarvis-dashboard/src/api/settings.ts
@@ -156,6 +156,56 @@ settingsRouter.patch('/agents/:id', (req, res) => {
   res.json({ id, enabled: enabled !== false })
 })
 
+// ─── Repair API ──────────────────────────────────────────────────────────────
+
+settingsRouter.post('/repair', (req, res) => {
+  const { check = 'all' } = req.body as { check?: 'lmstudio' | 'databases' | 'config' | 'all' }
+  const checks: Array<{ name: string; ok: boolean; message: string }> = []
+
+  if (check === 'config' || check === 'all') {
+    try {
+      const config = readConfig()
+      const hasLms = typeof config.lmstudio_url === 'string'
+      const hasMode = typeof config.adapter_mode === 'string'
+      checks.push({ name: 'config', ok: hasLms && hasMode, message: hasLms && hasMode ? 'Config valid' : 'Missing lmstudio_url or adapter_mode' })
+    } catch {
+      checks.push({ name: 'config', ok: false, message: 'Cannot read config.json' })
+    }
+  }
+
+  if (check === 'databases' || check === 'all') {
+    for (const dbName of ['runtime.db', 'crm.db', 'knowledge.db']) {
+      const dbPath = join(JARVIS_DIR, dbName)
+      if (!fs.existsSync(dbPath)) {
+        checks.push({ name: dbName, ok: false, message: `${dbName} not found` })
+      } else {
+        let db: DatabaseSync | undefined
+        try {
+          db = new DatabaseSync(dbPath)
+          db.prepare('SELECT 1').get()
+          checks.push({ name: dbName, ok: true, message: `${dbName} accessible` })
+        } catch {
+          checks.push({ name: dbName, ok: false, message: `${dbName} corrupted or locked` })
+        } finally {
+          try { db?.close() } catch {}
+        }
+      }
+    }
+  }
+
+  if (check === 'lmstudio' || check === 'all') {
+    // Sync check — just verify config has a URL
+    const config = readConfig()
+    const url = config.lmstudio_url as string | undefined
+    checks.push({ name: 'lmstudio', ok: !!url, message: url ? `LM Studio configured at ${url}` : 'No lmstudio_url in config' })
+  }
+
+  const allOk = checks.every(c => c.ok)
+  const actor = getActor(req as AuthenticatedRequest)
+  writeAuditLog(actor.type, actor.id, 'settings.repair', 'settings', check, { checks })
+  res.json({ repaired: allOk, checks, message: allOk ? 'All checks passed' : 'Some checks failed — see details' })
+})
+
 // ─── Expert Mode API ───────────────────────────────────────────────────────
 
 function getModeDb(): DatabaseSync {

--- a/packages/jarvis-dashboard/src/api/settings.ts
+++ b/packages/jarvis-dashboard/src/api/settings.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import { DatabaseSync } from 'node:sqlite'
 import os from 'os'
 import { join } from 'path'
 import fs from 'fs'
@@ -153,4 +154,65 @@ settingsRouter.patch('/agents/:id', (req, res) => {
   const actor = getActor(req as AuthenticatedRequest)
   writeAuditLog(actor.type, actor.id, 'agent.toggled', 'agent', id, { enabled: enabled !== false })
   res.json({ id, enabled: enabled !== false })
+})
+
+// ─── Expert Mode API ───────────────────────────────────────────────────────
+
+function getModeDb(): DatabaseSync {
+  const dbPath = join(JARVIS_DIR, 'runtime.db')
+  if (!fs.existsSync(dbPath)) {
+    throw new Error('runtime.db not found')
+  }
+  const db = new DatabaseSync(dbPath)
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}
+
+export const modeRouter = Router()
+
+// GET / — read current UI mode
+modeRouter.get('/', (_req, res) => {
+  let db: DatabaseSync | null = null
+  try {
+    db = getModeDb()
+    const row = db.prepare(
+      "SELECT value_json FROM settings WHERE key = 'ui_mode'"
+    ).get() as { value_json: string } | undefined
+
+    const mode = row ? JSON.parse(row.value_json) as string : 'simple'
+    res.json({ mode })
+  } catch {
+    // If DB doesn't exist yet, default to simple
+    res.json({ mode: 'simple' })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+})
+
+// POST / — set UI mode
+modeRouter.post('/', (req, res) => {
+  const { mode } = req.body as { mode?: string }
+
+  if (mode !== 'simple' && mode !== 'expert') {
+    res.status(400).json({ error: 'mode must be "simple" or "expert"' })
+    return
+  }
+
+  let db: DatabaseSync | null = null
+  try {
+    db = getModeDb()
+    db.prepare(
+      "INSERT OR REPLACE INTO settings (key, value_json, updated_at) VALUES ('ui_mode', ?, ?)"
+    ).run(JSON.stringify(mode), new Date().toISOString())
+
+    const actor = getActor(req as AuthenticatedRequest)
+    writeAuditLog(actor.type, actor.id, 'mode.changed', 'settings', 'ui_mode', { mode })
+
+    res.json({ mode })
+  } catch (e) {
+    res.status(500).json({ error: e instanceof Error ? e.message : String(e) })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
 })

--- a/packages/jarvis-dashboard/src/api/workflows.ts
+++ b/packages/jarvis-dashboard/src/api/workflows.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express'
 import { DatabaseSync } from 'node:sqlite'
 import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import os from 'os'
 import { join } from 'path'
 import { V1_WORKFLOWS } from '@jarvis/runtime'
 
-function getRuntimeDb() {
-  const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
+function getRuntimeDb(): DatabaseSync {
+  const dbPath = join(os.homedir(), '.jarvis', 'runtime.db')
+  if (!existsSync(dbPath)) throw new Error('runtime.db not found')
+  const db = new DatabaseSync(dbPath)
   db.exec("PRAGMA journal_mode = WAL;")
   db.exec("PRAGMA busy_timeout = 5000;")
   return db
@@ -34,15 +37,25 @@ workflowsRouter.post('/:workflowId/start', (req, res) => {
   let db: DatabaseSync | undefined
   try {
     db = getRuntimeDb()
-    const commands = []
-    for (const agentId of wf.agent_ids) {
-      const commandId = randomUUID()
-      db.prepare(`
-        INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
-        VALUES (?, 'run_agent', ?, ?, 'queued', 0, ?, 'workflow', ?)
-      `).run(commandId, agentId, JSON.stringify({ ...req.body, workflow_id: wf.workflow_id, preview: req.body?.preview ?? false }), new Date().toISOString(), `workflow-${wf.workflow_id}-${agentId}-${Date.now()}`)
-      commands.push({ command_id: commandId, agent_id: agentId })
+    const commands: Array<{ command_id: string; agent_id: string }> = []
+
+    // Wrap in transaction so workflow starts are all-or-nothing
+    db.exec("BEGIN IMMEDIATE")
+    try {
+      for (const agentId of wf.agent_ids) {
+        const commandId = randomUUID()
+        db.prepare(`
+          INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
+          VALUES (?, 'run_agent', ?, ?, 'queued', 0, ?, 'workflow', ?)
+        `).run(commandId, agentId, JSON.stringify({ ...req.body, workflow_id: wf.workflow_id, preview: req.body?.preview ?? false }), new Date().toISOString(), `workflow-${wf.workflow_id}-${agentId}-${Date.now()}`)
+        commands.push({ command_id: commandId, agent_id: agentId })
+      }
+      db.exec("COMMIT")
+    } catch (e) {
+      db.exec("ROLLBACK")
+      throw e
     }
+
     res.json({ ok: true, workflow_id: wf.workflow_id, commands })
   } catch {
     res.status(500).json({ error: 'Failed to start workflow' })

--- a/packages/jarvis-dashboard/src/api/workflows.ts
+++ b/packages/jarvis-dashboard/src/api/workflows.ts
@@ -1,0 +1,52 @@
+import { Router } from 'express'
+import { DatabaseSync } from 'node:sqlite'
+import { randomUUID } from 'node:crypto'
+import os from 'os'
+import { join } from 'path'
+import { V1_WORKFLOWS } from '@jarvis/runtime'
+
+function getRuntimeDb() {
+  const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}
+
+export const workflowsRouter = Router()
+
+// GET / — list available workflows
+workflowsRouter.get('/', (_req, res) => {
+  res.json(V1_WORKFLOWS)
+})
+
+// GET /:workflowId — get specific workflow
+workflowsRouter.get('/:workflowId', (req, res) => {
+  const wf = V1_WORKFLOWS.find(w => w.workflow_id === req.params.workflowId)
+  if (!wf) { res.status(404).json({ error: 'Workflow not found' }); return }
+  res.json(wf)
+})
+
+// POST /:workflowId/start — start a workflow
+workflowsRouter.post('/:workflowId/start', (req, res) => {
+  const wf = V1_WORKFLOWS.find(w => w.workflow_id === req.params.workflowId)
+  if (!wf) { res.status(404).json({ error: 'Workflow not found' }); return }
+
+  let db: DatabaseSync | undefined
+  try {
+    db = getRuntimeDb()
+    const commands = []
+    for (const agentId of wf.agent_ids) {
+      const commandId = randomUUID()
+      db.prepare(`
+        INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key)
+        VALUES (?, 'run_agent', ?, ?, 'queued', 0, ?, 'workflow', ?)
+      `).run(commandId, agentId, JSON.stringify({ ...req.body, workflow_id: wf.workflow_id, preview: req.body?.preview ?? false }), new Date().toISOString(), `workflow-${wf.workflow_id}-${agentId}-${Date.now()}`)
+      commands.push({ command_id: commandId, agent_id: agentId })
+    }
+    res.json({ ok: true, workflow_id: wf.workflow_id, commands })
+  } catch {
+    res.status(500).json({ error: 'Failed to start workflow' })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+})

--- a/packages/jarvis-runtime/src/agent-queue.ts
+++ b/packages/jarvis-runtime/src/agent-queue.ts
@@ -65,23 +65,23 @@ export class AgentQueue {
    * Add an agent run to the queue, sorted by priority (descending).
    * If the agent is already running or already queued, this is a no-op.
    */
-  enqueue(agentId: string, trigger: AgentTrigger, priority = 0, commandId?: string, commandPayload?: Record<string, unknown>): void {
+  enqueue(agentId: string, trigger: AgentTrigger, priority = 0, commandId?: string, commandPayload?: Record<string, unknown>): boolean {
     // Reject in drain mode
     if (this._draining) {
       this.logger.debug(`Agent ${agentId} rejected — queue is draining`);
-      return;
+      return false;
     }
 
     // Don't enqueue if already running
     if (this.running.has(agentId)) {
       this.logger.debug(`Agent ${agentId} already running — skipping enqueue`);
-      return;
+      return false;
     }
 
     // Don't enqueue if already in queue
     if (this.queue.some((e) => e.agentId === agentId)) {
       this.logger.debug(`Agent ${agentId} already queued — skipping enqueue`);
-      return;
+      return false;
     }
 
     this.queue.push({
@@ -102,6 +102,7 @@ export class AgentQueue {
     this.logger.debug(
       `Enqueued agent ${agentId} (priority=${priority}, queue=${this.queue.length})`,
     );
+    return true;
   }
 
   /**

--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -169,6 +169,8 @@ async function main() {
         runStore.transition(run.run_id, run.agent_id, "failed", "run_failed", {
           details: { reason: "restart_recovery", original_status: "awaiting_approval" },
         });
+        // Also complete the linked command so it doesn't stay stuck in 'claimed'
+        runStore.completeCommand(run.run_id, "failed");
         logger.info(`Restart recovery: failed stuck run ${run.run_id} (was awaiting_approval with no pending approvals)`);
       }
       logger.info(`Restart recovery: resolved ${stuckRuns.length} stuck awaiting_approval run(s)`);
@@ -226,9 +228,14 @@ async function main() {
           }
 
           // Enqueue the agent with command_id + payload for atomic linkage.
-          // The orchestrator receives command_id via trigger and links it to the run directly.
-          // RunStore.completeCommand() marks the command completed/failed when the run ends.
-          agentQueue.enqueue(cmd.target_agent_id, { kind: "manual" }, 0, cmd.command_id, commandPayload);
+          // If enqueue is a no-op (agent already running/queued), revert the claim.
+          const enqueued = agentQueue.enqueue(cmd.target_agent_id, { kind: "manual" }, 0, cmd.command_id, commandPayload);
+          if (!enqueued) {
+            runtimeDb.prepare(
+              "UPDATE agent_commands SET status = 'queued', claimed_at = NULL WHERE command_id = ?",
+            ).run(cmd.command_id);
+            logger.debug(`Reverted claim for command ${cmd.command_id} — agent ${cmd.target_agent_id} already running/queued`);
+          }
         } else {
           logger.warn(`Unknown command type: ${cmd.command_type}`);
           runtimeDb.prepare(

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -24,3 +24,5 @@ export {
 export { getHealthReport, getReadinessReport, type HealthReport, type HealthStatus, type ReadinessReport } from "./health.js";
 export { DbSchedulerStore } from "./db-scheduler.js";
 export { isReadOnlyAction, getReadOnlySuffixes } from "./action-classifier.js";
+export { V1_WORKFLOWS, type WorkflowDefinition, type WorkflowInput } from "./workflows.js";
+export { STARTER_PACKS, type StarterPack } from "./starter-packs.js";

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -16,6 +16,10 @@ import type { RagPipeline } from "./rag-pipeline.js";
 import type { Logger } from "./logger.js";
 import type { StatusWriter } from "./status-writer.js";
 
+/** Outbound actions that are skipped in preview mode. Excludes document.generate_report
+ *  since that's typically the main deliverable and should still execute in preview. */
+const OUTBOUND_ACTIONS = new Set(['email.send', 'social.post', 'crm.move_stage']);
+
 export type OrchestratorDeps = {
   runtime: AgentRuntime;
   registry: WorkerRegistry;
@@ -270,8 +274,7 @@ export async function runAgent(
       // ── Preview mode: skip outbound actions BEFORE approval gate ──
       // This prevents preview runs from blocking on approval waits for actions
       // that would be skipped anyway.
-      const outboundActions = new Set(['email.send', 'social.post', 'crm.move_stage']);
-      if (commandPayload?.preview === true && outboundActions.has(step.action)) {
+      if (commandPayload?.preview === true && OUTBOUND_ACTIONS.has(step.action)) {
         stepLog.info(`Preview mode: would have executed ${step.action} — skipping`);
         runStore?.emitEvent(run.run_id, agentId, "step_completed", {
           step_no: step.step, action: step.action,

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -53,9 +53,9 @@ export async function runAgent(
   // Load plugin permissions if this is a plugin agent
   const pluginPermissions = loadPluginPermissions(agentId, runtimeDb);
 
-  // 1. Start run
+  // 1. Start run — use the same run_id for both in-memory and durable state
   const run = runtime.startRun(agentId, trigger);
-  const durableRunId = runStore?.startRun(agentId, trigger.kind, commandId, run.goal);
+  runStore?.startRun(agentId, trigger.kind, commandId, run.goal, run.run_id);
 
   // Log retry relationship in the audit trail so retry runs are linked to originals
   if (commandPayload?.retry_of && runStore) {
@@ -175,6 +175,7 @@ export async function runAgent(
             details: { reason: "disagreement_timeout" },
           });
           runStore?.completeCommand(run.run_id, "failed");
+          writeTelegramQueue(agentId, `\u23F0 Approval expired for plan_disagreement. Run ${run.run_id} failed due to timeout.`, runtimeDb);
           statusWriter?.completeRun("disagreement_timeout");
           runtime.completeRun(run.run_id, "Disagreement approval timeout");
           return run;
@@ -252,10 +253,12 @@ export async function runAgent(
       // ── Plugin permission check ──
       // Enforce permissions at runtime for plugin agents
       if (pluginPermissions && !isActionPermitted(step.action, pluginPermissions)) {
+        const actionPrefix = step.action.split('.')[0];
+        const reason = `Action '${step.action}' requires 'execute_${actionPrefix}' permission. Granted permissions: ${pluginPermissions?.join(', ') || 'none'}.`;
         stepLog.warn(`Action blocked by plugin permissions: ${step.action}`);
         runStore?.emitEvent(run.run_id, agentId, "step_failed", {
           step_no: step.step, action: step.action,
-          details: { error: "permission_denied", reason: `Plugin lacks permission for ${step.action}` },
+          details: { error: "permission_denied", reason },
         });
         decisionLog.logDecision({
           agent_id: agentId, run_id: run.run_id, step: step.step,
@@ -316,6 +319,7 @@ export async function runAgent(
             agent_id: agentId, run_id: run.run_id, step: step.step,
             action: step.action, reasoning: step.reasoning, outcome: "approval_timeout",
           });
+          writeTelegramQueue(agentId, `\u23F0 Approval expired for ${step.action} (step ${step.step}). Run ${run.run_id} failed due to timeout.`, runtimeDb);
           statusWriter?.completeRun("approval_timeout");
           runtime.completeRun(run.run_id, "Approval timeout");
           return run;
@@ -327,6 +331,23 @@ export async function runAgent(
           step_no: step.step, action: step.action,
         });
         stepLog.info("Approved — executing");
+      }
+
+      // ── Preview mode: skip outbound actions ──
+      const outboundActions = new Set(['email.send', 'social.post', 'crm.move_stage', 'document.generate_report']);
+      if (commandPayload?.preview === true && outboundActions.has(step.action)) {
+        stepLog.info(`Preview mode: would have executed ${step.action} — skipping`);
+        runStore?.emitEvent(run.run_id, agentId, "step_completed", {
+          step_no: step.step, action: step.action,
+          details: { preview: true, skipped: true },
+        });
+        decisionLog.logDecision({
+          agent_id: agentId, run_id: run.run_id, step: step.step,
+          action: step.action, reasoning: step.reasoning, outcome: "preview_skipped",
+        });
+        run.current_step = step.step;
+        run.updated_at = new Date().toISOString();
+        continue;
       }
 
       // Execute the job

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -267,6 +267,25 @@ export async function runAgent(
         continue; // Skip this step
       }
 
+      // ── Preview mode: skip outbound actions BEFORE approval gate ──
+      // This prevents preview runs from blocking on approval waits for actions
+      // that would be skipped anyway.
+      const outboundActions = new Set(['email.send', 'social.post', 'crm.move_stage']);
+      if (commandPayload?.preview === true && outboundActions.has(step.action)) {
+        stepLog.info(`Preview mode: would have executed ${step.action} — skipping`);
+        runStore?.emitEvent(run.run_id, agentId, "step_completed", {
+          step_no: step.step, action: step.action,
+          details: { preview: true, skipped: true },
+        });
+        decisionLog.logDecision({
+          agent_id: agentId, run_id: run.run_id, step: step.step,
+          action: step.action, reasoning: step.reasoning, outcome: "preview_skipped",
+        });
+        run.current_step = step.step;
+        run.updated_at = new Date().toISOString();
+        continue;
+      }
+
       // ── Maturity-based approval gates ──
       const gate = resolveApprovalGate(def, step.action);
 
@@ -331,23 +350,6 @@ export async function runAgent(
           step_no: step.step, action: step.action,
         });
         stepLog.info("Approved — executing");
-      }
-
-      // ── Preview mode: skip outbound actions ──
-      const outboundActions = new Set(['email.send', 'social.post', 'crm.move_stage', 'document.generate_report']);
-      if (commandPayload?.preview === true && outboundActions.has(step.action)) {
-        stepLog.info(`Preview mode: would have executed ${step.action} — skipping`);
-        runStore?.emitEvent(run.run_id, agentId, "step_completed", {
-          step_no: step.step, action: step.action,
-          details: { preview: true, skipped: true },
-        });
-        decisionLog.logDecision({
-          agent_id: agentId, run_id: run.run_id, step: step.step,
-          action: step.action, reasoning: step.reasoning, outcome: "preview_skipped",
-        });
-        run.current_step = step.step;
-        run.updated_at = new Date().toISOString();
-        continue;
       }
 
       // Execute the job

--- a/packages/jarvis-runtime/src/run-store.ts
+++ b/packages/jarvis-runtime/src/run-store.ts
@@ -40,8 +40,8 @@ export class RunStore {
   constructor(private db: DatabaseSync) {}
 
   /** Start a new run. Inserts into runs table and emits run_started event atomically. Returns run_id. */
-  startRun(agentId: string, triggerKind?: string, commandId?: string, goal?: string): string {
-    const runId = randomUUID();
+  startRun(agentId: string, triggerKind?: string, commandId?: string, goal?: string, runId?: string): string {
+    runId = runId ?? randomUUID();
     const now = new Date().toISOString();
 
     this.db.exec("BEGIN IMMEDIATE");
@@ -170,10 +170,10 @@ export class RunStore {
     return (row?.status as RunStatus) ?? null;
   }
 
-  /** Find a run by its linked command_id. Used to link retry runs to originals. */
+  /** Find the most recent run by its linked command_id. Used to link retry runs to originals. */
   getRunByCommandId(commandId: string): { run_id: string; agent_id: string; status: string } | null {
     const row = this.db.prepare(
-      "SELECT run_id, agent_id, status FROM runs WHERE command_id = ?",
+      "SELECT run_id, agent_id, status FROM runs WHERE command_id = ? ORDER BY started_at DESC LIMIT 1",
     ).get(commandId) as { run_id: string; agent_id: string; status: string } | undefined;
     return row ?? null;
   }

--- a/packages/jarvis-runtime/src/starter-packs.ts
+++ b/packages/jarvis-runtime/src/starter-packs.ts
@@ -1,0 +1,39 @@
+export type StarterPack = {
+  pack_id: string;
+  name: string;
+  description: string;
+  enabled_agents: string[];
+  disabled_agents: string[];
+  adapter_mode: "mock" | "real";
+  approval_policy: "strict" | "standard" | "relaxed";
+};
+
+export const STARTER_PACKS: StarterPack[] = [
+  {
+    pack_id: "automotive-consulting",
+    name: "Automotive Consulting",
+    description: "Full suite for ISO 26262, ASPICE, and automotive safety consulting. Enables BD pipeline, proposals, evidence auditing, contract review, and staffing.",
+    enabled_agents: ["bd-pipeline", "proposal-engine", "evidence-auditor", "contract-reviewer", "staffing-monitor"],
+    disabled_agents: ["content-engine", "portfolio-monitor", "garden-calendar", "social-engagement", "security-monitor", "invoice-generator", "email-campaign", "meeting-transcriber", "drive-watcher"],
+    adapter_mode: "real",
+    approval_policy: "strict",
+  },
+  {
+    pack_id: "solo-consultant",
+    name: "Solo Consultant",
+    description: "Lean setup for individual consultants. BD pipeline, contract review, and staffing only.",
+    enabled_agents: ["bd-pipeline", "contract-reviewer", "staffing-monitor"],
+    disabled_agents: ["proposal-engine", "evidence-auditor", "content-engine", "portfolio-monitor", "garden-calendar", "social-engagement", "security-monitor", "invoice-generator", "email-campaign", "meeting-transcriber", "drive-watcher"],
+    adapter_mode: "real",
+    approval_policy: "standard",
+  },
+  {
+    pack_id: "development",
+    name: "Development Mode",
+    description: "All agents enabled with mock adapters. For testing and development only.",
+    enabled_agents: ["bd-pipeline", "proposal-engine", "evidence-auditor", "contract-reviewer", "staffing-monitor", "content-engine", "portfolio-monitor", "garden-calendar", "social-engagement", "security-monitor", "invoice-generator", "email-campaign", "meeting-transcriber", "drive-watcher"],
+    disabled_agents: [],
+    adapter_mode: "mock",
+    approval_policy: "relaxed",
+  },
+];

--- a/packages/jarvis-runtime/src/workflows.ts
+++ b/packages/jarvis-runtime/src/workflows.ts
@@ -1,0 +1,84 @@
+export type WorkflowInput = {
+  name: string;
+  label: string;
+  type: "text" | "file" | "select" | "date" | "checkbox";
+  required: boolean;
+  placeholder?: string;
+  options?: string[];
+};
+
+export type WorkflowDefinition = {
+  workflow_id: string;
+  name: string;
+  description: string;
+  agent_ids: string[];
+  expected_output: string;
+  inputs: WorkflowInput[];
+  approval_summary: string;
+  preview_available: boolean;
+};
+
+export const V1_WORKFLOWS: WorkflowDefinition[] = [
+  {
+    workflow_id: "contract-review",
+    name: "Review Contract",
+    description: "Analyze NDA/MSA clauses and produce sign, negotiate, or escalate recommendation.",
+    agent_ids: ["contract-reviewer"],
+    expected_output: "Clause analysis with sign/negotiate/escalate recommendation",
+    inputs: [
+      { name: "document", label: "Contract document", type: "file", required: true, placeholder: "Upload NDA or MSA" },
+      { name: "jurisdiction", label: "Jurisdiction", type: "select", required: false, options: ["EU", "US", "UK", "Other"] },
+    ],
+    approval_summary: "Report generation requires approval",
+    preview_available: true,
+  },
+  {
+    workflow_id: "rfq-analysis",
+    name: "Analyze RFQ/Document",
+    description: "Scan project documents for ISO 26262 compliance and build quote structure.",
+    agent_ids: ["evidence-auditor", "proposal-engine"],
+    expected_output: "Gap matrix and/or quote structure",
+    inputs: [
+      { name: "document", label: "RFQ or project document", type: "file", required: true },
+      { name: "scope", label: "Analysis scope", type: "select", required: false, options: ["Full audit", "Gap analysis only", "Quote only"] },
+    ],
+    approval_summary: "Outbound emails require approval",
+    preview_available: true,
+  },
+  {
+    workflow_id: "bd-pipeline",
+    name: "Monitor BD Pipeline",
+    description: "Scan for business development signals, enrich leads, draft outreach, update CRM.",
+    agent_ids: ["bd-pipeline"],
+    expected_output: "Enriched leads, CRM updates, outreach drafts",
+    inputs: [
+      { name: "focus", label: "Focus area", type: "text", required: false, placeholder: "e.g., automotive OEMs in Germany" },
+    ],
+    approval_summary: "Emails and CRM stage changes require approval",
+    preview_available: true,
+  },
+  {
+    workflow_id: "staffing-check",
+    name: "Check Staffing",
+    description: "Calculate team utilization, forecast gaps, match skills to pipeline.",
+    agent_ids: ["staffing-monitor"],
+    expected_output: "Utilization report with gap forecast",
+    inputs: [
+      { name: "period", label: "Report period", type: "select", required: false, options: ["This week", "Next 2 weeks", "This month", "This quarter"] },
+    ],
+    approval_summary: "Email notifications require approval",
+    preview_available: false,
+  },
+  {
+    workflow_id: "weekly-report",
+    name: "Create Weekly Report",
+    description: "Run scheduled monitoring agents and compile a weekly summary.",
+    agent_ids: ["evidence-auditor", "staffing-monitor", "bd-pipeline"],
+    expected_output: "Weekly summary report with action items",
+    inputs: [
+      { name: "week", label: "Report week", type: "date", required: false, placeholder: "Defaults to current week" },
+    ],
+    approval_summary: "Individual agent approvals apply",
+    preview_available: false,
+  },
+];

--- a/tests/smoke/lifecycle-certification.test.ts
+++ b/tests/smoke/lifecycle-certification.test.ts
@@ -380,19 +380,19 @@ describe("Lifecycle Certification", () => {
       store.transition(origRunId, "garden-calendar", "failed", "run_failed", { details: { error: "Weather API down" } });
       store.completeCommand(origRunId, "failed");
 
-      // Insert retry command referencing original via payload
-      const retryPayload = JSON.stringify({ retry_of: "cert-orig-cmd", original_run_id: origRunId });
+      // Insert retry command referencing original run_id (not command_id) via payload
+      const retryPayload = JSON.stringify({ retry_of: origRunId });
       db.prepare(
         "INSERT INTO agent_commands (command_id, command_type, target_agent_id, status, priority, created_at, created_by, payload_json, idempotency_key) VALUES (?, ?, ?, 'queued', 0, ?, ?, ?, ?)",
       ).run("cert-retry-cmd", "run_agent", "garden-calendar", now, "dashboard", retryPayload, "retry-garden-001");
 
-      // Verify new command exists
+      // Verify new command exists with retry_of pointing to run_id
       const retryCmd = db.prepare("SELECT status, payload_json FROM agent_commands WHERE command_id = ?").get("cert-retry-cmd") as {
         status: string;
         payload_json: string;
       };
       expect(retryCmd.status).toBe("queued");
-      expect(JSON.parse(retryCmd.payload_json).retry_of).toBe("cert-orig-cmd");
+      expect(JSON.parse(retryCmd.payload_json).retry_of).toBe(origRunId);
     });
 
     it("retry command has unique idempotency_key", () => {


### PR DESCRIPTION
## Summary

Implements Sprints 2-6 of the V1 product backlog — 16 new API endpoints across 6 product tracks.

**Sprint 2 — Operator console + safety:**
- `GET /api/attention` — needs-attention summary (approvals, failures, active work, recommendations)
- `GET /api/attention/statuses` — plain-English status descriptions
- Preview mode in orchestrator (skips outbound actions when `preview=true`)
- Enriched approval responses (risk level, linked run, timeout countdown, what-if)
- Timeout notification via Telegram when approval expires

**Sprint 3 — Workflow launcher:**
- `GET /api/workflows` + `POST /api/workflows/:id/start` — 5 V1 workflow definitions with guided inputs

**Sprint 4 — Setup + backup + safe mode:**
- `POST /api/settings/repair` — config/database/LM Studio repair checks
- `POST /api/backup` / `GET /api/backup/status` / `POST /api/restore`
- `GET /api/safemode` — safe mode detection

**Sprint 5 — Model health + education:**
- `GET /api/models/health` — runtime connectivity + degraded flag
- `GET /api/runs/:runId/explain` — plain-language "why did Jarvis do this"

**Sprint 6 — Starter packs + expert mode:**
- 3 starter packs (automotive consulting, solo consultant, development)
- `GET/POST /api/mode` — simple/expert toggle
- `GET /api/service/status`

**Review fixes (Copilot + Codex):**
- CRITICAL: RunStore.startRun accepts runId — durable and in-memory IDs now match
- Restart recovery completes linked commands (prevents stuck claimed state)
- Retry safety checks step_failed too (not just step_completed)
- AgentQueue.enqueue returns boolean — daemon reverts claim on no-op
- retry_of standardized to always reference run_id

**21 files changed, +1,191/-26 lines. 44 test files, 1,131 tests pass.**

## Test plan

- [x] `npm run check` passes locally (contracts + 1,131 tests + build)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)