### PR TITLE
Reengineer dashboard UI/UX around operating use cases

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "jarvis-dashboard",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", "packages/jarvis-dashboard/dist", "-l", "4250", "-s"],
+      "port": 4250
+    }
+  ]
+}

--- a/packages/jarvis-dashboard/src/api/history.ts
+++ b/packages/jarvis-dashboard/src/api/history.ts
@@ -1,0 +1,417 @@
+import { Router } from 'express'
+import { DatabaseSync } from 'node:sqlite'
+import type { SQLInputValue } from 'node:sqlite'
+import { existsSync } from 'node:fs'
+import os from 'os'
+import { join } from 'path'
+
+function getRuntimeDb(): DatabaseSync {
+  const dbPath = join(os.homedir(), '.jarvis', 'runtime.db')
+  if (!existsSync(dbPath)) throw new Error('runtime.db not found')
+  const db = new DatabaseSync(dbPath)
+  db.exec("PRAGMA journal_mode = WAL;")
+  db.exec("PRAGMA busy_timeout = 5000;")
+  return db
+}
+
+const AGENT_LABELS: Record<string, string> = {
+  'bd-pipeline': 'BD Pipeline',
+  'proposal-engine': 'Proposal Engine',
+  'evidence-auditor': 'Evidence Auditor',
+  'contract-reviewer': 'Contract Reviewer',
+  'staffing-monitor': 'Staffing Monitor',
+  'content-engine': 'Content Engine',
+  'portfolio-monitor': 'Portfolio Monitor',
+  'garden-calendar': 'Garden Calendar',
+  'email-campaign': 'Email Campaign',
+  'social-engagement': 'Social Engagement',
+  'security-monitor': 'Security Monitor',
+  'drive-watcher': 'Drive Watcher',
+  'invoice-generator': 'Invoice Generator',
+  'meeting-transcriber': 'Meeting Transcriber',
+}
+
+/** Audit log actions that map to settings_change events. */
+const SETTINGS_ACTIONS = new Set([
+  'settings.updated',
+  'agent.toggled',
+  'model.toggled',
+  'mode.changed',
+])
+
+/** Audit log actions that map to backup events. */
+const BACKUP_ACTIONS = new Set([
+  'backup.created',
+  'backup.restored',
+  'backup.restore_rollback',
+])
+
+/** Audit log actions that map to system events. */
+const SYSTEM_ACTIONS = new Set([
+  'service.restart_requested',
+  'service.restart_failed',
+])
+
+/** Audit log actions already covered by the approvals table (skip). */
+const APPROVAL_AUDIT_ACTIONS = new Set([
+  'approval.approved',
+  'approval.rejected',
+])
+
+/** Classify an audit_log action into a history event type, or null to skip. */
+function classifyAuditAction(action: string): string | null {
+  if (APPROVAL_AUDIT_ACTIONS.has(action)) return null
+  if (SETTINGS_ACTIONS.has(action)) return 'settings_change'
+  if (BACKUP_ACTIONS.has(action)) return 'backup'
+  if (SYSTEM_ACTIONS.has(action)) return 'system'
+  return 'system' // default bucket for unrecognized audit entries
+}
+
+/** Map a run status to a normalized history event status. */
+function runStatusToEventStatus(status: string): string {
+  switch (status) {
+    case 'completed': return 'completed'
+    case 'failed': return 'failed'
+    case 'cancelled': return 'failed'
+    case 'queued':
+    case 'planning':
+    case 'executing':
+    case 'awaiting_approval': return 'pending'
+    default: return status
+  }
+}
+
+/** Map an approval status to a normalized history event status. */
+function approvalStatusToEventStatus(status: string): string {
+  switch (status) {
+    case 'approved': return 'completed'
+    case 'rejected':
+    case 'expired': return 'failed'
+    case 'pending': return 'pending'
+    default: return status
+  }
+}
+
+interface HistoryEvent {
+  id: string
+  type: string
+  title: string
+  subtitle?: string
+  status: string
+  source: string
+  timestamp: string
+  agent_id?: string
+  run_id?: string
+  approval_id?: string
+  outcome?: string
+  payload?: Record<string, unknown>
+}
+
+interface HistoryQueryParams {
+  type?: string
+  status?: string
+  limit?: string
+  offset?: string
+  since?: string
+  agent?: string
+}
+
+export const historyRouter = Router()
+
+// GET / — unified timeline across runs, approvals, and audit_log
+historyRouter.get('/', (req, res) => {
+  const {
+    type = 'all',
+    status = 'all',
+    limit: limitStr = '50',
+    offset: offsetStr = '0',
+    since,
+    agent,
+  } = req.query as HistoryQueryParams
+
+  const limit = Math.min(Math.max(1, Number(limitStr) || 50), 200)
+  const offset = Math.max(0, Number(offsetStr) || 0)
+
+  let db: DatabaseSync | undefined
+  try {
+    db = getRuntimeDb()
+
+    // Build UNION ALL query across the three tables.
+    // Each sub-select emits a common set of columns:
+    //   id, event_type, agent_id, run_id, approval_id, title, subtitle, status, source, timestamp, payload_json
+    const unions: string[] = []
+    const params: SQLInputValue[] = []
+
+    // Determine which event types to include
+    const includeRuns = type === 'all' || type === 'run'
+    const includeApprovals = type === 'all' || type === 'approval'
+    const includeAudit = type === 'all' || type === 'settings_change' || type === 'backup' || type === 'system'
+
+    // --- runs ---
+    if (includeRuns) {
+      let runWhere = '1=1'
+      if (since) {
+        runWhere += ' AND r.started_at >= ?'
+        params.push(since)
+      }
+      if (agent && agent !== 'all') {
+        runWhere += ' AND r.agent_id = ?'
+        params.push(agent)
+      }
+      unions.push(`
+        SELECT
+          r.run_id AS id,
+          'run' AS event_type,
+          r.agent_id,
+          r.run_id,
+          NULL AS approval_id,
+          r.agent_id AS title_key,
+          r.goal AS subtitle,
+          r.status AS raw_status,
+          COALESCE(r.trigger_kind, 'manual') AS source,
+          r.started_at AS timestamp,
+          NULL AS payload_json,
+          r.error AS error_text,
+          NULL AS action_text,
+          NULL AS severity_text,
+          NULL AS resolved_by_text
+        FROM runs r
+        WHERE ${runWhere}
+      `)
+    }
+
+    // --- approvals ---
+    if (includeApprovals) {
+      let apprWhere = '1=1'
+      if (since) {
+        apprWhere += ' AND a.requested_at >= ?'
+        params.push(since)
+      }
+      if (agent && agent !== 'all') {
+        apprWhere += ' AND a.agent_id = ?'
+        params.push(agent)
+      }
+      unions.push(`
+        SELECT
+          a.approval_id AS id,
+          'approval' AS event_type,
+          a.agent_id,
+          a.run_id,
+          a.approval_id,
+          a.action AS title_key,
+          NULL AS subtitle,
+          a.status AS raw_status,
+          'agent' AS source,
+          a.requested_at AS timestamp,
+          NULL AS payload_json,
+          NULL AS error_text,
+          a.action AS action_text,
+          a.severity AS severity_text,
+          a.resolved_by AS resolved_by_text
+        FROM approvals a
+        WHERE ${apprWhere}
+      `)
+    }
+
+    // --- audit_log ---
+    if (includeAudit) {
+      let auditWhere = '1=1'
+      if (since) {
+        auditWhere += ' AND al.created_at >= ?'
+        params.push(since)
+      }
+      // Filter out approval-related audit entries (already covered by approvals table)
+      auditWhere += " AND al.action NOT IN ('approval.approved', 'approval.rejected')"
+
+      // If a specific audit sub-type is requested, filter to those actions
+      if (type === 'settings_change') {
+        const placeholders = [...SETTINGS_ACTIONS].map(() => '?').join(',')
+        auditWhere += ` AND al.action IN (${placeholders})`
+        params.push(...SETTINGS_ACTIONS)
+      } else if (type === 'backup') {
+        const placeholders = [...BACKUP_ACTIONS].map(() => '?').join(',')
+        auditWhere += ` AND al.action IN (${placeholders})`
+        params.push(...BACKUP_ACTIONS)
+      } else if (type === 'system') {
+        const placeholders = [...SYSTEM_ACTIONS].map(() => '?').join(',')
+        auditWhere += ` AND al.action IN (${placeholders})`
+        params.push(...SYSTEM_ACTIONS)
+      }
+
+      // Agent filter doesn't apply to audit_log entries (they don't have agent_id)
+      // but we can filter by actor_id if agent is specified
+      if (agent && agent !== 'all') {
+        auditWhere += ' AND al.actor_id = ?'
+        params.push(agent)
+      }
+
+      unions.push(`
+        SELECT
+          al.audit_id AS id,
+          al.action AS event_type,
+          al.actor_id AS agent_id,
+          NULL AS run_id,
+          NULL AS approval_id,
+          al.action AS title_key,
+          al.target_type AS subtitle,
+          'completed' AS raw_status,
+          COALESCE(al.actor_type, 'system') AS source,
+          al.created_at AS timestamp,
+          al.payload_json,
+          NULL AS error_text,
+          al.action AS action_text,
+          NULL AS severity_text,
+          NULL AS resolved_by_text
+        FROM audit_log al
+        WHERE ${auditWhere}
+      `)
+    }
+
+    if (unions.length === 0) {
+      res.json({ events: [], total: 0, has_more: false })
+      return
+    }
+
+    const unionQuery = unions.join(' UNION ALL ')
+
+    // Count total matching rows (before pagination)
+    const countSql = `SELECT COUNT(*) AS total FROM (${unionQuery})`
+    const totalRow = db.prepare(countSql).get(...params) as { total: number }
+    const total = totalRow.total
+
+    // Fetch paginated results
+    const dataSql = `SELECT * FROM (${unionQuery}) ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+    const dataParams = [...params, limit, offset]
+    const rows = db.prepare(dataSql).all(...dataParams) as Array<{
+      id: string
+      event_type: string
+      agent_id: string | null
+      run_id: string | null
+      approval_id: string | null
+      title_key: string | null
+      subtitle: string | null
+      raw_status: string
+      source: string
+      timestamp: string
+      payload_json: string | null
+      error_text: string | null
+      action_text: string | null
+      severity_text: string | null
+      resolved_by_text: string | null
+    }>
+
+    // Transform rows into HistoryEvent objects
+    const events: HistoryEvent[] = []
+    for (const row of rows) {
+      // Determine the normalized type for audit_log entries
+      let eventType = row.event_type
+      if (eventType !== 'run' && eventType !== 'approval') {
+        const classified = classifyAuditAction(eventType)
+        if (classified === null) continue // skip approval-related audit entries
+        eventType = classified
+      }
+
+      // Apply type filter for the 'all' case (audit sub-types are already filtered in SQL for specific types)
+      if (type !== 'all' && eventType !== type) continue
+
+      // Build title
+      let title: string
+      if (eventType === 'run') {
+        const agentLabel = AGENT_LABELS[row.title_key ?? ''] ?? row.title_key ?? 'Unknown Agent'
+        const goal = row.subtitle
+        title = goal ? `${agentLabel}: ${goal}` : agentLabel
+      } else if (eventType === 'approval') {
+        title = `Approval: ${row.action_text ?? 'unknown action'}`
+      } else {
+        // audit_log-based events: use a human-readable title from the action
+        title = formatAuditTitle(row.event_type, row.title_key)
+      }
+
+      // Normalize status
+      let eventStatus: string
+      if (eventType === 'run') {
+        eventStatus = runStatusToEventStatus(row.raw_status)
+      } else if (eventType === 'approval') {
+        eventStatus = approvalStatusToEventStatus(row.raw_status)
+      } else {
+        eventStatus = 'completed' // audit entries are always completed facts
+      }
+
+      // Apply status filter
+      if (status !== 'all' && eventStatus !== status) continue
+
+      // Build the event
+      const event: HistoryEvent = {
+        id: row.id,
+        type: eventType,
+        title,
+        status: eventStatus,
+        source: row.source,
+        timestamp: row.timestamp,
+      }
+
+      // Optional fields
+      if (row.subtitle && eventType === 'run') {
+        event.subtitle = row.subtitle
+      } else if (eventType === 'approval' && row.severity_text) {
+        event.subtitle = `Severity: ${row.severity_text}`
+        if (row.resolved_by_text) {
+          event.subtitle += ` | Resolved by: ${row.resolved_by_text}`
+        }
+      } else if (row.subtitle && eventType !== 'run') {
+        event.subtitle = row.subtitle
+      }
+
+      if (row.agent_id) event.agent_id = row.agent_id
+      if (row.run_id) event.run_id = row.run_id
+      if (row.approval_id) event.approval_id = row.approval_id
+
+      // Outcome
+      if (eventType === 'run') {
+        event.outcome = row.error_text
+          ? `Failed: ${row.error_text}`
+          : row.raw_status === 'completed' ? 'Completed successfully' : undefined
+      } else if (eventType === 'approval') {
+        event.outcome = row.raw_status === 'approved' ? 'Approved'
+          : row.raw_status === 'rejected' ? 'Rejected'
+          : row.raw_status === 'expired' ? 'Expired'
+          : undefined
+      }
+
+      // Payload (only for audit_log events that carry data)
+      if (row.payload_json) {
+        try {
+          event.payload = JSON.parse(row.payload_json) as Record<string, unknown>
+        } catch { /* skip unparseable payloads */ }
+      }
+
+      events.push(event)
+    }
+
+    res.json({
+      events,
+      total,
+      has_more: offset + limit < total,
+    })
+  } catch {
+    res.json({ events: [], total: 0, has_more: false })
+  } finally {
+    try { db?.close() } catch { /* best-effort */ }
+  }
+})
+
+/** Format an audit_log action into a human-readable title. */
+function formatAuditTitle(action: string, titleKey: string | null): string {
+  switch (action) {
+    case 'settings.updated': return 'Settings updated'
+    case 'agent.toggled': return `Agent toggled: ${titleKey ?? 'unknown'}`
+    case 'model.toggled': return `Model toggled: ${titleKey ?? 'unknown'}`
+    case 'mode.changed': return 'Operating mode changed'
+    case 'backup.created': return 'Backup created'
+    case 'backup.restored': return 'Backup restored'
+    case 'backup.restore_rollback': return 'Backup restore rolled back'
+    case 'service.restart_requested': return 'Service restart requested'
+    case 'service.restart_failed': return 'Service restart failed'
+    default: return action.replace(/[._]/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+  }
+}

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -21,6 +21,7 @@ import { modelsRouter } from './models.js'
 import { queueRouter } from './queue.js'
 import { policyRouter } from './policy.js'
 import { workflowsRouter } from './workflows.js'
+import { historyRouter } from './history.js'
 import { packsRouter } from './packs.js'
 import { serviceRouter } from './service.js'
 import { supportRouter } from './support.js'
@@ -81,6 +82,7 @@ app.use('/api/models', modelsRouter)
 app.use('/api/queue', queueRouter)
 app.use('/api/policy', policyRouter)
 app.use('/api/workflows', workflowsRouter)
+app.use('/api/history', historyRouter)
 app.use('/api/packs', packsRouter)
 app.use('/api/service', serviceRouter)
 app.use('/api/support', supportRouter)

--- a/packages/jarvis-dashboard/src/ui/App.tsx
+++ b/packages/jarvis-dashboard/src/ui/App.tsx
@@ -1,202 +1,80 @@
-import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { BrowserRouter, Routes, Route, NavLink, Navigate } from 'react-router-dom'
+import { useEffect } from 'react'
 import Home from './pages/Home.tsx'
+import Workflows from './pages/Workflows.tsx'
+import Inbox from './pages/Inbox.tsx'
+import History from './pages/History.tsx'
+import System from './pages/System.tsx'
+import Settings from './pages/Settings.tsx'
+import Recovery from './pages/Recovery.tsx'
+import Runs from './pages/Runs.tsx'
+import Models from './pages/Models.tsx'
+import Queue from './pages/Queue.tsx'
+import Support from './pages/Support.tsx'
+import Godmode from './pages/Godmode.tsx'
 import CrmPipeline from './pages/CrmPipeline.tsx'
+import CrmAnalytics from './pages/CrmAnalytics.tsx'
 import KnowledgeBase from './pages/KnowledgeBase.tsx'
 import Decisions from './pages/Decisions.tsx'
 import Schedule from './pages/Schedule.tsx'
 import Plugins from './pages/Plugins.tsx'
 import Portal from './pages/Portal.tsx'
-import RunTimeline from './pages/RunTimeline.tsx'
 import EntityGraph from './pages/EntityGraph.tsx'
-import CrmAnalytics from './pages/CrmAnalytics.tsx'
-import Settings from './pages/Settings.tsx'
-import Godmode from './pages/Godmode.tsx'
-import Approvals from './pages/Approvals.tsx'
 import { ModeProvider, useMode } from './context/ModeContext.tsx'
+import { useDashboardStore } from './stores/dashboard-store.ts'
+import {
+  IconHome, IconWorkflow, IconInbox, IconHistory, IconSystem, IconSettings,
+  IconRecovery, IconGodmode, IconRuns, IconModels, IconQueue, IconSupport,
+  IconCrm, IconKnowledge, IconDecisions, IconSchedule, IconPlugins, IconGraph, IconAnalytics,
+} from './shared/icons.tsx'
 
-interface HealthData {
-  pendingApprovals?: number
+/* ── Navigation configuration ────────────────────────────── */
+
+interface NavItem {
+  to: string
+  label: string
+  icon: () => React.JSX.Element
+  simple: boolean
+  badge?: boolean
+  end?: boolean
+  section?: 'main' | 'expert' | 'legacy'
 }
 
-interface AttentionSummary {
-  needs_attention: { pending_approvals: number; failed_runs: number; overdue_schedules: number }
-  system_status: string // "healthy" | "needs_attention" | "unknown"
-}
+const NAV_ITEMS: NavItem[] = [
+  // Simple mode — core operating loop
+  { to: '/', label: 'Home', icon: IconHome, simple: true, end: true, section: 'main' },
+  { to: '/workflows', label: 'Workflows', icon: IconWorkflow, simple: true, section: 'main' },
+  { to: '/inbox', label: 'Inbox', icon: IconInbox, simple: true, badge: true, section: 'main' },
+  { to: '/history', label: 'History', icon: IconHistory, simple: true, section: 'main' },
+  { to: '/system', label: 'System', icon: IconSystem, simple: true, section: 'main' },
 
-type SystemHealth = 'healthy' | 'needs_attention' | 'offline'
+  // Expert mode — deeper visibility
+  { to: '/godmode', label: 'Godmode', icon: IconGodmode, simple: false, section: 'expert' },
+  { to: '/runs', label: 'Runs', icon: IconRuns, simple: false, section: 'expert' },
+  { to: '/models', label: 'Models', icon: IconModels, simple: false, section: 'expert' },
+  { to: '/queue', label: 'Queue', icon: IconQueue, simple: false, section: 'expert' },
+  { to: '/support', label: 'Support', icon: IconSupport, simple: false, section: 'expert' },
 
-/* ── SVG Icon Components ─────────────────────────────────── */
+  // Expert — legacy pages moved from simple mode
+  { to: '/crm', label: 'CRM Pipeline', icon: IconCrm, simple: false, section: 'legacy' },
+  { to: '/crm/analytics', label: 'CRM Analytics', icon: IconAnalytics, simple: false, section: 'legacy' },
+  { to: '/knowledge', label: 'Knowledge Base', icon: IconKnowledge, simple: false, section: 'legacy' },
+  { to: '/decisions', label: 'Decisions', icon: IconDecisions, simple: false, section: 'legacy' },
+  { to: '/schedule', label: 'Schedule', icon: IconSchedule, simple: false, section: 'legacy' },
+  { to: '/plugins', label: 'Plugins', icon: IconPlugins, simple: false, section: 'legacy' },
+  { to: '/graph', label: 'Entity Graph', icon: IconGraph, simple: false, section: 'legacy' },
+]
 
-function IconGodmode() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M10 2L3 7v6l7 5 7-5V7z" />
-      <circle cx="10" cy="10" r="3" />
-      <path d="M10 7v6M7 10h6" />
-    </svg>
-  )
-}
-
-function IconHome() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M3 10.5L10 4l7 6.5" />
-      <path d="M5 9.5V16a1 1 0 001 1h3v-4h2v4h3a1 1 0 001-1V9.5" />
-    </svg>
-  )
-}
-
-function IconCrm() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="2" y="3" width="16" height="14" rx="2" />
-      <path d="M2 7h16" />
-      <path d="M7 7v10" />
-    </svg>
-  )
-}
-
-function IconKnowledge() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 4h4l2 2h6a1 1 0 011 1v8a1 1 0 01-1 1H4a1 1 0 01-1-1V5a1 1 0 011-1z" />
-    </svg>
-  )
-}
-
-function IconDecisions() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M10 3v14" />
-      <path d="M3 10h14" />
-      <circle cx="10" cy="10" r="7" />
-    </svg>
-  )
-}
-
-function IconSchedule() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="4" width="14" height="13" rx="2" />
-      <path d="M3 8h14" />
-      <path d="M7 2v4M13 2v4" />
-    </svg>
-  )
-}
-
-function IconPlugins() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M8 3v3M12 3v3" />
-      <rect x="4" y="6" width="12" height="11" rx="2" />
-      <path d="M8 17v-3h4v3" />
-    </svg>
-  )
-}
-
-function IconRuns() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M3 10h2l2-5 3 10 2-5h5" />
-    </svg>
-  )
-}
-
-function IconGraph() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="10" cy="5" r="2" />
-      <circle cx="5" cy="14" r="2" />
-      <circle cx="15" cy="14" r="2" />
-      <path d="M10 7v3M8.5 11.5L6.5 12.5M11.5 11.5l2 1" />
-    </svg>
-  )
-}
-
-function IconAnalytics() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M5 16V10M10 16V6M15 16V3" />
-    </svg>
-  )
-}
-
-function IconSettings() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="10" cy="10" r="3" />
-      <path d="M10 2v2M10 16v2M3.5 5.5l1.4 1.4M15.1 13.1l1.4 1.4M2 10h2M16 10h2M3.5 14.5l1.4-1.4M15.1 6.9l1.4-1.4" />
-    </svg>
-  )
-}
-
-/* ── Navigation item config ──────────────────────────────── */
-
-const NAV_ITEMS = [
-  { to: '/godmode', label: 'Godmode', icon: IconGodmode, simple: false },
-  { to: '/', end: true, label: 'Home', icon: IconHome, simple: true },
-  { to: '/crm', label: 'CRM Pipeline', icon: IconCrm, simple: false },
-  { to: '/knowledge', label: 'Knowledge Base', icon: IconKnowledge, simple: false },
-  { to: '/decisions', label: 'Decisions', icon: IconDecisions, simple: false },
-  { to: '/approvals', label: 'Approvals', icon: IconSchedule, badge: true, simple: true },
-  { to: '/schedule', label: 'Schedule', icon: IconSchedule, simple: true },
-  { to: '/plugins', label: 'Plugins', icon: IconPlugins, simple: false },
-  { to: '/runs', label: 'Run Timeline', icon: IconRuns, simple: true },
-  { to: '/graph', label: 'Entity Graph', icon: IconGraph, simple: false },
-  { to: '/crm/analytics', label: 'CRM Analytics', icon: IconAnalytics, simple: false },
-] as const
-
-/* ── App Shell (uses mode context) ───────────────────────── */
+/* ── App Shell ───────────────────────────────────────────── */
 
 function AppShell() {
-  const [pendingApprovals, setPendingApprovals] = useState(0)
-  const [systemHealth, setSystemHealth] = useState<SystemHealth>('offline')
-  const [systemLabel, setSystemLabel] = useState('Connecting...')
   const { mode, setMode } = useMode()
-  const healthIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-
-  const fetchSystemState = useCallback(() => {
-    Promise.all([
-      fetch('/api/health').then(r => r.json()).catch(() => null),
-      fetch('/api/attention').then(r => r.json()).catch(() => null),
-    ]).then(([healthData, attentionData]: [HealthData | null, AttentionSummary | null]) => {
-      if (healthData) {
-        setPendingApprovals(healthData.pendingApprovals ?? 0)
-      }
-
-      if (!attentionData) {
-        setSystemHealth('offline')
-        setSystemLabel('Offline')
-        return
-      }
-
-      const status = attentionData.system_status
-      if (status === 'needs_attention') {
-        setSystemHealth('needs_attention')
-        const attn = attentionData.needs_attention
-        const parts: string[] = []
-        if (attn.pending_approvals > 0) parts.push(`${attn.pending_approvals} approval${attn.pending_approvals !== 1 ? 's' : ''}`)
-        if (attn.failed_runs > 0) parts.push(`${attn.failed_runs} failure${attn.failed_runs !== 1 ? 's' : ''}`)
-        if (attn.overdue_schedules > 0) parts.push(`${attn.overdue_schedules} overdue`)
-        setSystemLabel(parts.length > 0 ? parts.join(', ') : 'Needs attention')
-      } else if (status === 'healthy') {
-        setSystemHealth('healthy')
-        setSystemLabel('Healthy')
-      } else {
-        setSystemHealth('offline')
-        setSystemLabel('Offline')
-      }
-    })
-  }, [])
+  const { systemHealth, pendingApprovals, safeMode, startPolling, stopPolling } = useDashboardStore()
 
   useEffect(() => {
-    fetchSystemState()
-    healthIntervalRef.current = setInterval(fetchSystemState, 15_000)
-    return () => {
-      if (healthIntervalRef.current) clearInterval(healthIntervalRef.current)
-    }
-  }, [fetchSystemState])
+    startPolling(10_000)
+    return stopPolling
+  }, [startPolling, stopPolling])
 
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer ${
@@ -205,25 +83,41 @@ function AppShell() {
         : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800/50'
     }`
 
-  const filteredNavItems = mode === 'simple'
+  // Filter nav items by mode
+  const visibleItems = mode === 'simple'
     ? NAV_ITEMS.filter(item => item.simple)
     : NAV_ITEMS
 
+  // Group expert items for visual separation
+  const mainItems = visibleItems.filter(i => i.section === 'main')
+  const expertItems = visibleItems.filter(i => i.section === 'expert')
+  const legacyItems = visibleItems.filter(i => i.section === 'legacy')
+
+  const showRecovery = safeMode?.safe_mode_recommended
+
+  // System health label
+  const healthLabel = systemHealth === 'healthy'
+    ? 'Healthy'
+    : systemHealth === 'needs_attention'
+      ? `${pendingApprovals > 0 ? `${pendingApprovals} approval${pendingApprovals !== 1 ? 's' : ''}` : 'Needs attention'}`
+      : 'Offline'
+
   return (
     <div className="flex h-screen bg-[#030712] text-slate-100 overflow-hidden font-sans">
-      {/* ── Sidebar ────────────────────────────────────── */}
+      {/* ── Sidebar ──────────────────────────────────────── */}
       <aside className="w-60 shrink-0 bg-[#0f172a] border-r border-white/5 flex flex-col">
         {/* Logo */}
         <div className="px-5 py-5 border-b border-white/5">
           <h1 className="text-xl font-bold tracking-tight bg-gradient-to-r from-indigo-400 via-purple-400 to-indigo-300 bg-clip-text text-transparent">
             Jarvis
           </h1>
-          <p className="text-xs text-slate-500 mt-0.5 font-medium">Autonomous Agent System</p>
+          <p className="text-xs text-slate-500 mt-0.5 font-medium">Operations Console</p>
         </div>
 
         {/* Nav Items */}
         <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
-          {filteredNavItems.map(item => {
+          {/* Main operating loop */}
+          {mainItems.map(item => {
             const Icon = item.icon
             return (
               <NavLink key={item.to} to={item.to} end={item.end ?? false} className={navLinkClass}>
@@ -237,14 +131,55 @@ function AppShell() {
               </NavLink>
             )
           })}
+
+          {/* Recovery — shown when safe mode is active */}
+          {showRecovery && (
+            <NavLink to="/recovery" className={navLinkClass}>
+              <IconRecovery />
+              <span className="flex-1 truncate">Recovery</span>
+              <span className="bg-red-500/90 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full">!</span>
+            </NavLink>
+          )}
+
+          {/* Expert mode sections */}
+          {expertItems.length > 0 && (
+            <>
+              <div className="pt-4 pb-1 px-3">
+                <span className="text-[10px] text-slate-600 uppercase tracking-wider font-medium">Expert</span>
+              </div>
+              {expertItems.map(item => {
+                const Icon = item.icon
+                return (
+                  <NavLink key={item.to} to={item.to} end={item.end ?? false} className={navLinkClass}>
+                    <Icon />
+                    <span className="flex-1 truncate">{item.label}</span>
+                  </NavLink>
+                )
+              })}
+            </>
+          )}
+
+          {legacyItems.length > 0 && (
+            <>
+              <div className="pt-4 pb-1 px-3">
+                <span className="text-[10px] text-slate-600 uppercase tracking-wider font-medium">Data</span>
+              </div>
+              {legacyItems.map(item => {
+                const Icon = item.icon
+                return (
+                  <NavLink key={item.to} to={item.to} end={item.end ?? false} className={navLinkClass}>
+                    <Icon />
+                    <span className="flex-1 truncate">{item.label}</span>
+                  </NavLink>
+                )
+              })}
+            </>
+          )}
         </nav>
 
         {/* Bottom section */}
         <div className="px-4 py-4 border-t border-white/5">
-          <NavLink
-            to="/settings"
-            className={navLinkClass}
-          >
+          <NavLink to="/settings" className={navLinkClass}>
             <IconSettings />
             <span className="flex-1">Settings</span>
           </NavLink>
@@ -278,7 +213,7 @@ function AppShell() {
                   ? 'text-amber-400/80'
                   : 'text-slate-600'
             }`}>
-              {systemLabel}
+              {healthLabel}
             </span>
           </div>
           <div className="mt-2 px-1">
@@ -288,29 +223,44 @@ function AppShell() {
         </div>
       </aside>
 
-      {/* ── Main content ───────────────────────────────── */}
+      {/* ── Main content ─────────────────────────────────── */}
       <main className="flex-1 overflow-y-auto bg-[#030712]">
         <Routes>
-          <Route path="/godmode" element={<Godmode />} />
-          <Route path="/approvals" element={<Approvals />} />
+          {/* Core operating loop */}
           <Route path="/" element={<Home />} />
+          <Route path="/workflows" element={<Workflows />} />
+          <Route path="/inbox" element={<Inbox />} />
+          <Route path="/history" element={<History />} />
+          <Route path="/system" element={<System />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/recovery" element={<Recovery />} />
+
+          {/* Expert pages */}
+          <Route path="/godmode" element={<Godmode />} />
+          <Route path="/runs" element={<Runs />} />
+          <Route path="/models" element={<Models />} />
+          <Route path="/queue" element={<Queue />} />
+          <Route path="/support" element={<Support />} />
+
+          {/* Legacy/Data pages (expert mode) */}
           <Route path="/crm" element={<CrmPipeline />} />
+          <Route path="/crm/analytics" element={<CrmAnalytics />} />
           <Route path="/knowledge" element={<KnowledgeBase />} />
           <Route path="/decisions" element={<Decisions />} />
           <Route path="/schedule" element={<Schedule />} />
           <Route path="/plugins" element={<Plugins />} />
-          <Route path="/portal" element={<Portal />} />
-          <Route path="/runs" element={<RunTimeline />} />
           <Route path="/graph" element={<EntityGraph />} />
-          <Route path="/crm/analytics" element={<CrmAnalytics />} />
-          <Route path="/settings" element={<Settings />} />
+          <Route path="/portal" element={<Portal />} />
+
+          {/* Redirects for old routes */}
+          <Route path="/approvals" element={<Navigate to="/inbox" replace />} />
         </Routes>
       </main>
     </div>
   )
 }
 
-/* ── App Component (wraps everything in providers) ──────── */
+/* ── App Component ───────────────────────────────────────── */
 
 export default function App() {
   return (

--- a/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
+++ b/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -7,22 +7,64 @@ interface Message {
   error?: boolean
 }
 
-// ─── Persistent state helpers (survives page navigation, clears on tab close) ──
-const STORAGE_KEY = 'jarvis-chat'
+interface ChatSession {
+  id: string
+  title: string
+  messages: Message[]
+  model: string
+  createdAt: string
+  updatedAt: string
+}
 
-function loadChatState(): { messages: Message[]; model: string; input: string } {
+// ─── Persistent state helpers ───────────────────────────────
+const SESSIONS_KEY = 'jarvis-chat-sessions'
+const ACTIVE_KEY = 'jarvis-chat-active'
+
+function loadSessions(): ChatSession[] {
   try {
-    const raw = sessionStorage.getItem(STORAGE_KEY)
-    if (raw) return JSON.parse(raw) as { messages: Message[]; model: string; input: string }
+    const raw = localStorage.getItem(SESSIONS_KEY)
+    if (raw) return JSON.parse(raw) as ChatSession[]
   } catch { /* ignore */ }
-  return { messages: [], model: '', input: '' }
+  return []
 }
 
-function saveChatState(messages: Message[], model: string, input: string): void {
+function saveSessions(sessions: ChatSession[]): void {
   try {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ messages, model, input }))
-  } catch { /* storage full or unavailable */ }
+    localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions))
+  } catch { /* storage full */ }
 }
+
+function loadActiveId(): string | null {
+  try { return localStorage.getItem(ACTIVE_KEY) } catch { return null }
+}
+
+function saveActiveId(id: string): void {
+  try { localStorage.setItem(ACTIVE_KEY, id) } catch { /* ignore */ }
+}
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6)
+}
+
+function deriveTitle(messages: Message[]): string {
+  const firstUser = messages.find(m => m.role === 'user')
+  if (!firstUser) return 'New chat'
+  const text = firstUser.content.trim()
+  return text.length > 50 ? text.slice(0, 47) + '...' : text
+}
+
+function timeLabel(iso: string): string {
+  const d = new Date(iso)
+  const now = new Date()
+  const diff = now.getTime() - d.getTime()
+  if (diff < 60_000) return 'Just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  if (diff < 172_800_000) return 'Yesterday'
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
+// ─── Message Bubble ─────────────────────────────────────────
 
 function MessageBubble({ msg, isLast, streaming }: { msg: Message; isLast: boolean; streaming: boolean }) {
   const [showThinking, setShowThinking] = useState(false)
@@ -31,7 +73,6 @@ function MessageBubble({ msg, isLast, streaming }: { msg: Message; isLast: boole
 
   return (
     <div className={`flex flex-col ${msg.role === 'user' ? 'items-end' : 'items-start'} gap-1`}>
-      {/* Thinking block -- only for assistant messages with reasoning_content */}
       {msg.role === 'assistant' && msg.thinking && (
         <div className="max-w-[85%] w-full">
           <button
@@ -51,7 +92,6 @@ function MessageBubble({ msg, isLast, streaming }: { msg: Message; isLast: boole
         </div>
       )}
 
-      {/* Main message bubble */}
       <div className={`max-w-[85%] rounded-xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap ${
         msg.role === 'user'
           ? 'bg-indigo-600 text-white rounded-br-md'
@@ -62,7 +102,7 @@ function MessageBubble({ msg, isLast, streaming }: { msg: Message; isLast: boole
         {msg.content
           ? msg.content
           : isThinking
-          ? null  // show nothing in bubble while thinking (thinking block above handles it)
+          ? null
           : isStreaming
           ? <span className="inline-flex gap-1.5 items-center text-slate-500">
               <span className="animate-pulse">&#9679;</span>
@@ -83,48 +123,123 @@ const QUICK_PROMPTS = [
   'What lessons have been captured so far?',
 ]
 
+// ─── Main Component ─────────────────────────────────────────
+
 export default function JarvisChat() {
-  const saved = loadChatState()
-  const [messages, setMessages] = useState<Message[]>(saved.messages)
-  const [input, setInput] = useState(saved.input)
+  const [sessions, setSessions] = useState<ChatSession[]>(loadSessions)
+  const [activeId, setActiveId] = useState<string | null>(loadActiveId)
+  const [showHistory, setShowHistory] = useState(false)
+  const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
-  const [model, setModel] = useState(saved.model || 'qwen/qwen3.5-35b-a3b')
+  const [model, setModel] = useState('qwen/qwen3.5-35b-a3b')
   const [models, setModels] = useState<string[]>([])
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  // Persist chat state whenever messages, model, or input change
-  useEffect(() => {
-    if (!streaming) saveChatState(messages, model, input)
-  }, [messages, model, input, streaming])
+  const activeSession = sessions.find(s => s.id === activeId) ?? null
+  const messages = activeSession?.messages ?? []
 
+  // Persist
+  useEffect(() => {
+    if (!streaming) saveSessions(sessions)
+  }, [sessions, streaming])
+
+  useEffect(() => {
+    if (activeId) saveActiveId(activeId)
+  }, [activeId])
+
+  // Load models
   useEffect(() => {
     fetch('/api/chat/models')
       .then(r => r.json())
       .then((d: { models: string[]; default: string }) => {
         if (d.models.length) setModels(d.models)
-        // Only set default model if no saved model preference
-        if (d.default && !saved.model) setModel(d.default)
+        if (d.default) setModel(d.default)
       })
       .catch(() => {})
   }, [])
 
+  // Auto-scroll
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
+
+  const updateActiveMessages = useCallback((updater: (msgs: Message[]) => Message[]) => {
+    setSessions(prev => prev.map(s =>
+      s.id === activeId
+        ? { ...s, messages: updater(s.messages), title: deriveTitle(updater(s.messages)), updatedAt: new Date().toISOString() }
+        : s
+    ))
+  }, [activeId])
+
+  const startNewSession = useCallback(() => {
+    const newSession: ChatSession = {
+      id: generateId(),
+      title: 'New chat',
+      messages: [],
+      model,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    setSessions(prev => [newSession, ...prev])
+    setActiveId(newSession.id)
+    setInput('')
+    inputRef.current?.focus()
+  }, [model])
+
+  const switchSession = useCallback((id: string) => {
+    setActiveId(id)
+    setShowHistory(false)
+    const session = sessions.find(s => s.id === id)
+    if (session) setModel(session.model)
+  }, [sessions])
+
+  const deleteSession = useCallback((id: string) => {
+    setSessions(prev => prev.filter(s => s.id !== id))
+    if (activeId === id) {
+      const remaining = sessions.filter(s => s.id !== id)
+      setActiveId(remaining.length > 0 ? remaining[0].id : null)
+    }
+  }, [activeId, sessions])
 
   const send = async (text: string) => {
     const trimmed = text.trim()
     if (!trimmed || streaming) return
     setInput('')
 
+    // Create session if none active
+    if (!activeId) {
+      const newSession: ChatSession = {
+        id: generateId(),
+        title: trimmed.length > 50 ? trimmed.slice(0, 47) + '...' : trimmed,
+        messages: [],
+        model,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }
+      setSessions(prev => [newSession, ...prev])
+      setActiveId(newSession.id)
+      // We need to wait a tick for state to settle, so use the ID directly
+      await sendToSession(newSession.id, trimmed, [])
+      return
+    }
+
+    await sendToSession(activeId, trimmed, messages)
+  }
+
+  const sendToSession = async (sessionId: string, trimmed: string, currentMessages: Message[]) => {
     const userMsg: Message = { role: 'user', content: trimmed }
     const assistantMsg: Message = { role: 'assistant', content: '' }
-    setMessages(prev => [...prev, userMsg, assistantMsg])
+    const newMessages = [...currentMessages, userMsg, assistantMsg]
+
+    setSessions(prev => prev.map(s =>
+      s.id === sessionId
+        ? { ...s, messages: newMessages, title: deriveTitle(newMessages), updatedAt: new Date().toISOString() }
+        : s
+    ))
     setStreaming(true)
 
-    // Build history from existing messages (exclude the blank assistant we just pushed)
-    const history = messages.map(m => ({ role: m.role, content: m.content }))
+    const history = currentMessages.map(m => ({ role: m.role, content: m.content }))
 
     try {
       const res = await fetch('/api/chat', {
@@ -152,49 +267,44 @@ export default function JarvisChat() {
           const data = line.slice(6)
           if (data === '[DONE]') continue
           try {
-            const parsed = JSON.parse(data) as { token?: string; error?: string }
-            const p = parsed as { token?: string; thinking?: string; error?: string }
+            const p = JSON.parse(data) as { token?: string; thinking?: string; error?: string }
             if (p.error) {
-              setMessages(prev => {
-                const updated = [...prev]
-                const last = updated[updated.length - 1]
-                if (last?.role === 'assistant') {
-                  updated[updated.length - 1] = { ...last, content: p.error!, error: true }
-                }
-                return updated
-              })
+              setSessions(prev => prev.map(s => {
+                if (s.id !== sessionId) return s
+                const msgs = [...s.messages]
+                const last = msgs[msgs.length - 1]
+                if (last?.role === 'assistant') msgs[msgs.length - 1] = { ...last, content: p.error!, error: true }
+                return { ...s, messages: msgs, updatedAt: new Date().toISOString() }
+              }))
             } else if (p.thinking) {
-              setMessages(prev => {
-                const updated = [...prev]
-                const last = updated[updated.length - 1]
-                if (last?.role === 'assistant') {
-                  updated[updated.length - 1] = { ...last, thinking: (last.thinking ?? '') + p.thinking }
-                }
-                return updated
-              })
+              setSessions(prev => prev.map(s => {
+                if (s.id !== sessionId) return s
+                const msgs = [...s.messages]
+                const last = msgs[msgs.length - 1]
+                if (last?.role === 'assistant') msgs[msgs.length - 1] = { ...last, thinking: (last.thinking ?? '') + p.thinking }
+                return { ...s, messages: msgs }
+              }))
             } else if (p.token) {
-              setMessages(prev => {
-                const updated = [...prev]
-                const last = updated[updated.length - 1]
-                if (last?.role === 'assistant') {
-                  updated[updated.length - 1] = { ...last, content: last.content + p.token }
-                }
-                return updated
-              })
+              setSessions(prev => prev.map(s => {
+                if (s.id !== sessionId) return s
+                const msgs = [...s.messages]
+                const last = msgs[msgs.length - 1]
+                if (last?.role === 'assistant') msgs[msgs.length - 1] = { ...last, content: last.content + p.token }
+                return { ...s, messages: msgs }
+              }))
             }
           } catch {}
         }
       }
     } catch (e) {
       const errMsg = e instanceof Error ? e.message : String(e)
-      setMessages(prev => {
-        const updated = [...prev]
-        const last = updated[updated.length - 1]
-        if (last?.role === 'assistant') {
-          updated[updated.length - 1] = { ...last, content: errMsg, error: true }
-        }
-        return updated
-      })
+      setSessions(prev => prev.map(s => {
+        if (s.id !== sessionId) return s
+        const msgs = [...s.messages]
+        const last = msgs[msgs.length - 1]
+        if (last?.role === 'assistant') msgs[msgs.length - 1] = { ...last, content: errMsg, error: true }
+        return { ...s, messages: msgs, updatedAt: new Date().toISOString() }
+      }))
     }
 
     setStreaming(false)
@@ -209,91 +319,163 @@ export default function JarvisChat() {
   }
 
   return (
-    <div className="flex flex-col bg-slate-800/30 backdrop-blur-sm border border-white/5 rounded-xl overflow-hidden" style={{ height: '460px' }}>
-      {/* ── Header ───────────────────────────────────────── */}
-      <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/5 shrink-0">
-        <div className="flex items-center gap-2.5">
-          {/* Chat icon */}
-          <div className="w-7 h-7 rounded-lg bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" className="text-indigo-400">
-              <path d="M2 3a1 1 0 011-1h8a1 1 0 011 1v6a1 1 0 01-1 1H5l-3 2V3z" />
-            </svg>
+    <div className="flex bg-slate-800/30 backdrop-blur-sm border border-white/5 rounded-xl overflow-hidden" style={{ height: '500px' }}>
+      {/* ── History sidebar ──────────────────────────────── */}
+      <div className={`${showHistory ? 'w-64' : 'w-0'} shrink-0 transition-all duration-200 overflow-hidden border-r border-white/5 bg-slate-900/50`}>
+        <div className="w-64 h-full flex flex-col">
+          <div className="flex items-center justify-between px-3 py-3 border-b border-white/5">
+            <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Chats</span>
+            <button
+              onClick={startNewSession}
+              className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors cursor-pointer"
+            >
+              + New
+            </button>
           </div>
-          <div>
-            <span className="text-sm font-semibold text-slate-100">Ask Jarvis</span>
-            <span className="ml-2 text-xs text-slate-500 font-mono">{model.split('/').pop()}</span>
+          <div className="flex-1 overflow-y-auto">
+            {sessions.length === 0 ? (
+              <p className="text-xs text-slate-600 px-3 py-4 text-center">No chat history yet</p>
+            ) : (
+              sessions.map(s => (
+                <div
+                  key={s.id}
+                  onClick={() => switchSession(s.id)}
+                  className={`group px-3 py-2.5 cursor-pointer border-b border-white/[0.03] transition-colors ${
+                    s.id === activeId
+                      ? 'bg-indigo-500/10 border-l-2 border-l-indigo-500'
+                      : 'hover:bg-slate-800/50 border-l-2 border-l-transparent'
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <p className={`text-xs font-medium truncate ${s.id === activeId ? 'text-indigo-300' : 'text-slate-300'}`}>
+                        {s.title}
+                      </p>
+                      <p className="text-[10px] text-slate-600 mt-0.5">
+                        {s.messages.length} message{s.messages.length !== 1 ? 's' : ''} · {timeLabel(s.updatedAt)}
+                      </p>
+                    </div>
+                    <button
+                      onClick={e => { e.stopPropagation(); deleteSession(s.id) }}
+                      className="text-slate-700 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 text-xs cursor-pointer shrink-0 mt-0.5"
+                      title="Delete chat"
+                    >
+                      ×
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         </div>
-        {models.length > 1 && (
-          <div className="relative">
-            <select
-              value={model}
-              onChange={e => setModel(e.target.value)}
-              className="text-xs bg-slate-900 border border-slate-700 rounded-lg px-2.5 py-1.5 text-slate-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 focus:outline-none transition-all duration-200 cursor-pointer appearance-none pr-7"
+      </div>
+
+      {/* ── Main chat area ───────────────────────────────── */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 shrink-0">
+          <div className="flex items-center gap-2.5">
+            <button
+              onClick={() => setShowHistory(v => !v)}
+              className="w-7 h-7 rounded-lg bg-slate-800/50 border border-white/5 flex items-center justify-center hover:bg-slate-700/50 transition-colors cursor-pointer"
+              title={showHistory ? 'Hide history' : 'Show history'}
             >
-              {models.map(m => (
-                <option key={m} value={m}>{m.split('/').pop() ?? m}</option>
-              ))}
-            </select>
-            <svg className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-slate-600" width="10" height="10" viewBox="0 0 10 10" fill="none">
-              <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          </div>
-        )}
-      </div>
-
-      {/* ── Messages ─────────────────────────────────────── */}
-      <div className="flex-1 overflow-y-auto px-5 py-4 space-y-3">
-        {messages.length === 0 && (
-          <div className="space-y-2">
-            <p className="text-xs text-slate-500 mb-3 font-medium">Quick questions:</p>
-            {QUICK_PROMPTS.map(q => (
-              <button
-                key={q}
-                onClick={() => send(q)}
-                disabled={streaming}
-                className="block w-full text-left text-xs px-3.5 py-2.5 bg-slate-800/50 hover:bg-slate-700/50 text-slate-400 hover:text-slate-200 rounded-lg border border-white/5 hover:border-white/10 transition-all duration-200 disabled:opacity-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-indigo-500/50"
-              >
-                {q}
-              </button>
-            ))}
-          </div>
-        )}
-
-        {messages.map((msg, i) => (
-          <MessageBubble key={i} msg={msg} isLast={i === messages.length - 1} streaming={streaming} />
-        ))}
-        <div ref={bottomRef} />
-      </div>
-
-      {/* ── Input ────────────────────────────────────────── */}
-      <div className="shrink-0 px-5 py-3.5 border-t border-white/5 flex gap-2">
-        <input
-          ref={inputRef}
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={streaming}
-          placeholder={streaming ? 'Thinking...' : 'Ask anything about your pipeline, contacts, decisions...'}
-          className="flex-1 text-sm bg-slate-900 border border-slate-700 rounded-lg px-3.5 py-2.5 text-slate-100 placeholder-slate-500 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 focus:outline-none disabled:opacity-50 transition-all duration-200"
-        />
-        <button
-          onClick={() => send(input)}
-          disabled={streaming || !input.trim()}
-          className="px-4 py-2.5 text-sm bg-indigo-600 hover:bg-indigo-500 disabled:opacity-30 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-all duration-200 shrink-0 cursor-pointer focus:ring-2 focus:ring-indigo-500/50 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none min-h-[44px] flex items-center gap-1.5"
-        >
-          {streaming ? (
-            <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-          ) : (
-            <>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M14 2L7 9" />
-                <path d="M14 2l-4 12-3-5-5-3z" />
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" className="text-slate-400">
+                <path d="M2 3.5h10M2 7h10M2 10.5h10" />
               </svg>
-              Send
-            </>
+            </button>
+            <div className="w-7 h-7 rounded-lg bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" className="text-indigo-400">
+                <path d="M2 3a1 1 0 011-1h8a1 1 0 011 1v6a1 1 0 01-1 1H5l-3 2V3z" />
+              </svg>
+            </div>
+            <div>
+              <span className="text-sm font-semibold text-slate-100">Ask Jarvis</span>
+              <span className="ml-2 text-xs text-slate-500 font-mono">{model.split('/').pop()}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {sessions.length > 0 && (
+              <span className="text-[10px] text-slate-600">{sessions.length} chat{sessions.length !== 1 ? 's' : ''}</span>
+            )}
+            <button
+              onClick={startNewSession}
+              className="text-xs text-slate-500 hover:text-slate-300 bg-slate-800/50 border border-white/5 px-2.5 py-1.5 rounded-lg transition-colors cursor-pointer"
+            >
+              New chat
+            </button>
+            {models.length > 1 && (
+              <div className="relative">
+                <select
+                  value={model}
+                  onChange={e => setModel(e.target.value)}
+                  className="text-xs bg-slate-900 border border-slate-700 rounded-lg px-2.5 py-1.5 text-slate-400 focus:border-indigo-500 focus:outline-none transition-all duration-200 cursor-pointer appearance-none pr-7"
+                >
+                  {models.map(m => (
+                    <option key={m} value={m}>{m.split('/').pop() ?? m}</option>
+                  ))}
+                </select>
+                <svg className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-slate-600" width="10" height="10" viewBox="0 0 10 10" fill="none">
+                  <path d="M3 4l2 2 2-2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-3">
+          {messages.length === 0 && (
+            <div className="space-y-2">
+              <p className="text-xs text-slate-500 mb-3 font-medium">Quick questions:</p>
+              {QUICK_PROMPTS.map(q => (
+                <button
+                  key={q}
+                  onClick={() => send(q)}
+                  disabled={streaming}
+                  className="block w-full text-left text-xs px-3.5 py-2.5 bg-slate-800/50 hover:bg-slate-700/50 text-slate-400 hover:text-slate-200 rounded-lg border border-white/5 hover:border-white/10 transition-all duration-200 disabled:opacity-50 cursor-pointer"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
           )}
-        </button>
+
+          {messages.map((msg, i) => (
+            <MessageBubble key={i} msg={msg} isLast={i === messages.length - 1} streaming={streaming} />
+          ))}
+          <div ref={bottomRef} />
+        </div>
+
+        {/* Input */}
+        <div className="shrink-0 px-4 py-3 border-t border-white/5 flex gap-2">
+          <input
+            ref={inputRef}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={streaming}
+            placeholder={streaming ? 'Thinking...' : 'Ask anything about your pipeline, contacts, decisions...'}
+            className="flex-1 text-sm bg-slate-900 border border-slate-700 rounded-lg px-3.5 py-2.5 text-slate-100 placeholder-slate-500 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/50 focus:outline-none disabled:opacity-50 transition-all duration-200"
+          />
+          <button
+            onClick={() => send(input)}
+            disabled={streaming || !input.trim()}
+            className="px-4 py-2.5 text-sm bg-indigo-600 hover:bg-indigo-500 disabled:opacity-30 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-all duration-200 shrink-0 cursor-pointer min-h-[44px] flex items-center gap-1.5"
+          >
+            {streaming ? (
+              <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            ) : (
+              <>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M14 2L7 9" />
+                  <path d="M14 2l-4 12-3-5-5-3z" />
+                </svg>
+                Send
+              </>
+            )}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/packages/jarvis-dashboard/src/ui/hooks/useApi.ts
+++ b/packages/jarvis-dashboard/src/ui/hooks/useApi.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useCallback } from 'react'
+
+interface UseApiResult<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+/**
+ * Single-fetch hook (no polling). Fetches on mount and provides refetch.
+ */
+export function useApi<T>(url: string | null): UseApiResult<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(!!url)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(() => {
+    if (!url) return
+    setLoading(true)
+    fetch(url)
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then((result: T) => {
+        setData(result)
+        setError(null)
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [url])
+
+  useEffect(() => { fetchData() }, [fetchData])
+
+  return { data, loading, error, refetch: fetchData }
+}
+
+/**
+ * Mutation helper for POST/PATCH/DELETE operations.
+ */
+export async function apiFetch<T>(
+  url: string,
+  options?: { method?: string; body?: unknown }
+): Promise<T> {
+  const resp = await fetch(url, {
+    method: options?.method ?? 'POST',
+    headers: options?.body ? { 'Content-Type': 'application/json' } : undefined,
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+  })
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => resp.statusText)
+    throw new Error(text)
+  }
+  return resp.json()
+}

--- a/packages/jarvis-dashboard/src/ui/hooks/usePolling.ts
+++ b/packages/jarvis-dashboard/src/ui/hooks/usePolling.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState, useRef, useCallback } from 'react'
+
+interface UsePollingResult<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+/**
+ * Generic polling hook that replaces duplicated setInterval + useRef patterns.
+ * Fetches from a URL on mount and at the specified interval.
+ */
+export function usePolling<T>(url: string, intervalMs: number): UsePollingResult<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetchData = useCallback(() => {
+    fetch(url)
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then((result: T) => {
+        setData(result)
+        setError(null)
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [url])
+
+  useEffect(() => {
+    fetchData()
+    intervalRef.current = setInterval(fetchData, intervalMs)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [fetchData, intervalMs])
+
+  return { data, loading, error, refetch: fetchData }
+}

--- a/packages/jarvis-dashboard/src/ui/pages/History.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/History.tsx
@@ -1,0 +1,351 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import PageHeader from '../shared/PageHeader.tsx'
+import TabBar from '../shared/TabBar.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import TimelineItem from '../shared/TimelineItem.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import {
+  IconRuns, IconInbox, IconCheck, IconWarning, IconError,
+  IconSettings, IconSystem, IconClock, IconHistory, IconRecovery,
+  IconWorkflow,
+} from '../shared/icons.tsx'
+import type { HistoryEvent, HistoryResponse, HistoryEventType } from '../types/index.ts'
+import { agentLabel } from '../types/index.ts'
+
+/* ── Tab definitions ─────────────────────────────────────── */
+
+const TABS = ['All', 'Runs', 'Approvals', 'Failures', 'System', 'Settings'] as const
+type Tab = (typeof TABS)[number]
+
+interface TabFilter {
+  type?: HistoryEventType
+  status?: string
+}
+
+const TAB_FILTERS: Record<Tab, TabFilter> = {
+  All:       {},
+  Runs:      { type: 'run' },
+  Approvals: { type: 'approval' },
+  Failures:  { type: 'run', status: 'failed' },
+  System:    { type: 'system' },
+  Settings:  { type: 'settings_change' },
+}
+
+const PAGE_SIZE = 50
+
+/* ── Type icon mapping ───────────────────────────────────── */
+
+function eventTypeIcon(type: HistoryEventType) {
+  switch (type) {
+    case 'run':             return <IconRuns />
+    case 'approval':        return <IconInbox />
+    case 'workflow_start':  return <IconWorkflow />
+    case 'system':          return <IconSystem />
+    case 'settings_change': return <IconSettings />
+    case 'recovery':        return <IconRecovery />
+    case 'backup':          return <IconClock />
+    default:                return <IconHistory />
+  }
+}
+
+function eventTypeLabel(type: HistoryEventType): string {
+  switch (type) {
+    case 'run':             return 'Run'
+    case 'approval':        return 'Approval'
+    case 'workflow_start':  return 'Workflow'
+    case 'system':          return 'System'
+    case 'settings_change': return 'Settings'
+    case 'recovery':        return 'Recovery'
+    case 'backup':          return 'Backup'
+    default:                return type
+  }
+}
+
+/* ── Date grouping ───────────────────────────────────────── */
+
+function dateGroupLabel(iso: string): string {
+  const date = new Date(iso)
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const eventDay = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const diffDays = Math.floor((today.getTime() - eventDay.getTime()) / 86400000)
+
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays < 7)   return date.toLocaleDateString([], { weekday: 'long' })
+  return date.toLocaleDateString([], { month: 'long', day: 'numeric', year: 'numeric' })
+}
+
+/* ── Action links per event type ─────────────────────────── */
+
+function EventActions({ event }: { event: HistoryEvent }) {
+  if (event.type === 'run' && event.run_id) {
+    return (
+      <Link
+        to={`/runs`}
+        className="text-[11px] font-medium text-indigo-400 hover:text-indigo-300 transition-colors px-2.5 py-1 rounded-md bg-indigo-500/10 hover:bg-indigo-500/15"
+      >
+        Inspect
+      </Link>
+    )
+  }
+  if (event.type === 'approval' && event.approval_id) {
+    return (
+      <Link
+        to={`/inbox`}
+        className="text-[11px] font-medium text-indigo-400 hover:text-indigo-300 transition-colors px-2.5 py-1 rounded-md bg-indigo-500/10 hover:bg-indigo-500/15"
+      >
+        View
+      </Link>
+    )
+  }
+  if (event.type === 'workflow_start' && event.workflow_id) {
+    return (
+      <Link
+        to={`/workflows`}
+        className="text-[11px] font-medium text-indigo-400 hover:text-indigo-300 transition-colors px-2.5 py-1 rounded-md bg-indigo-500/10 hover:bg-indigo-500/15"
+      >
+        Details
+      </Link>
+    )
+  }
+  return null
+}
+
+/* ── Subtitle enrichment ─────────────────────────────────── */
+
+function eventSubtitle(event: HistoryEvent): string | undefined {
+  if (event.subtitle) return event.subtitle
+  if (event.agent_id) return agentLabel(event.agent_id)
+  if (event.outcome) return event.outcome
+  return undefined
+}
+
+/* ── Main component ──────────────────────────────────────── */
+
+export default function History() {
+  const [activeTab, setActiveTab] = useState<Tab>('All')
+  const [events, setEvents] = useState<HistoryEvent[]>([])
+  const [total, setTotal] = useState(0)
+  const [hasMore, setHasMore] = useState(false)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  /* Build fetch URL from tab + offset */
+  const buildUrl = useCallback((tab: Tab, off: number) => {
+    const params = new URLSearchParams({ limit: String(PAGE_SIZE), offset: String(off) })
+    const filter = TAB_FILTERS[tab]
+    if (filter.type) params.set('type', filter.type)
+    if (filter.status) params.set('status', filter.status)
+    return `/api/history?${params}`
+  }, [])
+
+  /* Initial fetch + tab change */
+  const fetchEvents = useCallback((tab: Tab) => {
+    setLoading(true)
+    setError(null)
+    setOffset(0)
+    fetch(buildUrl(tab, 0))
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then((data: HistoryResponse) => {
+        setEvents(data.events)
+        setTotal(data.total)
+        setHasMore(data.has_more)
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setEvents([])
+        setLoading(false)
+      })
+  }, [buildUrl])
+
+  /* Load more (append) */
+  const loadMore = useCallback(() => {
+    const newOffset = offset + PAGE_SIZE
+    setLoadingMore(true)
+    fetch(buildUrl(activeTab, newOffset))
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`)
+        return r.json()
+      })
+      .then((data: HistoryResponse) => {
+        setEvents(prev => [...prev, ...data.events])
+        setOffset(newOffset)
+        setHasMore(data.has_more)
+        setTotal(data.total)
+        setLoadingMore(false)
+      })
+      .catch(() => {
+        setLoadingMore(false)
+      })
+  }, [offset, activeTab, buildUrl])
+
+  /* Refetch on tab change */
+  useEffect(() => {
+    fetchEvents(activeTab)
+  }, [activeTab, fetchEvents])
+
+  /* Tab change handler */
+  const handleTabChange = useCallback((tab: Tab) => {
+    setActiveTab(tab)
+  }, [])
+
+  /* ── Group events by date ──────────────────────────────── */
+  const groupedEvents: Array<{ label: string; events: HistoryEvent[] }> = []
+  let currentGroup = ''
+  for (const event of events) {
+    const group = dateGroupLabel(event.timestamp)
+    if (group !== currentGroup) {
+      currentGroup = group
+      groupedEvents.push({ label: group, events: [] })
+    }
+    groupedEvents[groupedEvents.length - 1].events.push(event)
+  }
+
+  /* ── Render ────────────────────────────────────────────── */
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <PageHeader
+        title="History"
+        subtitle="Activity timeline and audit log"
+        actions={
+          total > 0 ? (
+            <span className="text-xs text-slate-600 font-mono tabular-nums">
+              {events.length} of {total} events
+            </span>
+          ) : undefined
+        }
+      />
+
+      <TabBar
+        tabs={TABS}
+        active={activeTab}
+        onChange={handleTabChange}
+        variant="underline"
+      />
+
+      {/* Loading state */}
+      {loading && <LoadingSpinner message="Loading activity..." />}
+
+      {/* Error state */}
+      {!loading && error && (
+        <div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 text-center">
+          <p className="text-sm text-red-400">Failed to load history</p>
+          <p className="text-xs text-red-500/70 mt-1">{error}</p>
+          <button
+            onClick={() => fetchEvents(activeTab)}
+            className="mt-3 text-xs font-medium text-red-400 hover:text-red-300 transition-colors px-3 py-1.5 rounded-lg bg-red-500/10 hover:bg-red-500/15"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && events.length === 0 && (
+        <EmptyState
+          icon={<IconHistory />}
+          title={activeTab === 'All' ? 'No activity recorded yet' : `No ${activeTab.toLowerCase()} events`}
+          subtitle={
+            activeTab === 'All'
+              ? 'Events will appear here as agents run, approvals are made, and settings change.'
+              : `Try the "All" tab to see all event types.`
+          }
+        />
+      )}
+
+      {/* Event timeline */}
+      {!loading && !error && events.length > 0 && (
+        <div>
+          {groupedEvents.map((group) => (
+            <div key={group.label} className="mb-6">
+              {/* Date group header */}
+              <div className="flex items-center gap-3 mb-3">
+                <span className="text-[11px] font-semibold text-slate-500 uppercase tracking-wider">
+                  {group.label}
+                </span>
+                <div className="flex-1 h-px bg-slate-800/80" />
+                <span className="text-[10px] text-slate-700 font-mono tabular-nums">
+                  {group.events.length} {group.events.length === 1 ? 'event' : 'events'}
+                </span>
+              </div>
+
+              {/* Events within group */}
+              {group.events.map((event, idx) => (
+                <TimelineItem
+                  key={event.id}
+                  timestamp={event.timestamp}
+                  title={event.title}
+                  subtitle={eventSubtitle(event)}
+                  status={event.status}
+                  typeIcon={eventTypeIcon(event.type)}
+                  typeLabel={eventTypeLabel(event.type)}
+                  last={idx === group.events.length - 1}
+                  actions={
+                    <div className="flex items-center gap-2">
+                      <StatusBadge status={event.status} size="sm" />
+                      <EventActions event={event} />
+                    </div>
+                  }
+                >
+                  {/* Show source and agent context as inline metadata */}
+                  {(event.source || event.agent_id || event.outcome) && (
+                    <div className="flex items-center gap-3 flex-wrap">
+                      {event.source && (
+                        <span className="text-[10px] text-slate-600">
+                          <span className="text-slate-700">Source</span>{' '}
+                          {event.source}
+                        </span>
+                      )}
+                      {event.agent_id && (
+                        <span className="text-[10px] text-slate-600">
+                          <span className="text-slate-700">Agent</span>{' '}
+                          <span className="text-indigo-400/70">{agentLabel(event.agent_id)}</span>
+                        </span>
+                      )}
+                      {event.outcome && event.outcome !== event.status && (
+                        <span className="text-[10px] text-slate-600">
+                          <span className="text-slate-700">Outcome</span>{' '}
+                          {event.outcome}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </TimelineItem>
+              ))}
+            </div>
+          ))}
+
+          {/* Load more */}
+          {hasMore && (
+            <div className="flex justify-center pt-4 pb-2">
+              <button
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="text-xs font-medium text-slate-400 hover:text-white px-5 py-2 rounded-lg bg-slate-800/60 hover:bg-slate-800 border border-white/5 hover:border-white/10 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {loadingMore ? (
+                  <span className="flex items-center gap-2">
+                    <span className="w-3 h-3 border border-slate-500 border-t-slate-300 rounded-full animate-spin" />
+                    Loading...
+                  </span>
+                ) : (
+                  `Load more events`
+                )}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/Home.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Home.tsx
@@ -1,257 +1,27 @@
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import AgentCard from '../components/AgentCard.tsx'
 import JarvisChat from '../components/JarvisChat.tsx'
-
-interface HealthData {
-  ok: boolean
-  crm: { contacts: number }
-  knowledge: { documents: number; playbooks: number }
-  decisions: { total: number }
-  pendingApprovals: number
-  telegramConfigured: boolean
-}
-
-interface AgentData {
-  agentId: string
-  label: string
-  description: string
-  schedule: string
-  lastRun: string | null
-  lastOutcome: string | null
-}
-
-interface DaemonCurrentRun {
-  agent_id: string
-  status: string
-  step: number
-  total_steps: number
-  current_action: string
-  started_at: string
-}
-
-interface DaemonLastRun {
-  agent_id: string
-  status: string
-  completed_at: string
-}
-
-interface DaemonStatus {
-  running: boolean
-  pid: number | null
-  uptime_seconds: number | null
-  agents_registered: number
-  schedules_active: number
-  last_run: DaemonLastRun | null
-  /** @deprecated Use active_runs instead */
-  current_run: DaemonCurrentRun | null
-  /** All currently executing agent runs (supports concurrent execution). */
-  active_runs?: DaemonCurrentRun[]
-}
-
-/* ── Attention API types ─────────────────────────────────── */
-
-interface AttentionNeedsAttention {
-  pending_approvals: number
-  failed_runs: number
-  overdue_schedules: number
-}
-
-interface AttentionActiveWork {
-  agent_id: string
-  status: string
-  current_step: number
-  total_steps: number
-}
-
-interface AttentionRecentCompletion {
-  agent_id: string
-  status: string
-  completed_at: string
-}
-
-interface AttentionData {
-  needs_attention: AttentionNeedsAttention
-  active_work: AttentionActiveWork[]
-  recent_completions: AttentionRecentCompletion[]
-  recommended_actions: string[]
-  system_status: string // "healthy" | "needs_attention" | "unknown"
-}
-
-function formatUptime(seconds: number | null): string {
-  if (seconds === null || seconds < 0) return '--'
-  if (seconds < 60) return `${seconds}s`
-  const mins = Math.floor(seconds / 60)
-  if (mins < 60) return `${mins}m`
-  const hours = Math.floor(mins / 60)
-  const remMins = mins % 60
-  if (hours < 24) return `${hours}h ${remMins}m`
-  const days = Math.floor(hours / 24)
-  return `${days}d ${hours % 24}h`
-}
-
-function timeAgo(iso: string | null): string {
-  if (!iso) return 'Never'
-  const diff = Date.now() - new Date(iso).getTime()
-  const mins = Math.floor(diff / 60000)
-  if (mins < 1) return 'Just now'
-  if (mins < 60) return `${mins}m ago`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
-
-const POLL_INTERVAL = 5_000 // 5 seconds
-const ATTENTION_POLL_INTERVAL = 10_000 // 10 seconds
-
-/* ── Human-readable agent labels ────────────────────────── */
-
-const AGENT_LABELS: Record<string, string> = {
-  'bd-pipeline': 'BD Pipeline',
-  'proposal-engine': 'Proposal Engine',
-  'evidence-auditor': 'Evidence Auditor',
-  'contract-reviewer': 'Contract Reviewer',
-  'staffing-monitor': 'Staffing Monitor',
-  'content-engine': 'Content Engine',
-  'portfolio-monitor': 'Portfolio Monitor',
-  'garden-calendar': 'Garden Calendar',
-  'email-campaign': 'Email Campaign',
-  'social-engagement': 'Social Engagement',
-  'security-monitor': 'Security Monitor',
-  'drive-watcher': 'Drive Watcher',
-  'invoice-generator': 'Invoice Generator',
-  'meeting-transcriber': 'Meeting Transcriber',
-}
-
-function agentLabel(id: string): string {
-  return AGENT_LABELS[id] ?? id
-}
-
-/* ── Human-readable status labels ───────────────────────── */
-
-const STATUS_LABELS: Record<string, string> = {
-  planning: 'Planning',
-  executing: 'Running',
-  awaiting_approval: 'Awaiting Approval',
-  completed: 'Completed',
-  failed: 'Failed',
-  cancelled: 'Cancelled',
-  queued: 'Queued',
-}
-
-/* ── Stat Card Icons ─────────────────────────────────────── */
-
-function IconContacts() {
-  return (
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="11" cy="8" r="3.5" />
-      <path d="M4 19c0-3.3 3.1-6 7-6s7 2.7 7 6" />
-    </svg>
-  )
-}
-
-function IconDocuments() {
-  return (
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M6 3h7l5 5v10a2 2 0 01-2 2H6a2 2 0 01-2-2V5a2 2 0 012-2z" />
-      <path d="M13 3v5h5" />
-    </svg>
-  )
-}
-
-function IconPlaybooks() {
-  return (
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 5a2 2 0 012-2h10a2 2 0 012 2v14l-7-3-7 3V5z" />
-    </svg>
-  )
-}
-
-function IconApprovals() {
-  return (
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="11" cy="11" r="8" />
-      <path d="M8 11l2 2 4-4" />
-    </svg>
-  )
-}
+import { useDashboardStore } from '../stores/dashboard-store.ts'
+import { useApi } from '../hooks/useApi.ts'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import { IconWarning, IconError, IconClock, IconArrowRight } from '../shared/icons.tsx'
+import type { WorkflowDefinition, AttentionActiveWork } from '../types/index.ts'
+import { agentLabel, STATUS_LABELS, formatUptime, timeAgo } from '../types/index.ts'
 
 export default function Home() {
-  const [health, setHealth] = useState<HealthData | null>(null)
-  const [agents, setAgents] = useState<AgentData[]>([])
-  const [daemon, setDaemon] = useState<DaemonStatus | null>(null)
-  const [attention, setAttention] = useState<AttentionData | null>(null)
+  const { attention, daemon, safeMode, health } = useDashboardStore()
+  const { data: workflows } = useApi<WorkflowDefinition[]>('/api/workflows')
   const [loading, setLoading] = useState(true)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const attentionIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  const fetchData = useCallback(() => {
-    Promise.all([
-      fetch('/api/health').then(r => r.json()),
-      fetch('/api/agents').then(r => r.json()),
-      fetch('/api/daemon/status').then(r => r.json()),
-    ]).then(([h, a, d]: [HealthData, AgentData[], DaemonStatus]) => {
-      setHealth(h)
-      setAgents(a)
-      setDaemon(d)
-      setLoading(false)
-    }).catch(() => setLoading(false))
-  }, [])
-
-  const fetchAttention = useCallback(() => {
-    fetch('/api/attention')
-      .then(r => r.json())
-      .then((data: AttentionData) => setAttention(data))
-      .catch(() => {})
-  }, [])
-
+  // Wait for first dashboard-store fetch
   useEffect(() => {
-    // Initial fetch
-    fetchData()
-    fetchAttention()
-    // Poll every 5 seconds for daemon/agents, every 10 seconds for attention
-    intervalRef.current = setInterval(fetchData, POLL_INTERVAL)
-    attentionIntervalRef.current = setInterval(fetchAttention, ATTENTION_POLL_INTERVAL)
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current)
-      if (attentionIntervalRef.current) clearInterval(attentionIntervalRef.current)
-    }
-  }, [fetchData, fetchAttention])
+    if (attention !== null || daemon !== null) setLoading(false)
+  }, [attention, daemon])
 
-  const handleTrigger = async (agentId: string) => {
-    await fetch(`/api/agents/${agentId}/trigger`, { method: 'POST' })
-    setTimeout(fetchData, 500)
-  }
-
-  /** Compute the effective status for an agent based on daemon state.
-   *  Checks active_runs (concurrent) first, falls back to current_run (legacy). */
-  function getAgentStatus(agentId: string): 'ready' | 'running' | 'awaiting_approval' | 'error' {
-    const runs = daemon?.active_runs?.length
-      ? daemon.active_runs
-      : daemon?.current_run ? [daemon.current_run] : []
-    const run = runs.find(r => r.agent_id === agentId)
-    if (!run) return 'ready'
-    if (run.status === 'awaiting_approval') return 'awaiting_approval'
-    return 'running'
-  }
-
-  function getAgentCurrentRun(agentId: string): DaemonCurrentRun | null {
-    const runs = daemon?.active_runs?.length
-      ? daemon.active_runs
-      : daemon?.current_run ? [daemon.current_run] : []
-    return runs.find(r => r.agent_id === agentId) ?? null
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-2 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin" />
-          <span className="text-sm text-slate-500 font-medium">Loading dashboard...</span>
-        </div>
-      </div>
-    )
+  if (loading && !attention && !daemon) {
+    return <LoadingSpinner message="Loading dashboard..." />
   }
 
   const greeting = (() => {
@@ -262,23 +32,42 @@ export default function Home() {
   })()
 
   const today = new Date().toLocaleDateString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
   })
 
-  const needsAttention = attention?.needs_attention
-  const hasAttentionItems = needsAttention &&
-    (needsAttention.pending_approvals > 0 ||
-     needsAttention.failed_runs > 0 ||
-     needsAttention.overdue_schedules > 0)
+  const needs = attention?.needs_attention
+  const hasAttention = needs && (needs.pending_approvals > 0 || needs.failed_runs > 0 || needs.overdue_schedules > 0)
+  const activeWork = attention?.active_work ?? []
+  const completions = attention?.recent_completions ?? []
+  const actions = attention?.recommended_actions ?? []
+  const isSafeMode = safeMode?.safe_mode_recommended
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
-      {/* -- Daemon status banner -- */}
+      {/* ── System banner ──────────────────────────────── */}
       <div className="mb-6">
-        {daemon?.running ? (
+        {isSafeMode ? (
+          <Link
+            to="/recovery"
+            className="block bg-red-500/5 border border-red-500/15 rounded-xl px-5 py-3 backdrop-blur-sm hover:border-red-500/30 transition-colors"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <span className="relative flex h-2.5 w-2.5">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                  <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-red-500" />
+                </span>
+                <span className="text-sm text-red-300 font-medium">Safe mode recommended</span>
+              </div>
+              <span className="text-xs text-red-400/60">Open Recovery</span>
+            </div>
+            {safeMode?.reasons?.length ? (
+              <p className="text-xs text-red-400/50 mt-1 ml-6">
+                {safeMode.reasons.slice(0, 2).join(' · ')}
+              </p>
+            ) : null}
+          </Link>
+        ) : daemon?.running ? (
           <div className="bg-emerald-500/5 border border-emerald-500/10 rounded-xl px-5 py-3 flex items-center justify-between backdrop-blur-sm">
             <div className="flex items-center gap-3">
               <span className="relative flex h-2.5 w-2.5">
@@ -303,62 +92,53 @@ export default function Home() {
         )}
       </div>
 
-      {/* -- Header -- */}
+      {/* ── Header ─────────────────────────────────────── */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-slate-100 tracking-tight">{greeting}</h1>
         <p className="text-sm text-slate-500 mt-1">{today}</p>
       </div>
 
-      {/* -- Needs Attention section -- */}
-      {hasAttentionItems && (
+      {/* ── Needs Attention ────────────────────────────── */}
+      {hasAttention && (
         <div className="mb-8">
           <h2 className="text-lg font-semibold text-slate-200 tracking-tight mb-3">Needs Attention</h2>
           <div className="flex flex-wrap gap-3">
-            {needsAttention.pending_approvals > 0 && (
+            {needs.pending_approvals > 0 && (
               <Link
-                to="/approvals"
+                to="/inbox"
                 className="inline-flex items-center gap-2 bg-amber-500/5 border border-amber-500/15 rounded-xl px-4 py-2.5 backdrop-blur-sm hover:border-amber-500/30 transition-colors duration-200"
               >
-                <svg className="text-amber-400 shrink-0" width="16" height="16" viewBox="0 0 18 18" fill="none">
-                  <path d="M9 2L16.5 15H1.5L9 2Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
-                  <path d="M9 7v3M9 12v.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                </svg>
+                <span className="text-amber-400 shrink-0"><IconWarning /></span>
                 <span className="text-amber-300/90 text-sm font-medium">
-                  {needsAttention.pending_approvals} pending approval{needsAttention.pending_approvals !== 1 ? 's' : ''}
+                  {needs.pending_approvals} pending approval{needs.pending_approvals !== 1 ? 's' : ''}
                 </span>
                 <span className="bg-amber-500/90 text-black text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[20px] text-center">
-                  {needsAttention.pending_approvals}
+                  {needs.pending_approvals}
                 </span>
               </Link>
             )}
-            {needsAttention.failed_runs > 0 && (
+            {needs.failed_runs > 0 && (
               <Link
-                to="/runs"
+                to="/inbox?tab=Failures"
                 className="inline-flex items-center gap-2 bg-red-500/5 border border-red-500/15 rounded-xl px-4 py-2.5 backdrop-blur-sm hover:border-red-500/30 transition-colors duration-200"
               >
-                <svg className="text-red-400 shrink-0" width="16" height="16" viewBox="0 0 18 18" fill="none">
-                  <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="1.5"/>
-                  <path d="M6.5 6.5l5 5M11.5 6.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                </svg>
+                <span className="text-red-400 shrink-0"><IconError /></span>
                 <span className="text-red-300/90 text-sm font-medium">
-                  {needsAttention.failed_runs} failed run{needsAttention.failed_runs !== 1 ? 's' : ''}
+                  {needs.failed_runs} failed run{needs.failed_runs !== 1 ? 's' : ''}
                 </span>
                 <span className="bg-red-500/90 text-white text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[20px] text-center">
-                  {needsAttention.failed_runs}
+                  {needs.failed_runs}
                 </span>
               </Link>
             )}
-            {needsAttention.overdue_schedules > 0 && (
+            {needs.overdue_schedules > 0 && (
               <Link
-                to="/schedule"
+                to="/system"
                 className="inline-flex items-center gap-2 bg-amber-500/5 border border-amber-500/15 rounded-xl px-4 py-2.5 backdrop-blur-sm hover:border-amber-500/30 transition-colors duration-200"
               >
-                <svg className="text-amber-400 shrink-0" width="16" height="16" viewBox="0 0 18 18" fill="none">
-                  <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="1.5"/>
-                  <path d="M9 5v4l3 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
+                <span className="text-amber-400 shrink-0"><IconClock /></span>
                 <span className="text-amber-300/90 text-sm font-medium">
-                  {needsAttention.overdue_schedules} overdue schedule{needsAttention.overdue_schedules !== 1 ? 's' : ''}
+                  {needs.overdue_schedules} overdue schedule{needs.overdue_schedules !== 1 ? 's' : ''}
                 </span>
               </Link>
             )}
@@ -366,99 +146,74 @@ export default function Home() {
         </div>
       )}
 
-      {/* -- Stats cards row -- */}
-      {health && (
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          {/* Contacts */}
-          <div className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl p-5 hover:border-white/10 transition-all duration-200 group">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-slate-500 group-hover:text-slate-400 transition-colors duration-200">
-                <IconContacts />
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-slate-100 font-mono tabular-nums">{health.crm.contacts}</p>
-            <p className="text-xs text-slate-500 mt-1 font-medium">Contacts</p>
-          </div>
-
-          {/* Documents */}
-          <div className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl p-5 hover:border-white/10 transition-all duration-200 group">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-slate-500 group-hover:text-slate-400 transition-colors duration-200">
-                <IconDocuments />
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-slate-100 font-mono tabular-nums">{health.knowledge.documents}</p>
-            <p className="text-xs text-slate-500 mt-1 font-medium">Documents</p>
-          </div>
-
-          {/* Playbooks */}
-          <div className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl p-5 hover:border-white/10 transition-all duration-200 group">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-slate-500 group-hover:text-slate-400 transition-colors duration-200">
-                <IconPlaybooks />
-              </span>
-            </div>
-            <p className="text-2xl font-bold text-slate-100 font-mono tabular-nums">{health.knowledge.playbooks}</p>
-            <p className="text-xs text-slate-500 mt-1 font-medium">Playbooks</p>
-          </div>
-
-          {/* Approvals */}
-          <div className={`bg-slate-800/50 backdrop-blur-sm border rounded-xl p-5 transition-all duration-200 group ${
-            health.pendingApprovals > 0
-              ? 'border-amber-500/20 hover:border-amber-500/30'
-              : 'border-white/5 hover:border-white/10'
-          }`}>
-            <div className="flex items-center justify-between mb-3">
-              <span className={`transition-colors duration-200 ${
-                health.pendingApprovals > 0 ? 'text-amber-400' : 'text-slate-500 group-hover:text-slate-400'
-              }`}>
-                <IconApprovals />
-              </span>
-            </div>
-            <p className={`text-2xl font-bold font-mono tabular-nums ${
-              health.pendingApprovals > 0 ? 'text-amber-400' : 'text-slate-100'
-            }`}>{health.pendingApprovals}</p>
-            <p className="text-xs text-slate-500 mt-1 font-medium">Pending Approvals</p>
-          </div>
-        </div>
-      )}
-
-      {/* -- Active Work section -- */}
-      {attention && attention.active_work.length > 0 && (
+      {/* ── Active Work ────────────────────────────────── */}
+      {activeWork.length > 0 && (
         <div className="mb-8">
           <h2 className="text-lg font-semibold text-slate-200 tracking-tight mb-3">Active Work</h2>
           <div className="space-y-2">
-            {attention.active_work.map((work, i) => (
+            {activeWork.map((work: AttentionActiveWork, i: number) => (
+              <ActiveWorkRow key={`${work.agent_id}-${i}`} work={work} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Quick-Start Workflows ──────────────────────── */}
+      {workflows && workflows.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-slate-200 tracking-tight">Quick Start</h2>
+            <Link to="/workflows" className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
+              All workflows
+            </Link>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {workflows.slice(0, 5).map(wf => (
+              <Link key={wf.workflow_id} to={`/workflows?start=${wf.workflow_id}`}>
+                <DataCard className="h-full">
+                  <h3 className="text-sm font-medium text-slate-200 mb-1">{wf.name}</h3>
+                  <p className="text-xs text-slate-500 line-clamp-2">{wf.expected_output}</p>
+                  <div className="flex items-center gap-2 mt-3">
+                    <SafetyPostureBadge rules={wf.safety_rules} />
+                    {wf.safety_rules.preview_available && (
+                      <span className="text-[10px] text-blue-400/60 bg-blue-500/10 border border-blue-500/15 px-1.5 py-0.5 rounded">
+                        Preview
+                      </span>
+                    )}
+                  </div>
+                </DataCard>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Recent Completions ─────────────────────────── */}
+      {completions.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-slate-200 tracking-tight">Recent Completions</h2>
+            <Link to="/history" className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
+              View all
+            </Link>
+          </div>
+          <div className="space-y-2">
+            {completions.slice(0, 5).map((comp, i) => (
               <div
-                key={`${work.agent_id}-${i}`}
-                className="bg-slate-800/50 backdrop-blur-sm border border-amber-500/10 rounded-xl px-5 py-3 flex items-center justify-between"
+                key={`${comp.agent_id}-${i}`}
+                className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl px-5 py-3 flex items-center justify-between"
               >
                 <div className="flex items-center gap-3">
-                  <span className="relative flex h-2 w-2">
-                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
-                    <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-400" />
-                  </span>
-                  <span className="text-sm text-slate-200 font-medium">{agentLabel(work.agent_id)}</span>
-                  <span className="text-xs text-amber-400/70 bg-amber-500/10 border border-amber-500/20 px-2 py-0.5 rounded-full">
-                    {STATUS_LABELS[work.status] ?? work.status}
-                  </span>
+                  <StatusBadge status={comp.status} variant="dot" />
+                  <span className="text-sm text-slate-200 font-medium">{agentLabel(comp.agent_id)}</span>
+                  <StatusBadge status={comp.status} />
                 </div>
                 <div className="flex items-center gap-3">
-                  {work.total_steps > 0 && (
-                    <>
-                      <span className="text-xs text-slate-500 font-mono tabular-nums">
-                        Step {work.current_step}/{work.total_steps}
-                      </span>
-                      <div className="w-24 bg-slate-900/80 rounded-full h-1.5 overflow-hidden">
-                        <div
-                          className="bg-gradient-to-r from-amber-500 to-amber-400 h-1.5 rounded-full transition-all duration-500 ease-out"
-                          style={{ width: `${Math.max(5, (work.current_step / work.total_steps) * 100)}%` }}
-                        />
-                      </div>
-                      <span className="text-xs text-slate-600 font-mono tabular-nums">
-                        {Math.round((work.current_step / work.total_steps) * 100)}%
-                      </span>
-                    </>
+                  <span className="text-xs text-slate-500">{timeAgo(comp.completed_at)}</span>
+                  {comp.status === 'failed' && (
+                    <Link to="/inbox?tab=Failures" className="text-xs text-red-400 hover:text-red-300 transition-colors">
+                      View
+                    </Link>
                   )}
                 </div>
               </div>
@@ -467,64 +222,21 @@ export default function Home() {
         </div>
       )}
 
-      {/* -- Recent Completions section -- */}
-      {attention && attention.recent_completions.length > 0 && (
-        <div className="mb-8">
-          <h2 className="text-lg font-semibold text-slate-200 tracking-tight mb-3">Recent Completions</h2>
-          <div className="space-y-2">
-            {attention.recent_completions.slice(0, 5).map((comp, i) => {
-              const statusColor = comp.status === 'completed'
-                ? 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20'
-                : comp.status === 'failed'
-                  ? 'text-red-400 bg-red-500/10 border-red-500/20'
-                  : 'text-slate-400 bg-slate-500/10 border-slate-500/20'
-              return (
-                <div
-                  key={`${comp.agent_id}-${i}`}
-                  className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl px-5 py-3 flex items-center justify-between"
-                >
-                  <div className="flex items-center gap-3">
-                    <span className={`inline-flex rounded-full h-2 w-2 ${
-                      comp.status === 'completed' ? 'bg-emerald-500' : comp.status === 'failed' ? 'bg-red-500' : 'bg-slate-500'
-                    }`} />
-                    <span className="text-sm text-slate-200 font-medium">{agentLabel(comp.agent_id)}</span>
-                    <span className={`text-xs px-2 py-0.5 rounded-full border ${statusColor}`}>
-                      {STATUS_LABELS[comp.status] ?? comp.status}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-xs text-slate-500">{timeAgo(comp.completed_at)}</span>
-                    {comp.status === 'failed' && (
-                      <Link to="/runs" className="text-xs text-red-400 hover:text-red-300 transition-colors duration-200">View</Link>
-                    )}
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* -- Recommended Actions section -- */}
-      {attention && attention.recommended_actions.length > 0 && (
+      {/* ── Recommended Actions ────────────────────────── */}
+      {actions.length > 0 && (
         <div className="mb-8">
           <h2 className="text-lg font-semibold text-slate-200 tracking-tight mb-3">Recommended Actions</h2>
-          <div className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl p-5">
+          <DataCard>
             <ul className="space-y-2">
-              {attention.recommended_actions.map((action, i) => {
+              {actions.map((action, i) => {
                 const lc = action.toLowerCase()
-                const link = lc.includes('approval')
-                  ? '/approvals'
-                  : lc.includes('failed') || lc.includes('retry')
-                    ? '/runs'
-                    : lc.includes('schedule') || lc.includes('overdue')
-                      ? '/schedule'
-                      : null
+                const link = lc.includes('approval') ? '/inbox'
+                  : lc.includes('failed') || lc.includes('retry') ? '/inbox?tab=Failures'
+                  : lc.includes('schedule') || lc.includes('overdue') ? '/system'
+                  : null
                 return (
                   <li key={i} className="flex items-center gap-2.5 text-sm text-slate-300">
-                    <svg className="text-indigo-400 shrink-0" width="14" height="14" viewBox="0 0 14 14" fill="none">
-                      <path d="M2 7h10M8 3l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                    </svg>
+                    <span className="text-indigo-400 shrink-0"><IconArrowRight /></span>
                     <span className="flex-1">{action}</span>
                     {link && (
                       <Link
@@ -538,36 +250,64 @@ export default function Home() {
                 )
               })}
             </ul>
-          </div>
+          </DataCard>
         </div>
       )}
 
-      {/* -- Ask Jarvis chat -- */}
+      {/* ── Ask Jarvis ─────────────────────────────────── */}
       <div className="mb-10">
         <JarvisChat />
       </div>
+    </div>
+  )
+}
 
-      {/* -- Agent grid -- */}
-      <div className="mb-4">
-        <h2 className="text-lg font-semibold text-slate-200 tracking-tight">Agents</h2>
-        <p className="text-xs text-slate-500 mt-0.5">Manage and monitor your autonomous agents</p>
+/* ── Sub-components ──────────────────────────────────────── */
+
+function ActiveWorkRow({ work }: { work: AttentionActiveWork }) {
+  const progress = work.total_steps > 0 ? Math.round((work.current_step / work.total_steps) * 100) : 0
+
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm border border-amber-500/10 rounded-xl px-5 py-3 flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        <span className="relative flex h-2 w-2">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-400" />
+        </span>
+        <span className="text-sm text-slate-200 font-medium">{agentLabel(work.agent_id)}</span>
+        <StatusBadge status={work.status} />
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        {agents.map(agent => (
-          <AgentCard
-            key={agent.agentId}
-            agentId={agent.agentId}
-            label={agent.label}
-            description={agent.description}
-            schedule={agent.schedule}
-            lastRun={agent.lastRun}
-            lastOutcome={agent.lastOutcome}
-            status={getAgentStatus(agent.agentId)}
-            currentRun={getAgentCurrentRun(agent.agentId)}
-            onTrigger={handleTrigger}
-          />
-        ))}
+      <div className="flex items-center gap-3">
+        {work.total_steps > 0 && (
+          <>
+            <span className="text-xs text-slate-500 font-mono tabular-nums">
+              Step {work.current_step}/{work.total_steps}
+            </span>
+            <div className="w-24 bg-slate-900/80 rounded-full h-1.5 overflow-hidden">
+              <div
+                className="bg-gradient-to-r from-amber-500 to-amber-400 h-1.5 rounded-full transition-all duration-500 ease-out"
+                style={{ width: `${Math.max(5, progress)}%` }}
+              />
+            </div>
+            <span className="text-xs text-slate-600 font-mono tabular-nums">{progress}%</span>
+          </>
+        )}
       </div>
     </div>
+  )
+}
+
+function SafetyPostureBadge({ rules }: { rules: WorkflowDefinition['safety_rules'] }) {
+  const colors = {
+    draft: 'text-emerald-400/60 bg-emerald-500/10 border-emerald-500/15',
+    send: 'text-amber-400/60 bg-amber-500/10 border-amber-500/15',
+    blocked: 'text-red-400/60 bg-red-500/10 border-red-500/15',
+  }
+  const labels = { draft: 'Draft', send: 'Live', blocked: 'Blocked' }
+
+  return (
+    <span className={`text-[10px] border px-1.5 py-0.5 rounded ${colors[rules.outbound_default]}`}>
+      {labels[rules.outbound_default]}
+    </span>
   )
 }

--- a/packages/jarvis-dashboard/src/ui/pages/Inbox.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Inbox.tsx
@@ -1,0 +1,818 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useSearchParams, Link } from 'react-router-dom'
+import PageHeader from '../shared/PageHeader.tsx'
+import TabBar from '../shared/TabBar.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import ConfirmDialog from '../shared/ConfirmDialog.tsx'
+import { IconWarning, IconError, IconCheck, IconClock, IconArrowRight } from '../shared/icons.tsx'
+import { usePolling } from '../hooks/usePolling.ts'
+import { useApi, apiFetch } from '../hooks/useApi.ts'
+import type { EnrichedApproval, Run, RunExplanation, RepairReport } from '../types/index.ts'
+import { agentLabel, timeAgo, STATUS_COLORS } from '../types/index.ts'
+
+/* ── Constants ───────────────────────────────────────────── */
+
+const TABS = ['Approvals', 'Failures', 'Retries', 'Alerts'] as const
+type Tab = (typeof TABS)[number]
+
+const RISK_COLORS: Record<string, string> = {
+  low: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  medium: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  high: 'bg-red-500/10 text-red-400 border-red-500/20',
+}
+
+const REPAIR_BANNER: Record<string, { bg: string; border: string; text: string; dot: string }> = {
+  healthy: { bg: 'bg-emerald-500/5', border: 'border-emerald-500/15', text: 'text-emerald-300', dot: 'bg-emerald-500' },
+  degraded: { bg: 'bg-amber-500/5', border: 'border-amber-500/15', text: 'text-amber-300', dot: 'bg-amber-400' },
+  broken: { bg: 'bg-red-500/5', border: 'border-red-500/15', text: 'text-red-300', dot: 'bg-red-500' },
+}
+
+/* ── Main component ──────────────────────────────────────── */
+
+export default function Inbox() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const initialTab = (searchParams.get('tab') as Tab) || 'Approvals'
+  const [activeTab, setActiveTab] = useState<Tab>(TABS.includes(initialTab) ? initialTab : 'Approvals')
+  const [filterPending, setFilterPending] = useState(true)
+
+  // Approvals: poll every 10s
+  const approvalsUrl = filterPending ? '/api/approvals?status=pending' : '/api/approvals'
+  const { data: approvals, loading: loadingApprovals, refetch: refetchApprovals } = usePolling<EnrichedApproval[]>(approvalsUrl, 10_000)
+
+  // Failures: single fetch + manual refetch
+  const { data: failedRuns, loading: loadingFailures, refetch: refetchFailures } = useApi<Run[]>('/api/runs/failed')
+
+  // Repair: single fetch
+  const { data: repair, loading: loadingRepair } = useApi<RepairReport>('/api/repair')
+
+  // Tab badges
+  const pendingCount = approvals?.filter(a => a.status === 'pending').length ?? 0
+  const failureCount = failedRuns?.length ?? 0
+  const retryCount = failedRuns?.length ?? 0
+  const alertCount = repair?.recommended_actions?.length ?? 0
+
+  const badges: Partial<Record<Tab, number>> = {
+    Approvals: pendingCount,
+    Failures: failureCount,
+    Retries: retryCount,
+    Alerts: alertCount,
+  }
+
+  const handleTabChange = useCallback((tab: Tab) => {
+    setActiveTab(tab)
+    setSearchParams(tab === 'Approvals' ? {} : { tab })
+  }, [setSearchParams])
+
+  // Sync from URL on mount/navigation
+  useEffect(() => {
+    const urlTab = searchParams.get('tab') as Tab
+    if (urlTab && TABS.includes(urlTab) && urlTab !== activeTab) {
+      setActiveTab(urlTab)
+    }
+  }, [searchParams]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="Inbox"
+        subtitle="Decisions that need you — approvals, failures, and system alerts"
+      />
+
+      <TabBar
+        tabs={TABS}
+        active={activeTab}
+        onChange={handleTabChange}
+        badges={badges}
+      />
+
+      {activeTab === 'Approvals' && (
+        <ApprovalsTab
+          approvals={approvals}
+          loading={loadingApprovals}
+          filterPending={filterPending}
+          onToggleFilter={() => setFilterPending(f => !f)}
+          onActionComplete={refetchApprovals}
+        />
+      )}
+      {activeTab === 'Failures' && (
+        <FailuresTab runs={failedRuns} loading={loadingFailures} onRetry={refetchFailures} />
+      )}
+      {activeTab === 'Retries' && (
+        <RetriesTab runs={failedRuns} loading={loadingFailures} />
+      )}
+      {activeTab === 'Alerts' && (
+        <AlertsTab repair={repair} loading={loadingRepair} />
+      )}
+    </div>
+  )
+}
+
+/* ── Approvals Tab ───────────────────────────────────────── */
+
+function ApprovalsTab({
+  approvals, loading, filterPending, onToggleFilter, onActionComplete,
+}: {
+  approvals: EnrichedApproval[] | null
+  loading: boolean
+  filterPending: boolean
+  onToggleFilter: () => void
+  onActionComplete: () => void
+}) {
+  if (loading && !approvals) return <LoadingSpinner message="Loading approvals..." />
+
+  return (
+    <div>
+      {/* Filter toggle */}
+      <div className="flex items-center gap-2 mb-5">
+        <button
+          onClick={onToggleFilter}
+          className={`text-xs px-3 py-1.5 rounded-full font-medium transition-colors cursor-pointer ${
+            filterPending
+              ? 'bg-amber-500/15 text-amber-300 border border-amber-500/20'
+              : 'bg-slate-800 text-slate-400 border border-white/5 hover:text-white'
+          }`}
+        >
+          Pending
+        </button>
+        <button
+          onClick={onToggleFilter}
+          className={`text-xs px-3 py-1.5 rounded-full font-medium transition-colors cursor-pointer ${
+            !filterPending
+              ? 'bg-indigo-600 text-white'
+              : 'bg-slate-800 text-slate-400 border border-white/5 hover:text-white'
+          }`}
+        >
+          All
+        </button>
+      </div>
+
+      {!approvals?.length ? (
+        <EmptyState
+          icon={<IconCheck size={28} />}
+          title="No pending approvals"
+          subtitle="All agent actions are resolved. Jarvis is running autonomously."
+        />
+      ) : (
+        <div className="space-y-3">
+          {approvals.map(approval => (
+            <ApprovalCard key={approval.id} approval={approval} onActionComplete={onActionComplete} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── Single approval card ────────────────────────────────── */
+
+function ApprovalCard({
+  approval, onActionComplete,
+}: {
+  approval: EnrichedApproval
+  onActionComplete: () => void
+}) {
+  const [acting, setActing] = useState<'approve' | 'reject' | null>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [explanation, setExplanation] = useState<RunExplanation | null>(null)
+  const [explainLoading, setExplainLoading] = useState(false)
+
+  const isPending = approval.status === 'pending'
+  const riskLevel = approval.risk?.level ?? 'low'
+  const riskColor = RISK_COLORS[riskLevel] ?? RISK_COLORS.low
+
+  const handleAction = useCallback(async (action: 'approve' | 'reject') => {
+    setActing(action)
+    try {
+      await apiFetch(`/api/approvals/${approval.id}/${action}`)
+      onActionComplete()
+    } catch {
+      // swallow -- the refetch will show current state
+    } finally {
+      setActing(null)
+    }
+  }, [approval.id, onActionComplete])
+
+  const handleInspect = useCallback(async () => {
+    if (expanded) { setExpanded(false); return }
+    if (!approval.linked_run) { setExpanded(true); return }
+    setExpanded(true)
+    if (explanation) return // already loaded
+    setExplainLoading(true)
+    try {
+      const data = await apiFetch<RunExplanation>(`/api/runs/${approval.linked_run.run_id}/explain`, { method: 'GET' })
+      setExplanation(data)
+    } catch { /* ignore */ }
+    finally { setExplainLoading(false) }
+  }, [expanded, approval.linked_run, explanation])
+
+  const variant = riskLevel === 'high' ? 'error' as const
+    : riskLevel === 'medium' ? 'warning' as const
+    : 'default' as const
+
+  return (
+    <DataCard variant={variant} hover={false}>
+      <div className="flex items-start justify-between gap-4">
+        {/* Left: content */}
+        <div className="flex-1 min-w-0">
+          {/* Action name + status */}
+          <div className="flex items-center gap-3 mb-2">
+            <h3 className="text-base font-semibold text-slate-100 tracking-tight truncate">
+              {approval.action}
+            </h3>
+            {!isPending && <StatusBadge status={approval.status} />}
+          </div>
+
+          {/* Risk + reversibility + agent */}
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <span className={`inline-flex items-center border rounded-full text-xs font-medium px-2 py-0.5 ${riskColor}`}>
+              {riskLevel} risk
+            </span>
+            {approval.risk && (
+              <span className={`text-xs font-medium ${approval.risk.reversible ? 'text-emerald-400/70' : 'text-red-400/70'}`}>
+                {approval.risk.reversible ? 'Reversible' : 'Irreversible'}
+              </span>
+            )}
+            <span className="text-xs text-slate-500">
+              {agentLabel(approval.agent)}
+            </span>
+            {approval.created_at && (
+              <span className="text-xs text-slate-600">{timeAgo(approval.created_at)}</span>
+            )}
+          </div>
+
+          {/* Linked run */}
+          {approval.linked_run && (
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-xs text-slate-500">Run:</span>
+              <span className="text-xs text-slate-400 font-medium">{approval.linked_run.goal ?? approval.linked_run.run_id}</span>
+              {approval.linked_run.total_steps != null && approval.linked_run.current_step != null && (
+                <span className="text-xs text-slate-600 font-mono tabular-nums">
+                  Step {approval.linked_run.current_step}/{approval.linked_run.total_steps}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Timeout consequence */}
+          {isPending && approval.what_happens_if_nothing && (
+            <div className="bg-slate-900/50 border border-white/5 rounded-lg px-3 py-2 mt-2">
+              <p className="text-xs text-slate-400">
+                <span className="text-slate-500 font-medium">If no action: </span>
+                {approval.what_happens_if_nothing}
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Right: actions + countdown */}
+        <div className="flex flex-col items-end gap-2 shrink-0">
+          {/* Time remaining */}
+          {isPending && approval.time_remaining_ms != null && (
+            <TimeRemaining ms={approval.time_remaining_ms} />
+          )}
+
+          {/* Buttons */}
+          {isPending ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleInspect}
+                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-slate-700/50 text-slate-300 hover:bg-slate-700 transition-colors cursor-pointer border border-white/5"
+              >
+                Inspect
+              </button>
+              <button
+                onClick={() => handleAction('reject')}
+                disabled={!!acting}
+                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-red-500/10 text-red-400 hover:bg-red-500/20 border border-red-500/20 transition-colors cursor-pointer disabled:opacity-50"
+              >
+                {acting === 'reject' ? 'Rejecting...' : 'Reject'}
+              </button>
+              <button
+                onClick={() => handleAction('approve')}
+                disabled={!!acting}
+                className="text-xs px-3.5 py-1.5 rounded-lg font-medium bg-emerald-600 text-white hover:bg-emerald-500 transition-colors cursor-pointer disabled:opacity-50"
+              >
+                {acting === 'approve' ? 'Approving...' : 'Approve'}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleInspect}
+              className="text-xs px-3 py-1.5 rounded-lg font-medium bg-slate-700/50 text-slate-300 hover:bg-slate-700 transition-colors cursor-pointer border border-white/5"
+            >
+              {expanded ? 'Collapse' : 'Inspect'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expandable explanation */}
+      {expanded && (
+        <div className="mt-4 pt-4 border-t border-white/5">
+          {explainLoading ? (
+            <div className="flex items-center gap-2 py-2">
+              <div className="w-4 h-4 border-2 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin" />
+              <span className="text-xs text-slate-500">Loading explanation...</span>
+            </div>
+          ) : explanation ? (
+            <ExplanationPanel explanation={explanation} />
+          ) : (
+            <p className="text-xs text-slate-500">No run data available for this approval.</p>
+          )}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+/* ── Failures Tab ────────────────────────────────────────── */
+
+function FailuresTab({
+  runs, loading, onRetry,
+}: {
+  runs: Run[] | null
+  loading: boolean
+  onRetry: () => void
+}) {
+  if (loading && !runs) return <LoadingSpinner message="Loading failed runs..." />
+
+  if (!runs?.length) {
+    return (
+      <EmptyState
+        icon={<IconCheck size={28} />}
+        title="No recent failures"
+        subtitle="All agent runs completed successfully."
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {runs.map(run => (
+        <FailureCard key={run.run_id} run={run} onRetryComplete={onRetry} />
+      ))}
+    </div>
+  )
+}
+
+function FailureCard({
+  run, onRetryComplete,
+}: {
+  run: Run
+  onRetryComplete: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [explanation, setExplanation] = useState<RunExplanation | null>(null)
+  const [explainLoading, setExplainLoading] = useState(false)
+  const [confirmRetry, setConfirmRetry] = useState(false)
+  const [retrying, setRetrying] = useState(false)
+
+  const handleInspect = useCallback(async () => {
+    if (expanded) { setExpanded(false); return }
+    setExpanded(true)
+    if (explanation) return
+    setExplainLoading(true)
+    try {
+      const data = await apiFetch<RunExplanation>(`/api/runs/${run.run_id}/explain`, { method: 'GET' })
+      setExplanation(data)
+    } catch { /* ignore */ }
+    finally { setExplainLoading(false) }
+  }, [expanded, run.run_id, explanation])
+
+  const handleRetry = useCallback(async () => {
+    // If we have explanation and outbound effects occurred, require confirmation
+    if (explanation?.failure?.outbound_effects_may_have_occurred && !confirmRetry) {
+      setConfirmRetry(true)
+      return
+    }
+    setRetrying(true)
+    setConfirmRetry(false)
+    try {
+      await apiFetch(`/api/runs/${run.run_id}/retry`)
+      onRetryComplete()
+    } catch { /* ignore */ }
+    finally { setRetrying(false) }
+  }, [run.run_id, onRetryComplete, explanation, confirmRetry])
+
+  return (
+    <>
+      <DataCard variant="error" hover={false}>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            {/* Agent + goal */}
+            <div className="flex items-center gap-3 mb-1.5">
+              <span className="text-red-400 shrink-0"><IconError size={16} /></span>
+              <h3 className="text-sm font-semibold text-slate-100 tracking-tight truncate">
+                {agentLabel(run.agent_id)}
+              </h3>
+              <StatusBadge status="failed" />
+            </div>
+            {run.goal && (
+              <p className="text-xs text-slate-400 mb-2 ml-7">{run.goal}</p>
+            )}
+
+            {/* Error message */}
+            {run.error && (
+              <div className="bg-red-500/5 border border-red-500/10 rounded-lg px-3 py-2 ml-7">
+                <p className="text-xs text-red-300/80 font-mono break-all">{run.error}</p>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col items-end gap-2 shrink-0">
+            <span className="text-xs text-slate-600">{timeAgo(run.started_at)}</span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleInspect}
+                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-slate-700/50 text-slate-300 hover:bg-slate-700 transition-colors cursor-pointer border border-white/5"
+              >
+                {expanded ? 'Collapse' : 'Inspect'}
+              </button>
+              <button
+                onClick={handleRetry}
+                disabled={retrying}
+                className="text-xs px-3 py-1.5 rounded-lg font-medium bg-indigo-600 text-white hover:bg-indigo-500 transition-colors cursor-pointer disabled:opacity-50"
+              >
+                {retrying ? 'Retrying...' : 'Retry'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Expandable explanation */}
+        {expanded && (
+          <div className="mt-4 pt-4 border-t border-white/5 ml-7">
+            {explainLoading ? (
+              <div className="flex items-center gap-2 py-2">
+                <div className="w-4 h-4 border-2 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin" />
+                <span className="text-xs text-slate-500">Loading explanation...</span>
+              </div>
+            ) : explanation ? (
+              <ExplanationPanel explanation={explanation} />
+            ) : (
+              <p className="text-xs text-slate-500">No explanation available.</p>
+            )}
+          </div>
+        )}
+      </DataCard>
+
+      <ConfirmDialog
+        open={confirmRetry}
+        title="Retry with caution"
+        message={`This run may have produced outbound effects before failing. Retrying could cause duplicate actions.`}
+        warning={explanation?.failure?.probable_cause}
+        confirmLabel="Retry anyway"
+        cancelLabel="Cancel"
+        variant="warning"
+        onConfirm={handleRetry}
+        onCancel={() => setConfirmRetry(false)}
+      />
+    </>
+  )
+}
+
+/* ── Retries Tab ─────────────────────────────────────────── */
+
+function RetriesTab({ runs, loading }: { runs: Run[] | null; loading: boolean }) {
+  if (loading && !runs) return <LoadingSpinner message="Loading retry guidance..." />
+
+  if (!runs?.length) {
+    return (
+      <EmptyState
+        icon={<IconCheck size={28} />}
+        title="Nothing to retry"
+        subtitle="No failed runs require retry assessment."
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {runs.map(run => (
+        <RetryCard key={run.run_id} run={run} />
+      ))}
+    </div>
+  )
+}
+
+function RetryCard({ run }: { run: Run }) {
+  const [explanation, setExplanation] = useState<RunExplanation | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    apiFetch<RunExplanation>(`/api/runs/${run.run_id}/explain`, { method: 'GET' })
+      .then(setExplanation)
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [run.run_id])
+
+  const failure = explanation?.failure
+  const hasOutbound = failure?.outbound_effects_may_have_occurred
+
+  return (
+    <DataCard variant={hasOutbound ? 'warning' : 'default'} hover={false}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 mb-2">
+            <h3 className="text-sm font-semibold text-slate-100 tracking-tight truncate">
+              {agentLabel(run.agent_id)}
+            </h3>
+            {run.goal && (
+              <span className="text-xs text-slate-500 truncate">{run.goal}</span>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="flex items-center gap-2 py-1">
+              <div className="w-3 h-3 border-2 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin" />
+              <span className="text-xs text-slate-500">Assessing...</span>
+            </div>
+          ) : failure ? (
+            <div className="space-y-2">
+              {/* Probable cause */}
+              <div className="bg-slate-900/50 border border-white/5 rounded-lg px-3 py-2">
+                <p className="text-xs text-slate-500 font-medium mb-0.5">Probable cause</p>
+                <p className="text-xs text-slate-300">{failure.probable_cause}</p>
+              </div>
+
+              {/* Outbound effects warning */}
+              {hasOutbound && (
+                <div className="bg-amber-500/5 border border-amber-500/15 rounded-lg px-3 py-2 flex items-start gap-2">
+                  <span className="text-amber-400 shrink-0 mt-0.5"><IconWarning size={14} /></span>
+                  <p className="text-xs text-amber-300/80">
+                    Outbound effects may have occurred before failure. Retry with caution.
+                  </p>
+                </div>
+              )}
+
+              {/* Retry recommendation */}
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-slate-500 font-medium">Recommendation:</span>
+                <span className={`text-xs font-medium ${
+                  failure.retry_recommendation === 'safe'
+                    ? 'text-emerald-400'
+                    : failure.retry_recommendation === 'caution'
+                    ? 'text-amber-400'
+                    : 'text-red-400'
+                }`}>
+                  {failure.retry_recommendation}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500">No retry guidance available for this run.</p>
+          )}
+        </div>
+
+        <div className="flex flex-col items-end gap-2 shrink-0">
+          <span className="text-xs text-slate-600">{timeAgo(run.started_at)}</span>
+          {failure && (
+            <span className={`inline-flex items-center border rounded-full text-xs font-medium px-2 py-0.5 ${
+              hasOutbound
+                ? 'bg-amber-500/10 text-amber-400 border-amber-500/20'
+                : 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20'
+            }`}>
+              {hasOutbound ? 'Has side effects' : 'Safe to retry'}
+            </span>
+          )}
+        </div>
+      </div>
+    </DataCard>
+  )
+}
+
+/* ── Alerts Tab ──────────────────────────────────────────── */
+
+function AlertsTab({ repair, loading }: { repair: RepairReport | null; loading: boolean }) {
+  if (loading && !repair) return <LoadingSpinner message="Loading system health..." />
+
+  if (!repair) {
+    return (
+      <EmptyState
+        icon={<IconCheck size={28} />}
+        title="No repair data"
+        subtitle="Could not load system health information."
+      />
+    )
+  }
+
+  const banner = REPAIR_BANNER[repair.status] ?? REPAIR_BANNER.healthy
+
+  return (
+    <div>
+      {/* Status banner */}
+      <div className={`${banner.bg} border ${banner.border} rounded-xl px-5 py-4 mb-5 backdrop-blur-sm`}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="relative flex h-2.5 w-2.5">
+              {repair.status !== 'healthy' && (
+                <span className={`animate-ping absolute inline-flex h-full w-full rounded-full ${banner.dot} opacity-75`} />
+              )}
+              <span className={`relative inline-flex rounded-full h-2.5 w-2.5 ${banner.dot}`} />
+            </span>
+            <span className={`text-sm font-semibold ${banner.text} tracking-tight`}>
+              System {repair.status}
+            </span>
+            <span className="text-xs text-slate-500">
+              {repair.checks.length} check{repair.checks.length !== 1 ? 's' : ''} evaluated
+            </span>
+          </div>
+          <Link
+            to="/recovery"
+            className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
+            Full recovery view
+          </Link>
+        </div>
+      </div>
+
+      {/* Safe mode warning */}
+      {repair.safe_mode && (
+        <div className="bg-red-500/5 border border-red-500/15 rounded-xl px-5 py-3 mb-5 flex items-center gap-3">
+          <span className="text-red-400 shrink-0"><IconWarning size={18} /></span>
+          <div>
+            <p className="text-sm text-red-300 font-medium">Safe mode active</p>
+            <p className="text-xs text-red-400/60 mt-0.5">
+              Autonomous operations are paused. Resolve critical checks to resume.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Repair checks */}
+      {repair.checks.length === 0 ? (
+        <EmptyState
+          icon={<IconCheck size={28} />}
+          title="All checks passed"
+          subtitle="No issues detected."
+        />
+      ) : (
+        <div className="space-y-3">
+          {repair.checks.map(check => {
+            const checkColors = STATUS_COLORS[check.status] ?? STATUS_COLORS.ok
+            const fixAction = repair.recommended_actions.find(a => a.check === check.name)
+
+            return (
+              <DataCard
+                key={check.name}
+                variant={check.status === 'critical' ? 'error' : check.status === 'warning' ? 'warning' : 'default'}
+                hover={false}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-1.5">
+                      <span className={check.status === 'ok' ? 'text-emerald-400' : check.status === 'warning' ? 'text-amber-400' : 'text-red-400'}>
+                        {check.status === 'ok' ? <IconCheck size={16} /> : check.status === 'warning' ? <IconWarning size={16} /> : <IconError size={16} />}
+                      </span>
+                      <h3 className="text-sm font-semibold text-slate-100 tracking-tight">
+                        {check.name}
+                      </h3>
+                      <StatusBadge status={check.status} />
+                    </div>
+                    <p className="text-xs text-slate-400 ml-7 mb-1">{check.message}</p>
+
+                    {/* Fix action */}
+                    {fixAction && (
+                      <div className="bg-slate-900/50 border border-white/5 rounded-lg px-3 py-2 mt-2 ml-7">
+                        <p className="text-xs text-slate-500 font-medium mb-0.5">Suggested fix</p>
+                        <p className="text-xs text-slate-300">{fixAction.action.description}</p>
+                        {fixAction.action.example && (
+                          <pre className="text-[11px] text-indigo-400/80 mt-1 font-mono overflow-x-auto">
+                            {fixAction.action.example}
+                          </pre>
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="shrink-0">
+                    <span className={`inline-flex items-center border rounded-full text-xs font-medium px-2 py-0.5 ${checkColors}`}>
+                      severity {check.severity}
+                    </span>
+                  </div>
+                </div>
+              </DataCard>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── Shared sub-components ───────────────────────────────── */
+
+function ExplanationPanel({ explanation }: { explanation: RunExplanation }) {
+  return (
+    <div className="space-y-3">
+      {/* Summary */}
+      <p className="text-sm text-slate-200">{explanation.summary}</p>
+
+      {/* Stats row */}
+      <div className="flex flex-wrap gap-4">
+        <Stat label="Trigger" value={explanation.trigger} />
+        <Stat label="Steps" value={`${explanation.steps_completed}/${explanation.steps_total}`} />
+        <Stat label="Decisions" value={String(explanation.decisions_made)} />
+        <Stat label="Approvals" value={String(explanation.approvals_required)} />
+        <Stat label="Outcome" value={explanation.outcome} highlight={explanation.outcome === 'failed' ? 'red' : explanation.outcome === 'completed' ? 'emerald' : undefined} />
+      </div>
+
+      {/* Data sources */}
+      {explanation.data_sources.length > 0 && (
+        <div>
+          <p className="text-xs text-slate-500 font-medium mb-1">Data sources</p>
+          <div className="flex flex-wrap gap-1.5">
+            {explanation.data_sources.map(src => (
+              <span key={src} className="text-[11px] text-slate-400 bg-slate-800 border border-white/5 px-2 py-0.5 rounded">
+                {src}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Failure details */}
+      {explanation.failure && (
+        <div className="bg-red-500/5 border border-red-500/10 rounded-lg px-3 py-2.5">
+          <p className="text-xs text-red-300/80 font-medium mb-1">Probable cause</p>
+          <p className="text-xs text-red-300/60">{explanation.failure.probable_cause}</p>
+          {explanation.failure.outbound_effects_may_have_occurred && (
+            <div className="flex items-center gap-1.5 mt-2">
+              <span className="text-amber-400"><IconWarning size={12} /></span>
+              <span className="text-[11px] text-amber-300/80">Outbound effects may have occurred</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2 mt-2">
+            <span className="text-[11px] text-slate-500">Retry:</span>
+            <span className={`text-[11px] font-medium ${
+              explanation.failure.retry_recommendation === 'safe' ? 'text-emerald-400'
+              : explanation.failure.retry_recommendation === 'caution' ? 'text-amber-400'
+              : 'text-red-400'
+            }`}>
+              {explanation.failure.retry_recommendation}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Preview mode */}
+      {explanation.preview_mode?.enabled && (
+        <div className="bg-blue-500/5 border border-blue-500/10 rounded-lg px-3 py-2">
+          <p className="text-xs text-blue-300/80 font-medium mb-1">Preview mode</p>
+          {explanation.preview_mode.skipped_actions.length > 0 && (
+            <p className="text-xs text-blue-300/60">
+              Skipped: {explanation.preview_mode.skipped_actions.join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Stat({
+  label, value, highlight,
+}: {
+  label: string; value: string; highlight?: 'red' | 'emerald'
+}) {
+  const valueColor = highlight === 'red' ? 'text-red-400'
+    : highlight === 'emerald' ? 'text-emerald-400'
+    : 'text-slate-200'
+
+  return (
+    <div>
+      <p className="text-[10px] text-slate-600 uppercase tracking-wider">{label}</p>
+      <p className={`text-xs font-medium ${valueColor}`}>{value}</p>
+    </div>
+  )
+}
+
+function TimeRemaining({ ms }: { ms: number }) {
+  const [remaining, setRemaining] = useState(ms)
+
+  useEffect(() => {
+    setRemaining(ms)
+    const interval = setInterval(() => {
+      setRemaining(prev => Math.max(0, prev - 1000))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [ms])
+
+  const totalSecs = Math.max(0, Math.floor(remaining / 1000))
+  const mins = Math.floor(totalSecs / 60)
+  const secs = totalSecs % 60
+  const isUrgent = totalSecs < 60
+
+  return (
+    <div className={`flex items-center gap-1.5 ${isUrgent ? 'text-red-400' : 'text-slate-500'}`}>
+      <IconClock size={12} />
+      <span className="text-xs font-mono tabular-nums">
+        {mins}:{secs.toString().padStart(2, '0')}
+      </span>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/Models.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Models.tsx
@@ -1,0 +1,325 @@
+import { useState, useCallback } from 'react'
+import { useApi, apiFetch } from '../hooks/useApi.ts'
+import PageHeader from '../shared/PageHeader.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import { IconWarning } from '../shared/icons.tsx'
+import type { ModelInfo, ModelHealthReport } from '../types/index.ts'
+import { timeAgo } from '../types/index.ts'
+
+/* ── Page-local types ────────────────────────────────────── */
+
+interface WorkflowMapping {
+  workflow_id: string
+  agent_id: string
+  inference_tier: string
+}
+
+/* ── Main Component ──────────────────────────────────────── */
+
+export default function Models() {
+  const { data: models, loading: modelsLoading, refetch: refetchModels } =
+    useApi<ModelInfo[]>('/api/models')
+  const { data: health, loading: healthLoading, error: healthError } =
+    useApi<ModelHealthReport>('/api/models/health')
+  const { data: mappings, loading: mappingsLoading } =
+    useApi<WorkflowMapping[]>('/api/models/workflow-mapping')
+
+  const [toggling, setToggling] = useState<string | null>(null)
+
+  const handleToggle = useCallback(async (model: ModelInfo) => {
+    if (!model.runtime) return
+    const key = `${model.runtime}/${model.id}`
+    setToggling(key)
+    try {
+      await apiFetch(`/api/models/${encodeURIComponent(model.runtime)}/${encodeURIComponent(model.id)}`, {
+        method: 'PATCH',
+        body: { enabled: !model.enabled },
+      })
+      refetchModels()
+    } catch {
+      // toggle failed silently — user sees stale state until next refetch
+    } finally {
+      setToggling(null)
+    }
+  }, [refetchModels])
+
+  const loading = modelsLoading || healthLoading || mappingsLoading
+  if (loading) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <PageHeader title="Models" subtitle="Model registry and runtime health" />
+        <LoadingSpinner message="Loading model data..." />
+      </div>
+    )
+  }
+
+  const degraded = health?.degraded ?? false
+  const runtimes = health?.runtimes ?? []
+  const modelList = models ?? []
+  const workflowMappings = mappings ?? []
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="Models"
+        subtitle="Model registry and runtime health"
+        actions={
+          <StatusBadge
+            status={degraded ? 'degraded' : 'healthy'}
+            label={degraded ? 'Degraded' : 'All Healthy'}
+            pulse={degraded}
+            variant="dot"
+            size="md"
+          />
+        }
+      />
+
+      {/* ── Degradation Banner ───────────────────────────────── */}
+      {degraded && <DegradationBanner runtimes={runtimes} />}
+
+      {/* ── Runtime Health ───────────────────────────────────── */}
+      <div className="mb-6">
+        <RuntimeHealthSection runtimes={runtimes} error={healthError} />
+      </div>
+
+      {/* ── Model Registry ───────────────────────────────────── */}
+      <div className="mb-6">
+        <ModelRegistryTable
+          models={modelList}
+          toggling={toggling}
+          onToggle={handleToggle}
+        />
+      </div>
+
+      {/* ── Workflow Mapping ─────────────────────────────────── */}
+      <div className="mb-6">
+        <WorkflowMappingTable mappings={workflowMappings} />
+      </div>
+    </div>
+  )
+}
+
+/* ── Section Components ──────────────────────────────────── */
+
+function DegradationBanner({ runtimes }: { runtimes: ModelHealthReport['runtimes'] }) {
+  const disconnected = runtimes.filter(r => !r.connected)
+  return (
+    <div className="mb-6 bg-amber-500/10 border border-amber-500/20 rounded-xl px-5 py-4 flex items-start gap-3">
+      <span className="text-amber-400 mt-0.5 shrink-0"><IconWarning size={18} /></span>
+      <div>
+        <p className="text-sm font-medium text-amber-300">Model service degraded</p>
+        <p className="text-xs text-amber-300/60 mt-1">
+          {disconnected.length} runtime{disconnected.length !== 1 ? 's' : ''} disconnected
+          {disconnected.length > 0 && `: ${disconnected.map(r => r.name).join(', ')}`}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function RuntimeHealthSection({
+  runtimes,
+  error,
+}: {
+  runtimes: ModelHealthReport['runtimes']
+  error: string | null
+}) {
+  return (
+    <DataCard hover={false}>
+      <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+        Runtime Health
+      </h2>
+
+      {error ? (
+        <p className="text-xs text-red-400">{error}</p>
+      ) : runtimes.length === 0 ? (
+        <EmptyState title="No runtimes configured" subtitle="Add model runtimes to enable agent execution." />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {runtimes.map(rt => (
+            <div
+              key={rt.name}
+              className="bg-slate-900/40 border border-white/5 rounded-lg px-4 py-3"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2.5 min-w-0">
+                  <span className="relative flex h-2 w-2 shrink-0">
+                    {rt.connected && (
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                    )}
+                    <span className={`relative inline-flex rounded-full h-2 w-2 ${rt.connected ? 'bg-emerald-500' : 'bg-red-500'}`} />
+                  </span>
+                  <span className="text-sm font-medium text-slate-200 truncate">{rt.name}</span>
+                </div>
+                <StatusBadge
+                  status={rt.connected ? 'ok' : 'critical'}
+                  label={rt.connected ? 'Connected' : 'Down'}
+                  size="sm"
+                />
+              </div>
+
+              <p className="text-[11px] text-slate-600 font-mono mb-2 truncate">{rt.url}</p>
+
+              {rt.error && (
+                <p className="text-[11px] text-red-400 mb-2 truncate">{rt.error}</p>
+              )}
+
+              {rt.models.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {rt.models.map(m => (
+                    <span
+                      key={m}
+                      className="text-[10px] bg-slate-800 text-slate-400 px-2 py-0.5 rounded-md font-mono"
+                    >
+                      {m}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-[11px] text-slate-600">No models loaded</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+function ModelRegistryTable({
+  models,
+  toggling,
+  onToggle,
+}: {
+  models: ModelInfo[]
+  toggling: string | null
+  onToggle: (model: ModelInfo) => void
+}) {
+  return (
+    <DataCard hover={false}>
+      <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+        Model Registry
+      </h2>
+
+      {models.length === 0 ? (
+        <EmptyState title="No models registered" subtitle="Models appear here when runtimes report them." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-white/5">
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Model ID</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Runtime</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Tags</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Last Seen</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 text-right">Enabled</th>
+              </tr>
+            </thead>
+            <tbody>
+              {models.map(model => {
+                const key = `${model.runtime ?? ''}/${model.id}`
+                const isToggling = toggling === key
+                return (
+                  <tr key={model.id} className="border-b border-white/[0.03] last:border-0">
+                    <td className="py-2.5 pr-4">
+                      <span className="text-sm text-slate-200 font-mono">{model.id}</span>
+                      {model.name && model.name !== model.id && (
+                        <span className="text-[11px] text-slate-600 ml-2">{model.name}</span>
+                      )}
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <span className="text-xs text-slate-400 font-mono">{model.runtime ?? '--'}</span>
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <div className="flex flex-wrap gap-1">
+                        {(model.capabilities ?? []).map(tag => (
+                          <span
+                            key={tag}
+                            className="text-[10px] bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 px-1.5 py-0.5 rounded-md"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <span className="text-xs text-slate-500">{timeAgo(model.last_seen_at ?? null)}</span>
+                    </td>
+                    <td className="py-2.5 text-right">
+                      <button
+                        onClick={() => onToggle(model)}
+                        disabled={isToggling || !model.runtime}
+                        className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                        style={{ backgroundColor: model.enabled ? 'rgb(16 185 129 / 0.6)' : 'rgb(51 65 85 / 0.6)' }}
+                      >
+                        <span
+                          className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                            model.enabled ? 'translate-x-[18px]' : 'translate-x-[3px]'
+                          }`}
+                        />
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+function WorkflowMappingTable({ mappings }: { mappings: WorkflowMapping[] }) {
+  const tierColors: Record<string, string> = {
+    opus: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
+    sonnet: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+    haiku: 'bg-cyan-500/10 text-cyan-400 border-cyan-500/20',
+  }
+
+  return (
+    <DataCard hover={false}>
+      <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+        Workflow Mapping
+      </h2>
+
+      {mappings.length === 0 ? (
+        <EmptyState title="No workflow mappings" subtitle="Workflow-to-model tier mappings will appear here." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-white/5">
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Workflow</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Agent</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2">Inference Tier</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mappings.map(m => (
+                <tr key={`${m.workflow_id}-${m.agent_id}`} className="border-b border-white/[0.03] last:border-0">
+                  <td className="py-2.5 pr-4">
+                    <span className="text-sm text-slate-200 font-mono">{m.workflow_id}</span>
+                  </td>
+                  <td className="py-2.5 pr-4">
+                    <span className="text-xs text-slate-400">{m.agent_id}</span>
+                  </td>
+                  <td className="py-2.5">
+                    <span className={`inline-flex items-center text-[10px] font-medium border rounded-full px-2 py-0.5 ${
+                      tierColors[m.inference_tier] ?? 'bg-slate-500/10 text-slate-400 border-slate-500/20'
+                    }`}>
+                      {m.inference_tier}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </DataCard>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/Queue.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Queue.tsx
@@ -1,0 +1,152 @@
+import { usePolling } from '../hooks/usePolling.ts'
+import PageHeader from '../shared/PageHeader.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import { timeAgo } from '../types/index.ts'
+
+/* ── Page-local types ────────────────────────────────────── */
+
+interface QueueCommand {
+  id: string
+  type: string
+  target_agent: string
+  status: string
+  priority: number
+  created_at: string
+}
+
+/* ── Priority helpers ────────────────────────────────────── */
+
+const PRIORITY_LABELS: Record<number, string> = {
+  0: 'Low',
+  1: 'Normal',
+  2: 'High',
+  3: 'Critical',
+}
+
+const PRIORITY_COLORS: Record<number, string> = {
+  0: 'text-slate-500',
+  1: 'text-slate-300',
+  2: 'text-amber-400',
+  3: 'text-red-400',
+}
+
+function priorityLabel(p: number): string {
+  return PRIORITY_LABELS[p] ?? `P${p}`
+}
+
+function truncateId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}...` : id
+}
+
+/* ── Main Component ──────────────────────────────────────── */
+
+export default function Queue() {
+  const { data, loading, error } = usePolling<QueueCommand[]>('/api/queue', 5000)
+
+  const commands = data ?? []
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="Command Queue"
+        subtitle="Pending and active commands"
+        actions={
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-slate-500 font-mono">
+              Auto-refresh 5s
+            </span>
+            {!loading && (
+              <StatusBadge
+                status={commands.length > 0 ? 'pending' : 'ok'}
+                label={`${commands.length} command${commands.length !== 1 ? 's' : ''}`}
+                size="sm"
+              />
+            )}
+          </div>
+        }
+      />
+
+      {loading && !data ? (
+        <LoadingSpinner message="Loading command queue..." />
+      ) : error ? (
+        <ErrorBanner message={error} />
+      ) : commands.length === 0 ? (
+        <EmptyState
+          title="Queue is empty"
+          subtitle="No pending commands. Commands appear here when agents or workflows enqueue work."
+        />
+      ) : (
+        <QueueTable commands={commands} />
+      )}
+    </div>
+  )
+}
+
+/* ── Section Components ──────────────────────────────────── */
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="bg-red-500/10 border border-red-500/20 rounded-xl px-5 py-4">
+      <p className="text-sm text-red-400">Failed to load queue</p>
+      <p className="text-xs text-red-300/60 mt-1">{message}</p>
+    </div>
+  )
+}
+
+function QueueTable({ commands }: { commands: QueueCommand[] }) {
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b border-white/5 bg-slate-900/30">
+              <th className="text-[10px] text-slate-600 uppercase tracking-wider px-5 py-3">Command ID</th>
+              <th className="text-[10px] text-slate-600 uppercase tracking-wider px-5 py-3">Type</th>
+              <th className="text-[10px] text-slate-600 uppercase tracking-wider px-5 py-3">Target Agent</th>
+              <th className="text-[10px] text-slate-600 uppercase tracking-wider px-5 py-3">Status</th>
+              <th className="text-[10px] text-slate-600 uppercase tracking-wider px-5 py-3">Priority</th>
+              <th className="text-[10px] text-slate-600 uppercase tracking-wider px-5 py-3 text-right">Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {commands.map(cmd => (
+              <tr key={cmd.id} className="border-b border-white/[0.03] last:border-0 hover:bg-slate-800/30 transition-colors">
+                <td className="px-5 py-3">
+                  <span className="text-xs text-slate-300 font-mono" title={cmd.id}>
+                    {truncateId(cmd.id)}
+                  </span>
+                </td>
+                <td className="px-5 py-3">
+                  <span className="text-sm text-slate-200">{cmd.type}</span>
+                </td>
+                <td className="px-5 py-3">
+                  <span className="text-xs text-slate-400">{cmd.target_agent}</span>
+                </td>
+                <td className="px-5 py-3">
+                  <StatusBadge status={cmd.status} size="sm" />
+                </td>
+                <td className="px-5 py-3">
+                  <span className={`text-xs font-medium ${PRIORITY_COLORS[cmd.priority] ?? 'text-slate-400'}`}>
+                    {priorityLabel(cmd.priority)}
+                  </span>
+                </td>
+                <td className="px-5 py-3 text-right">
+                  <span className="text-xs text-slate-500">{timeAgo(cmd.created_at)}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Footer */}
+      <div className="border-t border-white/5 px-5 py-2.5 bg-slate-900/20">
+        <span className="text-[11px] text-slate-600">
+          Showing {commands.length} command{commands.length !== 1 ? 's' : ''} ordered by priority then creation time
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/Recovery.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Recovery.tsx
@@ -1,0 +1,855 @@
+import React, { useState, useCallback } from 'react'
+import { useDashboardStore } from '../stores/dashboard-store.ts'
+import { useApi, apiFetch } from '../hooks/useApi.ts'
+import PageHeader from '../shared/PageHeader.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import ConfirmDialog from '../shared/ConfirmDialog.tsx'
+import { IconWarning, IconCheck, IconError, IconRecovery } from '../shared/icons.tsx'
+import type { RepairReport, RepairCheck, FixAction, DaemonStatus } from '../types/index.ts'
+import { formatUptime, timeAgo } from '../types/index.ts'
+
+/* ── API response shapes (page-local) ────────────────────── */
+
+interface SafeModeApiResponse {
+  safe_mode: boolean
+  reason: string
+  checks: { databases_ok: boolean; config_ok: boolean; daemon_running: boolean }
+}
+
+interface BackupStatusResponse {
+  last_backup: string | null
+  path: string | null
+  files: string[]
+  size: number
+}
+
+interface SupportBundleResponse {
+  generated_at: string
+  system: Record<string, unknown>
+  repair: Record<string, unknown>
+  daemon: Record<string, unknown>
+  [key: string]: unknown
+}
+
+/* ── Main Component ──────────────────────────────────────── */
+
+export default function Recovery() {
+  const { daemon } = useDashboardStore()
+
+  const { data: repair, loading: repairLoading, error: repairError, refetch: refetchRepair } =
+    useApi<RepairReport>('/api/repair')
+  const { data: safeModeData, loading: safeModeLoading, refetch: refetchSafeMode } =
+    useApi<SafeModeApiResponse>('/api/safemode')
+  const { data: daemonStatus, loading: daemonLoading, refetch: refetchDaemon } =
+    useApi<DaemonStatus>('/api/daemon/status')
+  const { data: backupStatus, loading: backupLoading, refetch: refetchBackup } =
+    useApi<BackupStatusResponse>('/api/backup/status')
+
+  /* ── Dialog state ──────────────────────────────────────── */
+  const [restartConfirm, setRestartConfirm] = useState(false)
+  const [restartRunning, setRestartRunning] = useState(false)
+  const [backupConfirm, setBackupConfirm] = useState(false)
+  const [backupRunning, setBackupRunning] = useState(false)
+  const [restoreConfirm, setRestoreConfirm] = useState(false)
+  const [restoreRunning, setRestoreRunning] = useState(false)
+  const [restorePath, setRestorePath] = useState('')
+  const [exitSafeModeRunning, setExitSafeModeRunning] = useState(false)
+  const [exitSafeModeResult, setExitSafeModeResult] = useState<string | null>(null)
+  const [bundleData, setBundleData] = useState<SupportBundleResponse | null>(null)
+  const [bundleLoading, setBundleLoading] = useState(false)
+  const [bundleExpanded, setBundleExpanded] = useState(false)
+  const [actionErrors, setActionErrors] = useState<Record<string, string>>({})
+
+  /* ── Handlers ──────────────────────────────────────────── */
+
+  const handleRestartDaemon = useCallback(async () => {
+    setRestartConfirm(false)
+    setRestartRunning(true)
+    setActionErrors(prev => ({ ...prev, restart: '' }))
+    try {
+      await apiFetch('/api/service/restart', { method: 'POST' })
+      refetchDaemon()
+      refetchRepair()
+    } catch (err) {
+      setActionErrors(prev => ({ ...prev, restart: err instanceof Error ? err.message : 'Restart failed' }))
+    } finally {
+      setRestartRunning(false)
+    }
+  }, [refetchDaemon, refetchRepair])
+
+  const handleBackup = useCallback(async () => {
+    setBackupConfirm(false)
+    setBackupRunning(true)
+    setActionErrors(prev => ({ ...prev, backup: '' }))
+    try {
+      await apiFetch('/api/backup', { method: 'POST' })
+      refetchBackup()
+      refetchRepair()
+    } catch (err) {
+      setActionErrors(prev => ({ ...prev, backup: err instanceof Error ? err.message : 'Backup failed' }))
+    } finally {
+      setBackupRunning(false)
+    }
+  }, [refetchBackup, refetchRepair])
+
+  const handleRestore = useCallback(async () => {
+    setRestoreConfirm(false)
+    setRestoreRunning(true)
+    setActionErrors(prev => ({ ...prev, restore: '' }))
+    try {
+      await apiFetch('/api/backup/restore', { method: 'POST', body: { backup_path: restorePath } })
+      refetchRepair()
+      refetchDaemon()
+      refetchBackup()
+    } catch (err) {
+      setActionErrors(prev => ({ ...prev, restore: err instanceof Error ? err.message : 'Restore failed' }))
+    } finally {
+      setRestoreRunning(false)
+    }
+  }, [restorePath, refetchRepair, refetchDaemon, refetchBackup])
+
+  const handleExitSafeMode = useCallback(async () => {
+    setExitSafeModeRunning(true)
+    setExitSafeModeResult(null)
+    try {
+      const result = await apiFetch<{ ok: boolean; message?: string }>('/api/safemode/exit', { method: 'POST' })
+      setExitSafeModeResult(result.ok ? 'Safe mode exited successfully.' : (result.message ?? 'Validation failed.'))
+      refetchSafeMode()
+      refetchRepair()
+    } catch (err) {
+      setExitSafeModeResult(err instanceof Error ? err.message : 'Failed to exit safe mode.')
+    } finally {
+      setExitSafeModeRunning(false)
+    }
+  }, [refetchSafeMode, refetchRepair])
+
+  const handleExportBundle = useCallback(async () => {
+    setBundleLoading(true)
+    try {
+      const data = await apiFetch<SupportBundleResponse>('/api/support/bundle', { method: 'GET' })
+      setBundleData(data)
+      setBundleExpanded(true)
+      // Trigger download
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `jarvis-support-bundle-${new Date().toISOString().slice(0, 10)}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      // Silent — user sees empty state
+    } finally {
+      setBundleLoading(false)
+    }
+  }, [])
+
+  const refetchAll = useCallback(() => {
+    refetchRepair()
+    refetchSafeMode()
+    refetchDaemon()
+    refetchBackup()
+  }, [refetchRepair, refetchSafeMode, refetchDaemon, refetchBackup])
+
+  /* ── Derived ───────────────────────────────────────────── */
+
+  const overallStatus = repair?.status ?? 'healthy'
+  const checks = repair?.checks ?? []
+  const recommendedActions = repair?.recommended_actions ?? []
+  const isSafeMode = safeModeData?.safe_mode ?? repair?.safe_mode ?? false
+  const issueCount = checks.filter(c => c.status !== 'ok').length
+
+  if (repairLoading && safeModeLoading) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <PageHeader title="Recovery" subtitle="Repair and recovery tools" />
+        <LoadingSpinner message="Running diagnostics..." />
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="Recovery"
+        subtitle="Repair and recovery tools"
+        actions={
+          <button
+            onClick={refetchAll}
+            className="text-xs px-3 py-1.5 rounded-lg font-medium bg-slate-800 text-slate-300 hover:bg-slate-700 border border-white/5 transition-colors cursor-pointer"
+          >
+            Re-scan
+          </button>
+        }
+      />
+
+      {/* ── 1. Overall Status Banner ─────────────────────────── */}
+      <OverallStatusBanner
+        status={overallStatus}
+        issueCount={issueCount}
+        loading={repairLoading}
+        error={repairError}
+      />
+
+      {/* ── 2. Safe Mode Status ──────────────────────────────── */}
+      <div className="mt-4">
+        <SafeModeSection
+          data={safeModeData}
+          active={isSafeMode}
+          loading={safeModeLoading}
+          exiting={exitSafeModeRunning}
+          exitResult={exitSafeModeResult}
+          onExit={handleExitSafeMode}
+        />
+      </div>
+
+      {/* ── 3. Repair Checks ─────────────────────────────────── */}
+      {checks.length > 0 && (
+        <div className="mt-4">
+          <SectionHeading title="Repair Checks" count={checks.length} />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+            {checks.map(check => (
+              <RepairCheckCard
+                key={check.name}
+                check={check}
+                onRestartDaemon={() => setRestartConfirm(true)}
+                restartRunning={restartRunning}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── 4. Recommended Actions ───────────────────────────── */}
+      {recommendedActions.length > 0 && (
+        <div className="mt-4">
+          <RecommendedActionsSection actions={recommendedActions} />
+        </div>
+      )}
+
+      {/* ── 5. Daemon Control ────────────────────────────────── */}
+      <div className="mt-4">
+        <DaemonControlSection
+          daemon={daemonStatus ?? daemon ?? null}
+          loading={daemonLoading}
+          restartRunning={restartRunning}
+          restartError={actionErrors.restart}
+          onRestart={() => setRestartConfirm(true)}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
+        {/* ── 6. Backup / Restore ──────────────────────────────── */}
+        <BackupRestoreSection
+          backup={backupStatus}
+          loading={backupLoading}
+          backupRunning={backupRunning}
+          restoreRunning={restoreRunning}
+          restorePath={restorePath}
+          backupError={actionErrors.backup}
+          restoreError={actionErrors.restore}
+          onBackup={() => setBackupConfirm(true)}
+          onRestorePathChange={setRestorePath}
+          onRestore={() => setRestoreConfirm(true)}
+        />
+
+        {/* ── 7. Support Bundle ────────────────────────────────── */}
+        <SupportBundleSection
+          data={bundleData}
+          loading={bundleLoading}
+          expanded={bundleExpanded}
+          onExport={handleExportBundle}
+          onToggleExpand={() => setBundleExpanded(v => !v)}
+        />
+      </div>
+
+      {/* ── Confirmation Dialogs ────────────────────────────── */}
+      <ConfirmDialog
+        open={restartConfirm}
+        title="Restart Daemon"
+        message="This will restart the Jarvis daemon process. Active runs will be interrupted."
+        warning="Any currently executing agent runs will be terminated."
+        confirmLabel="Restart Daemon"
+        variant="warning"
+        onConfirm={handleRestartDaemon}
+        onCancel={() => setRestartConfirm(false)}
+      />
+      <ConfirmDialog
+        open={backupConfirm}
+        title="Create Backup"
+        message="This will create a new backup of all Jarvis databases and configuration files."
+        confirmLabel="Create Backup"
+        onConfirm={handleBackup}
+        onCancel={() => setBackupConfirm(false)}
+      />
+      <ConfirmDialog
+        open={restoreConfirm}
+        title="Restore from Backup"
+        message={`This will restore Jarvis state from the backup at: ${restorePath || '(no path specified)'}`}
+        warning="This is a destructive operation. Current databases will be overwritten with the backup contents. This cannot be undone."
+        confirmLabel="Restore Backup"
+        variant="danger"
+        onConfirm={handleRestore}
+        onCancel={() => setRestoreConfirm(false)}
+      />
+    </div>
+  )
+}
+
+/* ── Section Components ──────────────────────────────────── */
+
+function SectionHeading({ title, count }: { title: string; count?: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">{title}</h2>
+      {count != null && (
+        <span className="text-[10px] text-slate-600 font-mono bg-slate-800 px-1.5 py-0.5 rounded">
+          {count}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/* ── 1. Overall Status Banner ────────────────────────────── */
+
+function OverallStatusBanner({
+  status, issueCount, loading, error,
+}: {
+  status: string
+  issueCount: number
+  loading: boolean
+  error: string | null
+}) {
+  if (loading) {
+    return (
+      <DataCard hover={false}>
+        <LoadingSpinner message="Running diagnostics..." />
+      </DataCard>
+    )
+  }
+
+  if (error) {
+    return (
+      <DataCard variant="error" hover={false}>
+        <div className="flex items-center gap-3 py-2">
+          <span className="text-red-400"><IconError size={24} /></span>
+          <div>
+            <p className="text-lg font-bold text-red-400">Diagnostics Unavailable</p>
+            <p className="text-xs text-red-300/60 mt-0.5">{error}</p>
+          </div>
+        </div>
+      </DataCard>
+    )
+  }
+
+  const configs: Record<string, { color: string; bg: string; border: string; icon: React.ReactNode; label: string; sub: string }> = {
+    healthy: {
+      color: 'text-emerald-400',
+      bg: 'bg-emerald-500/5',
+      border: 'border-emerald-500/20',
+      icon: <IconCheck size={28} />,
+      label: 'All Systems Operational',
+      sub: 'All repair checks passed. No issues detected.',
+    },
+    degraded: {
+      color: 'text-amber-400',
+      bg: 'bg-amber-500/5',
+      border: 'border-amber-500/20',
+      icon: <IconWarning size={28} />,
+      label: 'Degraded',
+      sub: `${issueCount} issue${issueCount !== 1 ? 's' : ''} need${issueCount === 1 ? 's' : ''} attention.`,
+    },
+    broken: {
+      color: 'text-red-400',
+      bg: 'bg-red-500/5',
+      border: 'border-red-500/20',
+      icon: <IconError size={28} />,
+      label: 'System Broken',
+      sub: `${issueCount} critical issue${issueCount !== 1 ? 's' : ''} detected. Immediate action required.`,
+    },
+  }
+
+  const cfg = configs[status] ?? configs.healthy
+
+  return (
+    <div className={`${cfg.bg} border ${cfg.border} rounded-xl px-6 py-5 flex items-center gap-4`}>
+      <span className={cfg.color}>{cfg.icon}</span>
+      <div>
+        <p className={`text-xl font-bold ${cfg.color}`}>{cfg.label}</p>
+        <p className="text-sm text-slate-400 mt-0.5">{cfg.sub}</p>
+      </div>
+      <div className="ml-auto">
+        <StatusBadge status={status} size="md" />
+      </div>
+    </div>
+  )
+}
+
+/* ── 2. Safe Mode Status ─────────────────────────────────── */
+
+function SafeModeSection({
+  data, active, loading, exiting, exitResult, onExit,
+}: {
+  data: SafeModeApiResponse | null
+  active: boolean
+  loading: boolean
+  exiting: boolean
+  exitResult: string | null
+  onExit: () => void
+}) {
+  if (loading) {
+    return <DataCard hover={false}><LoadingSpinner message="Checking safe mode..." /></DataCard>
+  }
+
+  const checks = data?.checks
+
+  if (active) {
+    return (
+      <DataCard variant="error" hover={false}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Safe Mode</h2>
+          <StatusBadge status="critical" label="Active" pulse />
+        </div>
+
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-red-400"><IconWarning size={20} /></span>
+          <span className="text-lg font-bold text-red-400">Safe Mode Active</span>
+        </div>
+
+        {data?.reason && (
+          <p className="text-xs text-red-300/70 mb-4">{data.reason}</p>
+        )}
+
+        {/* Individual checks */}
+        {checks && (
+          <div className="grid grid-cols-3 gap-2 mb-4">
+            <SafeModeCheckItem label="Databases" ok={checks.databases_ok} />
+            <SafeModeCheckItem label="Config" ok={checks.config_ok} />
+            <SafeModeCheckItem label="Daemon" ok={checks.daemon_running} />
+          </div>
+        )}
+
+        {exitResult && (
+          <div className={`text-xs px-3 py-2 rounded-lg mb-3 ${
+            exitResult.includes('success') ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : 'bg-red-500/10 text-red-400 border border-red-500/20'
+          }`}>
+            {exitResult}
+          </div>
+        )}
+
+        <button
+          onClick={onExit}
+          disabled={exiting}
+          className="text-sm px-4 py-2 rounded-lg font-medium bg-red-600 hover:bg-red-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+        >
+          {exiting ? 'Validating...' : 'Validate & Exit Safe Mode'}
+        </button>
+      </DataCard>
+    )
+  }
+
+  return (
+    <DataCard variant="success" hover={false}>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Safe Mode</h2>
+        <span className="text-emerald-400"><IconCheck size={18} /></span>
+      </div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-lg font-bold text-emerald-400">Normal Operation</span>
+      </div>
+      {checks && (
+        <div className="grid grid-cols-3 gap-2 mt-3">
+          <SafeModeCheckItem label="Databases" ok={checks.databases_ok} />
+          <SafeModeCheckItem label="Config" ok={checks.config_ok} />
+          <SafeModeCheckItem label="Daemon" ok={checks.daemon_running} />
+        </div>
+      )}
+      {!checks && (
+        <p className="text-xs text-slate-500">All systems operating normally. No restrictions active.</p>
+      )}
+    </DataCard>
+  )
+}
+
+function SafeModeCheckItem({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <div className={`rounded-lg px-3 py-2 border ${
+      ok ? 'bg-emerald-500/5 border-emerald-500/15' : 'bg-red-500/5 border-red-500/15'
+    }`}>
+      <div className="flex items-center gap-1.5">
+        <span className={ok ? 'text-emerald-400' : 'text-red-400'}>
+          {ok ? <IconCheck size={12} /> : <IconError size={12} />}
+        </span>
+        <span className={`text-xs font-medium ${ok ? 'text-emerald-300' : 'text-red-300'}`}>
+          {label}
+        </span>
+      </div>
+      <span className={`text-[10px] ${ok ? 'text-emerald-400/60' : 'text-red-400/60'}`}>
+        {ok ? 'OK' : 'Failed'}
+      </span>
+    </div>
+  )
+}
+
+/* ── 3. Repair Check Card ────────────────────────────────── */
+
+function RepairCheckCard({
+  check, onRestartDaemon, restartRunning,
+}: {
+  check: RepairCheck
+  onRestartDaemon: () => void
+  restartRunning: boolean
+}) {
+  const statusIcon = {
+    ok: <span className="text-emerald-400"><IconCheck size={18} /></span>,
+    warning: <span className="text-amber-400"><IconWarning size={18} /></span>,
+    critical: <span className="text-red-400"><IconError size={18} /></span>,
+  }
+
+  const variant = check.status === 'ok' ? 'default' as const
+    : check.status === 'warning' ? 'warning' as const
+    : 'error' as const
+
+  const severityLabel = check.severity <= 1 ? 'Low' : check.severity <= 3 ? 'Medium' : check.severity <= 5 ? 'High' : 'Critical'
+  const severityColor = check.severity <= 1 ? 'text-slate-500'
+    : check.severity <= 3 ? 'text-amber-400'
+    : check.severity <= 5 ? 'text-orange-400'
+    : 'text-red-400'
+
+  // Determine if this check has an actionable button
+  const isDaemonCheck = check.name.toLowerCase().includes('daemon')
+  const hasFixAction = check.fix_action != null
+
+  return (
+    <DataCard variant={variant} hover={false}>
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 shrink-0">{statusIcon[check.status]}</div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2 mb-1">
+            <span className="text-sm font-medium text-slate-200 truncate">{check.name}</span>
+            <div className="flex items-center gap-2 shrink-0">
+              <span className={`text-[10px] font-mono ${severityColor}`}>
+                SEV {check.severity}
+              </span>
+              <StatusBadge status={check.status} size="sm" />
+            </div>
+          </div>
+
+          <p className="text-xs text-slate-400 mb-2">{check.message}</p>
+
+          {hasFixAction && (
+            <div className="bg-slate-900/40 border border-white/5 rounded-lg px-3 py-2 mt-2">
+              <p className="text-[11px] text-slate-500 mb-1">
+                <span className="text-slate-400 font-medium">Fix:</span>{' '}
+                {check.fix_action!.description}
+              </p>
+              {check.fix_action!.example && (
+                <code className="text-[10px] text-indigo-400 font-mono bg-indigo-500/5 px-1.5 py-0.5 rounded">
+                  {check.fix_action!.example}
+                </code>
+              )}
+            </div>
+          )}
+
+          {/* Actionable button for daemon-related checks */}
+          {isDaemonCheck && check.status !== 'ok' && (
+            <button
+              onClick={onRestartDaemon}
+              disabled={restartRunning}
+              className="mt-2 text-xs px-3 py-1.5 rounded-lg font-medium bg-amber-600 hover:bg-amber-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+            >
+              {restartRunning ? 'Restarting...' : 'Restart Daemon'}
+            </button>
+          )}
+        </div>
+      </div>
+    </DataCard>
+  )
+}
+
+/* ── 4. Recommended Actions ──────────────────────────────── */
+
+function RecommendedActionsSection({
+  actions,
+}: {
+  actions: Array<{ check: string; action: FixAction }>
+}) {
+  return (
+    <DataCard variant="warning" hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Recommended Actions</h2>
+        <span className="text-[10px] text-amber-400 font-mono bg-amber-500/10 px-2 py-0.5 rounded border border-amber-500/20">
+          {actions.length} action{actions.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {actions.map((item, i) => (
+          <div
+            key={`${item.check}-${i}`}
+            className="bg-slate-900/40 border border-white/5 rounded-lg px-4 py-3"
+          >
+            <div className="flex items-start gap-3">
+              <span className="text-amber-400 mt-0.5 shrink-0">
+                <IconWarning size={14} />
+              </span>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-xs font-medium text-slate-200">{item.check}</span>
+                  {item.action.type && (
+                    <span className="text-[10px] text-slate-600 font-mono bg-slate-800 px-1.5 py-0.5 rounded">
+                      {item.action.type}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-slate-400">{item.action.description}</p>
+                {item.action.example && (
+                  <code className="block mt-1.5 text-[10px] text-indigo-400 font-mono bg-indigo-500/5 px-2 py-1 rounded border border-indigo-500/10">
+                    {item.action.example}
+                  </code>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </DataCard>
+  )
+}
+
+/* ── 5. Daemon Control ───────────────────────────────────── */
+
+function DaemonControlSection({
+  daemon, loading, restartRunning, restartError, onRestart,
+}: {
+  daemon: DaemonStatus | null
+  loading: boolean
+  restartRunning: boolean
+  restartError?: string
+  onRestart: () => void
+}) {
+  if (loading) {
+    return <DataCard hover={false}><LoadingSpinner message="Checking daemon..." /></DataCard>
+  }
+
+  const running = daemon?.running ?? false
+
+  return (
+    <DataCard variant={running ? 'default' : 'error'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Daemon Control</h2>
+        <StatusBadge
+          status={running ? 'ok' : 'critical'}
+          label={running ? 'Running' : 'Stopped'}
+          pulse={running}
+          variant="dot"
+          size="md"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="grid grid-cols-3 gap-3 flex-1">
+          <StatItem label="Status" value={running ? 'Online' : 'Offline'} />
+          <StatItem label="PID" value={daemon?.pid != null ? String(daemon.pid) : '--'} />
+          <StatItem label="Uptime" value={formatUptime(daemon?.uptime_seconds ?? null)} />
+        </div>
+        <div className="shrink-0">
+          <button
+            onClick={onRestart}
+            disabled={restartRunning}
+            className="text-sm px-4 py-2 rounded-lg font-medium bg-amber-600 hover:bg-amber-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            {restartRunning ? 'Restarting...' : 'Restart Daemon'}
+          </button>
+        </div>
+      </div>
+
+      {restartError && (
+        <div className="mt-3 text-xs px-3 py-2 rounded-lg bg-red-500/10 text-red-400 border border-red-500/20">
+          {restartError}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+/* ── 6. Backup / Restore ─────────────────────────────────── */
+
+function BackupRestoreSection({
+  backup, loading, backupRunning, restoreRunning, restorePath,
+  backupError, restoreError,
+  onBackup, onRestorePathChange, onRestore,
+}: {
+  backup: BackupStatusResponse | null
+  loading: boolean
+  backupRunning: boolean
+  restoreRunning: boolean
+  restorePath: string
+  backupError?: string
+  restoreError?: string
+  onBackup: () => void
+  onRestorePathChange: (v: string) => void
+  onRestore: () => void
+}) {
+  if (loading) {
+    return <DataCard hover={false}><LoadingSpinner message="Checking backups..." /></DataCard>
+  }
+
+  const lastBackup = backup?.last_backup ?? null
+  const backupPath = backup?.path ?? null
+  const fileCount = backup?.files?.length ?? 0
+  const sizeBytes = backup?.size ?? 0
+  const sizeMb = sizeBytes > 0 ? (sizeBytes / (1024 * 1024)).toFixed(1) : '0'
+
+  const stale = lastBackup
+    ? (Date.now() - new Date(lastBackup).getTime()) > 24 * 60 * 60 * 1000
+    : true
+
+  return (
+    <DataCard variant={stale ? 'warning' : 'default'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Backup / Restore</h2>
+        {stale && <StatusBadge status="warning" label="Stale" size="sm" />}
+      </div>
+
+      {/* Backup info */}
+      <div className="space-y-2 mb-4">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-slate-500">Last Backup</span>
+          <span className="text-sm text-slate-200 font-medium">{timeAgo(lastBackup)}</span>
+        </div>
+        {backupPath && (
+          <div className="flex items-start justify-between gap-4">
+            <span className="text-xs text-slate-500 shrink-0">Path</span>
+            <span className="text-[11px] text-slate-400 font-mono text-right truncate">{backupPath}</span>
+          </div>
+        )}
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-slate-500">Size</span>
+          <span className="text-xs text-slate-400 font-mono">{fileCount} files / {sizeMb} MB</span>
+        </div>
+      </div>
+
+      {/* Create backup button */}
+      <button
+        onClick={onBackup}
+        disabled={backupRunning}
+        className="w-full text-sm px-4 py-2 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+      >
+        {backupRunning ? 'Creating Backup...' : 'Create Backup'}
+      </button>
+
+      {backupError && (
+        <div className="mt-2 text-xs px-3 py-2 rounded-lg bg-red-500/10 text-red-400 border border-red-500/20">
+          {backupError}
+        </div>
+      )}
+
+      {/* Restore section */}
+      <div className="mt-4 pt-4 border-t border-white/5">
+        <span className="text-xs text-slate-500 block mb-2">Restore from Backup</span>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={restorePath}
+            onChange={e => onRestorePathChange(e.target.value)}
+            placeholder="Backup file path..."
+            className="flex-1 text-xs px-3 py-2 rounded-lg bg-slate-900/60 border border-white/5 text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-indigo-500/30 font-mono"
+          />
+          <button
+            onClick={onRestore}
+            disabled={restoreRunning || !restorePath.trim()}
+            className="text-xs px-3 py-2 rounded-lg font-medium bg-red-600 hover:bg-red-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer shrink-0"
+          >
+            {restoreRunning ? 'Restoring...' : 'Restore'}
+          </button>
+        </div>
+        {restoreError && (
+          <div className="mt-2 text-xs px-3 py-2 rounded-lg bg-red-500/10 text-red-400 border border-red-500/20">
+            {restoreError}
+          </div>
+        )}
+      </div>
+    </DataCard>
+  )
+}
+
+/* ── 7. Support Bundle ───────────────────────────────────── */
+
+function SupportBundleSection({
+  data, loading, expanded, onExport, onToggleExpand,
+}: {
+  data: SupportBundleResponse | null
+  loading: boolean
+  expanded: boolean
+  onExport: () => void
+  onToggleExpand: () => void
+}) {
+  return (
+    <DataCard hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Support Bundle</h2>
+        <span className="text-slate-600"><IconRecovery /></span>
+      </div>
+
+      <p className="text-xs text-slate-500 mb-4">
+        Export a diagnostic snapshot for troubleshooting. Includes system state, repair checks, daemon info, and configuration.
+      </p>
+
+      <button
+        onClick={onExport}
+        disabled={loading}
+        className="w-full text-sm px-4 py-2 rounded-lg font-medium bg-slate-700 hover:bg-slate-600 text-slate-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer border border-white/5"
+      >
+        {loading ? 'Generating...' : 'Export Support Bundle'}
+      </button>
+
+      {data && (
+        <div className="mt-3">
+          <button
+            onClick={onToggleExpand}
+            className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors cursor-pointer"
+          >
+            {expanded ? 'Hide details' : 'Show diagnostic summary'}
+          </button>
+
+          {expanded && (
+            <div className="mt-2 bg-slate-900/60 border border-white/5 rounded-lg p-3 max-h-64 overflow-y-auto">
+              <pre className="text-[10px] text-slate-400 font-mono whitespace-pre-wrap break-all">
+                {JSON.stringify(data, null, 2).slice(0, 3000)}
+                {JSON.stringify(data, null, 2).length > 3000 && '\n... (truncated)'}
+              </pre>
+            </div>
+          )}
+
+          {data.generated_at && (
+            <span className="text-[10px] text-slate-600 mt-2 block">
+              Generated {timeAgo(data.generated_at)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {!data && !loading && (
+        <p className="text-[11px] text-slate-600 mt-3">
+          No bundle generated yet. Click export to create one.
+        </p>
+      )}
+    </DataCard>
+  )
+}
+
+/* ── Utility sub-component ───────────────────────────────── */
+
+function StatItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-slate-900/40 rounded-lg px-3 py-2">
+      <span className="text-[10px] text-slate-600 uppercase tracking-wider block">{label}</span>
+      <span className="text-sm text-slate-200 font-mono font-medium">{value}</span>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/Runs.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Runs.tsx
@@ -1,0 +1,1 @@
+export { default } from './RunTimeline.tsx'

--- a/packages/jarvis-dashboard/src/ui/pages/Schedule.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Schedule.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import PageHeader from '../shared/PageHeader.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import { useDashboardStore } from '../stores/dashboard-store.ts'
+import { timeAgo, agentLabel } from '../types/index.ts'
 
 interface ScheduledTask {
   id: string
@@ -6,242 +13,236 @@ interface ScheduledTask {
   label: string
   cron: string
   humanSchedule: string
-  nextFire: string
+  enabled: boolean
+  lastRun?: { status: string; completed_at: string } | null
 }
 
-interface DaemonCurrentRun {
-  agent_id: string
-  status: string
-  step: number
-  total_steps: number
-  current_action: string
-  started_at: string
-}
+// ── Cron helpers ────────────────────────────────────────────
 
-interface DaemonStatus {
-  running: boolean
-  pid: number | null
-  uptime_seconds: number | null
-  agents_registered: number
-  schedules_active: number
-  last_run: { agent_id: string; status: string; completed_at: string } | null
-  current_run: DaemonCurrentRun | null
-}
+function cronToHuman(cron: string): string {
+  const [minute, hour, , , dow] = cron.split(' ')
+  const h = parseInt(hour, 10)
+  const m = parseInt(minute, 10)
+  const time = `${h > 12 ? h - 12 : h}:${m.toString().padStart(2, '0')} ${h >= 12 ? 'PM' : 'AM'}`
 
-const POLL_INTERVAL = 30_000 // 30 seconds
+  if (dow === '*') return `Daily at ${time}`
+  if (dow === '1-5') return `Weekdays at ${time}`
+  const dayNames: Record<string, string> = { '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed', '4': 'Thu', '5': 'Fri', '6': 'Sat' }
+  const days = dow.split(',').map(d => dayNames[d] ?? d).join(', ')
+  return `${days} at ${time}`
+}
 
 function nextFireTime(cron: string): string {
   const now = new Date()
-  const [, , , , dayOfWeekField] = cron.split(' ')
-  const [hourField] = cron.split(' ')
-  const hour = parseInt(cron.split(' ')[1], 10)
-  const minute = parseInt(cron.split(' ')[0], 10)
+  const [minute, hour, , , dowField] = cron.split(' ')
+  const h = parseInt(hour, 10)
+  const m = parseInt(minute, 10)
 
-  const isDaily = dayOfWeekField === '*'
-  const isWeekdays = dayOfWeekField === '1-5'
-
-  if (isDaily) {
-    const candidate = new Date(now)
-    candidate.setHours(hour, minute, 0, 0)
-    if (candidate <= now) candidate.setDate(candidate.getDate() + 1)
-    return candidate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-  }
-
-  // Specific day(s)
-  const targetDays: number[] = isWeekdays
+  const targetDays: number[] = dowField === '*'
+    ? [0, 1, 2, 3, 4, 5, 6]
+    : dowField === '1-5'
     ? [1, 2, 3, 4, 5]
-    : cron.split(' ')[4].split(',').map(Number)
+    : dowField.split(',').map(Number)
 
   const candidate = new Date(now)
-  candidate.setHours(hour, minute, 0, 0)
+  candidate.setHours(h, m, 0, 0)
   for (let i = 0; i < 8; i++) {
     if (targetDays.includes(candidate.getDay()) && candidate > now) {
       return candidate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
     }
     candidate.setDate(candidate.getDate() + 1)
-    candidate.setHours(hour, minute, 0, 0)
+    candidate.setHours(h, m, 0, 0)
   }
   return 'Unknown'
 }
 
-// Static task list — cannot query Scheduled Tasks MCP from web context
-const TASKS: ScheduledTask[] = [
-  {
-    id: 'jarvis-bd-pipeline',
-    agentId: 'bd-pipeline',
-    label: 'BD Pipeline',
-    cron: '0 8 * * 1-5',
-    humanSchedule: 'Weekdays at 8:00 AM',
-    nextFire: nextFireTime('0 8 * * 1-5')
-  },
-  {
-    id: 'jarvis-evidence-auditor',
-    agentId: 'evidence-auditor',
-    label: 'Evidence Auditor',
-    cron: '0 9 * * 1',
-    humanSchedule: 'Mondays at 9:00 AM',
-    nextFire: nextFireTime('0 9 * * 1')
-  },
-  {
-    id: 'jarvis-staffing-monitor',
-    agentId: 'staffing-monitor',
-    label: 'Staffing Monitor',
-    cron: '0 9 * * 1',
-    humanSchedule: 'Mondays at 9:00 AM',
-    nextFire: nextFireTime('0 9 * * 1')
-  },
-  {
-    id: 'jarvis-content-monday',
-    agentId: 'content-engine',
-    label: 'Content Engine (Monday)',
-    cron: '0 7 * * 1',
-    humanSchedule: 'Mondays at 7:00 AM',
-    nextFire: nextFireTime('0 7 * * 1')
-  },
-  {
-    id: 'jarvis-content-wednesday',
-    agentId: 'content-engine',
-    label: 'Content Engine (Wednesday)',
-    cron: '0 7 * * 3',
-    humanSchedule: 'Wednesdays at 7:00 AM',
-    nextFire: nextFireTime('0 7 * * 3')
-  },
-  {
-    id: 'jarvis-content-thursday',
-    agentId: 'content-engine',
-    label: 'Content Engine (Thursday)',
-    cron: '0 7 * * 4',
-    humanSchedule: 'Thursdays at 7:00 AM',
-    nextFire: nextFireTime('0 7 * * 4')
-  },
-  {
-    id: 'jarvis-portfolio-am',
-    agentId: 'portfolio-monitor',
-    label: 'Portfolio Monitor (AM)',
-    cron: '0 8 * * *',
-    humanSchedule: 'Daily at 8:00 AM',
-    nextFire: nextFireTime('0 8 * * *')
-  },
-  {
-    id: 'jarvis-portfolio-pm',
-    agentId: 'portfolio-monitor',
-    label: 'Portfolio Monitor (PM)',
-    cron: '0 20 * * *',
-    humanSchedule: 'Daily at 8:00 PM',
-    nextFire: nextFireTime('0 20 * * *')
-  },
-  {
-    id: 'jarvis-garden-calendar',
-    agentId: 'garden-calendar',
-    label: 'Garden Calendar',
-    cron: '0 7 * * 1',
-    humanSchedule: 'Mondays at 7:00 AM',
-    nextFire: nextFireTime('0 7 * * 1')
-  }
+// ── Static task definitions ─────────────────────────────────
+
+const TASK_DEFS = [
+  { id: 'jarvis-bd-pipeline', agentId: 'bd-pipeline', label: 'BD Pipeline', cron: '0 8 * * 1-5', description: 'Scan for BD signals, enrich leads, draft outreach' },
+  { id: 'jarvis-evidence-auditor', agentId: 'evidence-auditor', label: 'Evidence Auditor', cron: '0 9 * * 1', description: 'Scan project for ISO 26262 work products' },
+  { id: 'jarvis-staffing-monitor', agentId: 'staffing-monitor', label: 'Staffing Monitor', cron: '0 9 * * 1', description: 'Calculate team utilization, forecast gaps' },
+  { id: 'jarvis-content-monday', agentId: 'content-engine', label: 'Content Engine (Mon)', cron: '0 7 * * 1', description: 'Draft LinkedIn post for Monday pillar' },
+  { id: 'jarvis-content-wednesday', agentId: 'content-engine', label: 'Content Engine (Wed)', cron: '0 7 * * 3', description: 'Draft LinkedIn post for Wednesday pillar' },
+  { id: 'jarvis-content-thursday', agentId: 'content-engine', label: 'Content Engine (Thu)', cron: '0 7 * * 4', description: 'Draft LinkedIn post for Thursday pillar' },
+  { id: 'jarvis-portfolio-am', agentId: 'portfolio-monitor', label: 'Portfolio Monitor (AM)', cron: '0 8 * * *', description: 'Check crypto prices, calculate drift' },
+  { id: 'jarvis-portfolio-pm', agentId: 'portfolio-monitor', label: 'Portfolio Monitor (PM)', cron: '0 20 * * *', description: 'Evening portfolio check and summary' },
+  { id: 'jarvis-garden-calendar', agentId: 'garden-calendar', label: 'Garden Calendar', cron: '0 7 * * 1', description: 'Generate weekly garden brief' },
 ]
 
 export default function Schedule() {
+  const { daemon } = useDashboardStore()
+  const [agents, setAgents] = useState<Array<{ id: string; enabled: boolean }>>([])
   const [triggering, setTriggering] = useState<string | null>(null)
   const [triggered, setTriggered] = useState<Set<string>>(new Set())
-  const [daemon, setDaemon] = useState<DaemonStatus | null>(null)
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [lastRuns, setLastRuns] = useState<Record<string, { status: string; completed_at: string }>>({})
+  const [loading, setLoading] = useState(true)
 
-  const fetchDaemonStatus = useCallback(() => {
-    fetch('/api/daemon/status')
-      .then(r => r.json())
-      .then((d: DaemonStatus) => setDaemon(d))
-      .catch(() => {})
+  const fetchData = useCallback(() => {
+    Promise.all([
+      fetch('/api/settings/agents').then(r => r.ok ? r.json() : []).catch(() => []),
+      fetch('/api/runs?limit=50').then(r => r.ok ? r.json() : []).catch(() => []),
+    ]).then(([agentList, runs]) => {
+      setAgents(agentList)
+      // Build last-run map per agent
+      const runMap: Record<string, { status: string; completed_at: string }> = {}
+      for (const run of (runs as Array<{ agent_id: string; status: string; completed_at?: string; started_at: string }>)) {
+        if (!runMap[run.agent_id] && (run.status === 'completed' || run.status === 'failed')) {
+          runMap[run.agent_id] = { status: run.status, completed_at: run.completed_at ?? run.started_at }
+        }
+      }
+      setLastRuns(runMap)
+      setLoading(false)
+    })
   }, [])
 
-  useEffect(() => {
-    fetchDaemonStatus()
-    intervalRef.current = setInterval(fetchDaemonStatus, POLL_INTERVAL)
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current)
-    }
-  }, [fetchDaemonStatus])
+  useEffect(() => { fetchData() }, [fetchData])
 
-  const handleRunNow = async (task: ScheduledTask) => {
+  const handleToggle = async (agentId: string, enabled: boolean) => {
+    await fetch(`/api/settings/agents/${agentId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    })
+    setAgents(prev => prev.map(a => a.id === agentId ? { ...a, enabled } : a))
+  }
+
+  const handleRunNow = async (task: typeof TASK_DEFS[0]) => {
     setTriggering(task.id)
     try {
       await fetch(`/api/agents/${task.agentId}/trigger`, { method: 'POST' })
       setTriggered(prev => new Set([...prev, task.id]))
       setTimeout(() => {
-        setTriggered(prev => {
-          const next = new Set(prev)
-          next.delete(task.id)
-          return next
-        })
+        setTriggered(prev => { const n = new Set(prev); n.delete(task.id); return n })
       }, 3000)
     } finally {
       setTriggering(null)
     }
   }
 
+  if (loading) return <LoadingSpinner message="Loading schedules..." />
+
+  const activeRuns = daemon?.active_runs ?? (daemon?.current_run ? [daemon.current_run] : [])
+  const enabledCount = TASK_DEFS.filter(t => agents.find(a => a.id === t.agentId)?.enabled !== false).length
+
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold text-white mb-2">Scheduled Tasks</h1>
-      <p className="text-sm text-gray-500 mb-6">
-        9 automated tasks. "Run Now" writes a trigger file that the agent picks up on its next poll cycle.
-      </p>
+    <div className="p-6 max-w-5xl mx-auto">
+      <PageHeader
+        title="Scheduled Tasks"
+        subtitle={`${enabledCount} of ${TASK_DEFS.length} tasks active`}
+        actions={
+          <div className="flex items-center gap-2">
+            <StatusBadge
+              status={daemon?.running ? 'healthy' : 'offline'}
+              label={daemon?.running ? 'Daemon running' : 'Daemon offline'}
+              variant="dot"
+              pulse={daemon?.running}
+            />
+          </div>
+        }
+      />
 
-      {/* Daemon connection indicator */}
-      {daemon && (
-        <div className="mb-4 flex items-center gap-2 text-xs text-gray-500">
-          <span className={`inline-flex rounded-full h-2 w-2 ${daemon.running ? 'bg-green-500' : 'bg-gray-600'}`} />
-          <span>{daemon.running ? 'Daemon connected' : 'Daemon offline'}</span>
-          {daemon.current_run && (
-            <span className="text-yellow-400 ml-2">
-              Running: {daemon.current_run.agent_id} (step {daemon.current_run.step}/{daemon.current_run.total_steps})
-            </span>
-          )}
-        </div>
-      )}
-
-      <div className="space-y-2">
-        {TASKS.map(task => {
+      <div className="space-y-3">
+        {TASK_DEFS.map(task => {
+          const agentEnabled = agents.find(a => a.id === task.agentId)?.enabled !== false
           const isTriggering = triggering === task.id
           const wasTriggered = triggered.has(task.id)
-          const isRunning = daemon?.current_run?.agent_id === task.agentId
+          const isRunning = activeRuns.some(r => r.agent_id === task.agentId)
+          const lastRun = lastRuns[task.agentId]
+
           return (
-            <div
+            <DataCard
               key={task.id}
-              className={`bg-gray-900 border ${isRunning ? 'border-yellow-700/50' : 'border-gray-800'} rounded-xl px-5 py-4 flex items-center gap-4`}
+              variant={isRunning ? 'warning' : !agentEnabled ? 'default' : 'default'}
             >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-0.5">
-                  <h3 className="text-sm font-medium text-white">{task.label}</h3>
-                  <span className="text-xs text-gray-600 font-mono">{task.id}</span>
-                  {isRunning && (
-                    <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-900 text-yellow-400 font-medium flex items-center gap-1">
-                      <span className="relative flex h-1.5 w-1.5">
-                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-yellow-400 opacity-75" />
-                        <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-yellow-400" />
-                      </span>
-                      Running
+              <div className="flex items-start gap-4">
+                {/* Left: info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className={`inline-flex rounded-full h-2 w-2 shrink-0 ${
+                      isRunning ? 'bg-amber-400' : agentEnabled ? 'bg-emerald-500' : 'bg-slate-600'
+                    }`} />
+                    <h3 className={`text-sm font-medium ${agentEnabled ? 'text-white' : 'text-slate-500'}`}>
+                      {task.label}
+                    </h3>
+                    {isRunning && <StatusBadge status="running" label="Running" size="sm" />}
+                    {!agentEnabled && <StatusBadge status="cancelled" label="Paused" size="sm" />}
+                  </div>
+
+                  <p className="text-xs text-slate-500 mb-2">{task.description}</p>
+
+                  {/* Schedule + next fire */}
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
+                    <span className="text-slate-500">
+                      <span className="text-slate-400">Schedule:</span> {cronToHuman(task.cron)}
                     </span>
+                    {agentEnabled && (
+                      <span className="text-slate-600">
+                        Next: <span className="text-slate-400">{nextFireTime(task.cron)}</span>
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Last run */}
+                  {lastRun && (
+                    <div className="flex items-center gap-2 mt-2 text-[11px]">
+                      <span className="text-slate-600">Last run:</span>
+                      <StatusBadge status={lastRun.status} size="sm" />
+                      <span className="text-slate-600">{timeAgo(lastRun.completed_at)}</span>
+                    </div>
                   )}
+
+                  {/* Links */}
+                  <div className="flex items-center gap-3 mt-2.5 pt-2.5 border-t border-white/5">
+                    <Link
+                      to={`/history?agent=${task.agentId}`}
+                      className="text-[11px] text-indigo-400 hover:text-indigo-300 transition-colors"
+                    >
+                      View history
+                    </Link>
+                    <Link
+                      to={`/runs?agent=${task.agentId}`}
+                      className="text-[11px] text-indigo-400 hover:text-indigo-300 transition-colors"
+                    >
+                      View runs
+                    </Link>
+                  </div>
                 </div>
-                <div className="flex items-center gap-4 text-xs text-gray-500">
-                  <span>{task.humanSchedule}</span>
-                  <span className="text-gray-700">·</span>
-                  <span>Next: <span className="text-gray-400">{task.nextFire}</span></span>
+
+                {/* Right: controls */}
+                <div className="shrink-0 flex flex-col items-end gap-3">
+                  {/* Enable/disable toggle */}
+                  <button
+                    onClick={() => handleToggle(task.agentId, !agentEnabled)}
+                    className={`w-11 h-6 rounded-full p-0.5 transition-colors cursor-pointer ${
+                      agentEnabled ? 'bg-indigo-600' : 'bg-slate-700'
+                    }`}
+                    title={agentEnabled ? 'Pause this task' : 'Enable this task'}
+                  >
+                    <div className={`w-5 h-5 rounded-full bg-white shadow-sm transition-transform ${
+                      agentEnabled ? 'translate-x-5' : 'translate-x-0'
+                    }`} />
+                  </button>
+
+                  {/* Run Now button */}
+                  <button
+                    onClick={() => handleRunNow(task)}
+                    disabled={isTriggering || wasTriggered || isRunning || !agentEnabled}
+                    className={`text-xs px-3.5 py-1.5 rounded-lg font-medium transition-colors cursor-pointer ${
+                      wasTriggered
+                        ? 'bg-emerald-900/50 text-emerald-400'
+                        : isRunning
+                        ? 'bg-amber-900/50 text-amber-400 cursor-not-allowed'
+                        : !agentEnabled
+                        ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
+                        : 'bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50'
+                    }`}
+                  >
+                    {isTriggering ? 'Triggering...' : wasTriggered ? 'Triggered' : isRunning ? 'Running...' : 'Run Now'}
+                  </button>
                 </div>
               </div>
-              <button
-                onClick={() => handleRunNow(task)}
-                disabled={isTriggering || wasTriggered || isRunning}
-                className={`shrink-0 text-xs px-4 py-2 rounded-lg font-medium transition-colors ${
-                  wasTriggered
-                    ? 'bg-green-900 text-green-400 cursor-default'
-                    : isRunning
-                      ? 'bg-yellow-900 text-yellow-400 cursor-not-allowed'
-                      : 'bg-indigo-700 hover:bg-indigo-600 text-white disabled:opacity-50 disabled:cursor-not-allowed'
-                }`}
-              >
-                {isTriggering ? 'Triggering...' : wasTriggered ? 'Triggered!' : isRunning ? 'Running...' : 'Run Now'}
-              </button>
-            </div>
+            </DataCard>
           )
         })}
       </div>

--- a/packages/jarvis-dashboard/src/ui/pages/Settings.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Settings.tsx
@@ -1,24 +1,204 @@
 import { useEffect, useState, useCallback } from 'react'
+import PageHeader from '../shared/PageHeader.tsx'
+import TabBar from '../shared/TabBar.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import ConfirmDialog from '../shared/ConfirmDialog.tsx'
+import { IconCheck, IconWarning, IconError } from '../shared/icons.tsx'
+import { useMode } from '../context/ModeContext.tsx'
+import { useApi, apiFetch } from '../hooks/useApi.ts'
+import type {
+  AgentSetting,
+  WorkflowDefinition,
+  RepairReport,
+  RepairCheck,
+  ModelHealthReport,
+} from '../types/index.ts'
 
-interface AgentSetting {
-  id: string
-  label: string
-  description: string
-  schedule: string
-  enabled: boolean
-}
+/* ── Types ───────────────────────────────────────────────── */
 
 interface Model {
   id: string
   name?: string
 }
 
-const TABS = ['General', 'Models', 'Agents', 'Integrations', 'Social'] as const
+interface BackupStatus {
+  last_backup_at: string | null
+  last_backup_path: string | null
+  size_mb: number | null
+}
+
+interface RestartPolicy {
+  max_retries: number
+  restart_delay_ms: number
+  description: string
+}
+
+/* ── Constants ───────────────────────────────────────────── */
+
+const TABS = [
+  'General', 'Workflows', 'Agents', 'Safety',
+  'Models', 'Integrations', 'Backup', 'Repair', 'Advanced',
+] as const
 type SettingsTab = typeof TABS[number]
 
 const LOG_LEVELS = ['debug', 'info', 'warn', 'error']
 
+const INTEGRATIONS = [
+  {
+    key: 'gmail', label: 'Gmail', icon: 'M',
+    description: 'Email search, read, draft, and send via Gmail API.',
+    fields: [
+      { key: 'client_id', label: 'Client ID', help: 'From Google Cloud Console > Credentials' },
+      { key: 'client_secret', label: 'Client Secret', help: 'Keep this private — never share it', sensitive: true },
+      { key: 'redirect_uri', label: 'Redirect URI', help: 'Usually http://localhost:4242/auth/callback' },
+    ],
+  },
+  {
+    key: 'calendar', label: 'Google Calendar', icon: 'C',
+    description: 'Read and manage calendar events.',
+    fields: [
+      { key: 'client_id', label: 'Client ID', help: 'From Google Cloud Console > Credentials' },
+      { key: 'client_secret', label: 'Client Secret', help: 'Keep this private', sensitive: true },
+      { key: 'redirect_uri', label: 'Redirect URI', help: 'Usually http://localhost:4242/auth/callback' },
+    ],
+  },
+  {
+    key: 'chrome', label: 'Chrome MCP', icon: 'B',
+    description: 'Browser automation via Chrome DevTools Protocol.',
+    fields: [
+      { key: 'extension_id', label: 'Extension ID', help: 'Find in chrome://extensions with Developer mode on' },
+      { key: 'debug_port', label: 'Debug Port', help: 'Default: 9222' },
+    ],
+  },
+  {
+    key: 'telegram', label: 'Telegram', icon: 'T',
+    description: 'Send notifications and receive commands via Telegram bot.',
+    fields: [
+      { key: 'bot_token', label: 'Bot Token', help: 'Get from @BotFather on Telegram', sensitive: true },
+      { key: 'chat_id', label: 'Chat ID', help: 'Your personal or group chat ID' },
+    ],
+  },
+  {
+    key: 'drive', label: 'Google Drive', icon: 'D',
+    description: 'Watch shared drives for new or changed documents.',
+    fields: [
+      { key: 'client_id', label: 'Client ID', help: 'From Google Cloud Console > Credentials' },
+      { key: 'client_secret', label: 'Client Secret', help: 'Keep this private', sensitive: true },
+      { key: 'redirect_uri', label: 'Redirect URI', help: 'Usually http://localhost:4242/auth/callback' },
+    ],
+  },
+] as const
+
+/* ── Helpers ─────────────────────────────────────────────── */
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <h2 className="text-sm font-semibold text-slate-400 uppercase tracking-wider">
+      {children}
+    </h2>
+  )
+}
+
+function FieldLabel({ children }: { children: string }) {
+  return <label className="text-xs text-slate-500 block mb-1.5">{children}</label>
+}
+
+function TextInput({
+  value, onChange, placeholder,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+}) {
+  return (
+    <input
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      placeholder={placeholder}
+      className="w-full text-sm bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-slate-300 placeholder-slate-600 focus:outline-none focus:border-indigo-500 transition-colors"
+    />
+  )
+}
+
+function SelectInput({
+  value, onChange, options, placeholder,
+}: {
+  value: string
+  onChange: (v: string) => void
+  options: Array<{ value: string; label: string }>
+  placeholder?: string
+}) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className="w-full text-sm bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-slate-300 focus:outline-none focus:border-indigo-500 transition-colors"
+    >
+      {placeholder && <option value="">{placeholder}</option>}
+      {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  )
+}
+
+function Toggle({
+  checked, onChange, label,
+}: {
+  checked: boolean
+  onChange: (v: boolean) => void
+  label?: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      className="inline-flex items-center gap-2 cursor-pointer"
+    >
+      <div className={`shrink-0 w-10 h-5 rounded-full p-0.5 transition-colors ${
+        checked ? 'bg-indigo-600' : 'bg-slate-700'
+      }`}>
+        <div className={`w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${
+          checked ? 'translate-x-5' : 'translate-x-0'
+        }`} />
+      </div>
+      {label && <span className="text-sm text-slate-300">{label}</span>}
+    </button>
+  )
+}
+
+function SaveButton({
+  saving, saved, onClick,
+}: {
+  saving: boolean
+  saved: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={saving}
+      className={`text-sm px-5 py-2 rounded-lg font-medium transition-colors cursor-pointer ${
+        saved
+          ? 'bg-emerald-900/60 text-emerald-400 border border-emerald-500/20'
+          : 'bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50'
+      }`}
+    >
+      {saving ? 'Saving...' : saved ? 'Saved!' : 'Save Changes'}
+    </button>
+  )
+}
+
+function RepairStatusIcon({ status }: { status: string }) {
+  if (status === 'ok') return <span className="text-emerald-400"><IconCheck size={18} /></span>
+  if (status === 'warning') return <span className="text-amber-400"><IconWarning size={18} /></span>
+  return <span className="text-red-400"><IconError size={18} /></span>
+}
+
+/* ── Main Component ──────────────────────────────────────── */
+
 export default function Settings() {
+  const { mode, setMode } = useMode()
   const [activeTab, setActiveTab] = useState<SettingsTab>('General')
   const [config, setConfig] = useState<Record<string, unknown>>({})
   const [agents, setAgents] = useState<AgentSetting[]>([])
@@ -26,6 +206,38 @@ export default function Settings() {
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [loading, setLoading] = useState(true)
+  const [editingIntegration, setEditingIntegration] = useState<string | null>(null)
+
+  // Backup / Restore state
+  const [restorePath, setRestorePath] = useState('')
+  const [backupBusy, setBackupBusy] = useState(false)
+  const [confirmDialog, setConfirmDialog] = useState<{
+    open: boolean
+    title: string
+    message: string
+    warning?: string
+    variant: 'danger' | 'warning' | 'default'
+    onConfirm: () => void
+  }>({ open: false, title: '', message: '', variant: 'default', onConfirm: () => {} })
+
+  // Secondary API data (loaded per-tab)
+  const { data: workflows } = useApi<WorkflowDefinition[]>(
+    activeTab === 'Workflows' || activeTab === 'Safety' ? '/api/workflows' : null
+  )
+  const { data: modelHealth, refetch: refetchModelHealth } = useApi<ModelHealthReport>(
+    activeTab === 'Models' ? '/api/models/health' : null
+  )
+  const { data: backupStatus, refetch: refetchBackup } = useApi<BackupStatus>(
+    activeTab === 'Backup' ? '/api/backup/status' : null
+  )
+  const { data: repairReport, refetch: refetchRepair } = useApi<RepairReport>(
+    activeTab === 'Repair' ? '/api/repair' : null
+  )
+  const { data: restartPolicy } = useApi<RestartPolicy>(
+    activeTab === 'Advanced' ? '/api/service/restart-policy' : null
+  )
+
+  /* ── Data fetching ───────────────────────────────────────── */
 
   const fetchData = useCallback(() => {
     setLoading(true)
@@ -36,13 +248,17 @@ export default function Settings() {
     ]).then(([c, a, m]) => {
       setConfig(c ?? {})
       setAgents(a ?? [])
-      const modelList = Array.isArray(m) ? m : (m?.models ?? []).map((id: string) => ({ id, name: id.split('/').pop() ?? id }))
+      const modelList = Array.isArray(m)
+        ? m
+        : (m?.models ?? []).map((id: string) => ({ id, name: id.split('/').pop() ?? id }))
       setModels(modelList)
       setLoading(false)
     }).catch(() => setLoading(false))
   }, [])
 
   useEffect(() => { fetchData() }, [fetchData])
+
+  /* ── Config helpers ──────────────────────────────────────── */
 
   const updateConfig = (key: string, value: unknown) => {
     setConfig(prev => ({ ...prev, [key]: value }))
@@ -51,7 +267,7 @@ export default function Settings() {
   const updateNestedConfig = (section: string, key: string, value: unknown) => {
     setConfig(prev => ({
       ...prev,
-      [section]: { ...((prev[section] as Record<string, unknown>) ?? {}), [key]: value }
+      [section]: { ...((prev[section] as Record<string, unknown>) ?? {}), [key]: value },
     }))
   }
 
@@ -61,13 +277,13 @@ export default function Settings() {
       const resp = await fetch('/api/settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(config)
+        body: JSON.stringify(config),
       })
       const data = await resp.json()
       setConfig(data)
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
-    } catch {}
+    } catch { /* swallow */ }
     setSaving(false)
   }
 
@@ -75,293 +291,795 @@ export default function Settings() {
     await fetch(`/api/settings/agents/${agentId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ enabled })
+      body: JSON.stringify({ enabled }),
     })
     setAgents(prev => prev.map(a => a.id === agentId ? { ...a, enabled } : a))
   }
 
-  if (loading) {
-    return <div className="flex items-center justify-center h-full text-gray-500">Loading...</div>
-  }
+  /* ── Derived ─────────────────────────────────────────────── */
 
   const integrations = config.integrations as Record<string, Record<string, unknown>> | undefined
   const social = config.social as Record<string, unknown> | undefined
   const modelTiers = config.model_tiers as Record<string, string> | undefined
-  const [editingIntegration, setEditingIntegration] = useState<string | null>(null)
+
+  /* ── Loading ─────────────────────────────────────────────── */
+
+  if (loading) {
+    return <LoadingSpinner message="Loading settings..." />
+  }
+
+  /* ── Render ──────────────────────────────────────────────── */
 
   return (
     <div className="p-6 max-w-4xl mx-auto">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-white">Settings</h1>
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className={`text-sm px-5 py-2 rounded-lg font-medium transition-colors ${
-            saved
-              ? 'bg-green-900 text-green-400'
-              : 'bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50'
-          }`}
-        >
-          {saving ? 'Saving...' : saved ? 'Saved!' : 'Save Changes'}
-        </button>
-      </div>
+      <PageHeader
+        title="Settings"
+        subtitle="Configure how Jarvis behaves"
+        actions={
+          <SaveButton saving={saving} saved={saved} onClick={handleSave} />
+        }
+      />
 
-      {/* Tabs */}
-      <div className="flex gap-1.5 mb-6">
-        {TABS.map(tab => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={`text-xs px-3.5 py-1.5 rounded-full font-medium transition-colors ${
-              activeTab === tab
-                ? 'bg-indigo-600 text-white'
-                : 'bg-gray-800 text-gray-400 hover:text-white hover:bg-gray-700'
-            }`}
-          >
-            {tab}
-          </button>
-        ))}
-      </div>
+      <TabBar tabs={TABS} active={activeTab} onChange={setActiveTab} variant="pill" />
 
-      {/* General Tab */}
+      {/* ────────────── 1. General ────────────── */}
       {activeTab === 'General' && (
         <div className="space-y-5">
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-4">
-            <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">General Configuration</h2>
+          <DataCard>
+            <div className="space-y-5">
+              <SectionTitle>General Configuration</SectionTitle>
 
-            <div>
-              <label className="text-xs text-gray-500 block mb-1.5">LM Studio URL</label>
-              <input
-                value={(config.lm_studio_url as string) ?? 'http://localhost:1234'}
-                onChange={e => updateConfig('lm_studio_url', e.target.value)}
-                className="w-full text-sm bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-gray-300 placeholder-gray-600 focus:outline-none focus:border-indigo-500"
-                placeholder="http://localhost:1234"
-              />
-            </div>
-
-            <div>
-              <label className="text-xs text-gray-500 block mb-1.5">Log Level</label>
-              <select
-                value={(config.log_level as string) ?? 'info'}
-                onChange={e => updateConfig('log_level', e.target.value)}
-                className="w-full text-sm bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-gray-300 focus:outline-none focus:border-indigo-500"
-              >
-                {LOG_LEVELS.map(l => <option key={l} value={l}>{l}</option>)}
-              </select>
-            </div>
-
-            <div>
-              <label className="text-xs text-gray-500 block mb-1.5">
-                Max Concurrent Agents: {(config.max_concurrent as number) ?? 2}
-              </label>
-              <input
-                type="range"
-                min="1"
-                max="8"
-                value={(config.max_concurrent as number) ?? 2}
-                onChange={e => updateConfig('max_concurrent', Number(e.target.value))}
-                className="w-full accent-indigo-500"
-              />
-              <div className="flex justify-between text-xs text-gray-600 mt-1">
-                <span>1</span>
-                <span>8</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Models Tab */}
-      {activeTab === 'Models' && (
-        <div className="space-y-5">
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-4">
-            <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">Model Configuration</h2>
-
-            <div>
-              <label className="text-xs text-gray-500 block mb-1.5">Default Model</label>
-              <select
-                value={(config.default_model as string) ?? ''}
-                onChange={e => updateConfig('default_model', e.target.value)}
-                className="w-full text-sm bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-gray-300 focus:outline-none focus:border-indigo-500"
-              >
-                <option value="">Select a model...</option>
-                {models.map(m => (
-                  <option key={m.id} value={m.id}>{m.name ?? m.id}</option>
-                ))}
-              </select>
-            </div>
-
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider pt-2">Tier Mapping</h3>
-            {['haiku', 'sonnet', 'opus'].map(tier => (
-              <div key={tier}>
-                <label className="text-xs text-gray-500 block mb-1.5 capitalize">{tier}</label>
-                <select
-                  value={modelTiers?.[tier] ?? ''}
-                  onChange={e => updateNestedConfig('model_tiers', tier, e.target.value)}
-                  className="w-full text-sm bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-gray-300 focus:outline-none focus:border-indigo-500"
-                >
-                  <option value="">Default</option>
-                  {models.map(m => (
-                    <option key={m.id} value={m.id}>{m.name ?? m.id}</option>
-                  ))}
-                </select>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Agents Tab */}
-      {activeTab === 'Agents' && (
-        <div className="space-y-2">
-          {agents.map(agent => (
-            <div
-              key={agent.id}
-              className="bg-gray-900 border border-gray-800 rounded-xl px-5 py-4 flex items-center gap-4"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-0.5">
-                  <h3 className="text-sm font-medium text-white">{agent.label}</h3>
-                  <span className="text-xs text-gray-600 font-mono">{agent.id}</span>
-                </div>
-                <div className="flex items-center gap-4 text-xs text-gray-500">
-                  <span>{agent.description}</span>
-                </div>
-                <p className="text-xs text-gray-600 mt-0.5">{agent.schedule}</p>
-              </div>
-              <button
-                onClick={() => handleToggleAgent(agent.id, !agent.enabled)}
-                className={`shrink-0 w-12 h-6 rounded-full p-0.5 transition-colors ${
-                  agent.enabled ? 'bg-indigo-600' : 'bg-gray-700'
-                }`}
-              >
-                <div
-                  className={`w-5 h-5 rounded-full bg-white shadow-sm transition-transform ${
-                    agent.enabled ? 'translate-x-6' : 'translate-x-0'
-                  }`}
-                />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Integrations Tab */}
-      {activeTab === 'Integrations' && (
-        <div className="grid grid-cols-2 gap-4">
-          {[
-            { key: 'gmail', label: 'Gmail', icon: 'M', fields: ['client_id', 'client_secret', 'redirect_uri'] },
-            { key: 'calendar', label: 'Google Calendar', icon: 'C', fields: ['client_id', 'client_secret', 'redirect_uri'] },
-            { key: 'chrome', label: 'Chrome MCP', icon: 'B', fields: ['extension_id', 'debug_port'] },
-            { key: 'telegram', label: 'Telegram', icon: 'T', fields: ['bot_token', 'chat_id'] },
-            { key: 'drive', label: 'Google Drive', icon: 'D', fields: ['client_id', 'client_secret', 'redirect_uri'] },
-          ].map(integration => {
-            const integrationConfig = integrations?.[integration.key] ?? {}
-            const isConfigured = Object.keys(integrationConfig).length > 0
-            const isEditing = editingIntegration === integration.key
-            return (
-              <div
-                key={integration.key}
-                className="bg-gray-900 border border-gray-800 rounded-xl p-5"
-              >
-                <div className="flex items-center gap-3 mb-3">
-                  <div className={`w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold ${
-                    isConfigured ? 'bg-indigo-900 text-indigo-400' : 'bg-gray-800 text-gray-600'
-                  }`}>
-                    {integration.icon}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="text-sm font-medium text-white">{integration.label}</h3>
-                    <span className={`text-xs ${isConfigured ? 'text-green-400' : 'text-gray-600'}`}>
-                      {isConfigured ? 'Configured' : 'Not configured'}
-                    </span>
-                  </div>
+              {/* UI Mode toggle */}
+              <div>
+                <FieldLabel>UI Mode</FieldLabel>
+                <div className="flex items-center gap-3 mt-1">
                   <button
-                    onClick={() => setEditingIntegration(isEditing ? null : integration.key)}
-                    className={`text-xs px-3 py-1.5 rounded-lg font-medium transition-colors ${
-                      isEditing
-                        ? 'bg-gray-700 text-gray-300'
-                        : isConfigured
-                        ? 'bg-gray-800 text-gray-400 hover:text-white hover:bg-gray-700'
-                        : 'bg-indigo-600 hover:bg-indigo-500 text-white'
+                    onClick={() => setMode('simple')}
+                    className={`text-sm px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer ${
+                      mode === 'simple'
+                        ? 'bg-indigo-600 text-white'
+                        : 'bg-slate-800 text-slate-400 hover:text-white hover:bg-slate-700'
                     }`}
                   >
-                    {isEditing ? 'Cancel' : isConfigured ? 'Edit' : 'Configure'}
+                    Simple
+                  </button>
+                  <button
+                    onClick={() => setMode('expert')}
+                    className={`text-sm px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer ${
+                      mode === 'expert'
+                        ? 'bg-indigo-600 text-white'
+                        : 'bg-slate-800 text-slate-400 hover:text-white hover:bg-slate-700'
+                    }`}
+                  >
+                    Expert
                   </button>
                 </div>
+                <p className="text-xs text-slate-600 mt-1.5">
+                  Simple mode shows essential pages. Expert mode unlocks all pages.
+                </p>
+              </div>
 
-                {/* Config display (read-only) */}
-                {isConfigured && !isEditing && (
-                  <div className="space-y-1">
-                    {Object.entries(integrationConfig).map(([k, v]) => (
-                      <div key={k} className="text-xs">
-                        <span className="text-gray-600">{k}: </span>
-                        <span className="text-gray-400 font-mono">{String(v)}</span>
+              {/* LM Studio URL */}
+              <div>
+                <FieldLabel>LM Studio URL</FieldLabel>
+                <TextInput
+                  value={(config.lm_studio_url as string) ?? 'http://localhost:1234'}
+                  onChange={v => updateConfig('lm_studio_url', v)}
+                  placeholder="http://localhost:1234"
+                />
+              </div>
+
+              {/* Log Level */}
+              <div>
+                <FieldLabel>Log Level</FieldLabel>
+                <SelectInput
+                  value={(config.log_level as string) ?? 'info'}
+                  onChange={v => updateConfig('log_level', v)}
+                  options={LOG_LEVELS.map(l => ({ value: l, label: l }))}
+                />
+              </div>
+
+              {/* Max Concurrent */}
+              <div>
+                <FieldLabel>
+                  {`Max Concurrent Agents: ${(config.max_concurrent as number) ?? 2}`}
+                </FieldLabel>
+                <input
+                  type="range"
+                  min="1"
+                  max="8"
+                  value={(config.max_concurrent as number) ?? 2}
+                  onChange={e => updateConfig('max_concurrent', Number(e.target.value))}
+                  className="w-full accent-indigo-500"
+                />
+                <div className="flex justify-between text-xs text-slate-600 mt-1">
+                  <span>1</span>
+                  <span>8</span>
+                </div>
+              </div>
+            </div>
+          </DataCard>
+        </div>
+      )}
+
+      {/* ────────────── 2. Workflows ────────────── */}
+      {activeTab === 'Workflows' && (
+        <div className="space-y-3">
+          {!workflows || workflows.length === 0 ? (
+            <DataCard>
+              <p className="text-sm text-slate-500">No workflow definitions found.</p>
+            </DataCard>
+          ) : (
+            workflows.map(wf => (
+              <DataCard key={wf.workflow_id}>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2.5 mb-1">
+                      <h3 className="text-sm font-medium text-white">{wf.name}</h3>
+                      <span className="text-xs text-slate-600 font-mono">{wf.workflow_id}</span>
+                    </div>
+                    {wf.description && (
+                      <p className="text-xs text-slate-500 mb-2">{wf.description}</p>
+                    )}
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <StatusBadge
+                        status={wf.safety_rules.outbound_default === 'blocked' ? 'critical' : wf.safety_rules.outbound_default === 'draft' ? 'warning' : 'ok'}
+                        label={`Outbound: ${wf.safety_rules.outbound_default}`}
+                        size="sm"
+                      />
+                      {wf.safety_rules.preview_recommended && (
+                        <span className="text-xs text-slate-500">Preview recommended</span>
+                      )}
+                      {wf.safety_rules.retry_safe && (
+                        <span className="text-xs text-emerald-500/70">Retry safe</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1.5 shrink-0">
+                    <span className="text-xs text-slate-600">
+                      {wf.agent_ids.length} agent{wf.agent_ids.length !== 1 ? 's' : ''}
+                    </span>
+                    {wf.safety_rules.preview_available && (
+                      <span className="text-[10px] bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 rounded-full px-2 py-0.5">
+                        Preview
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </DataCard>
+            ))
+          )}
+          <p className="text-xs text-slate-600 mt-2">
+            Workflow definitions are managed in code. This view is read-only.
+          </p>
+        </div>
+      )}
+
+      {/* ────────────── 3. Agents ────────────── */}
+      {activeTab === 'Agents' && (
+        <div className="space-y-3">
+          <DataCard>
+            <p className="text-xs text-slate-500">
+              Enable or disable individual agents. Disabled agents will not run on schedule or be triggered by workflows.
+            </p>
+          </DataCard>
+          {agents.length === 0 ? (
+            <DataCard>
+              <p className="text-sm text-slate-500">No agents registered.</p>
+            </DataCard>
+          ) : (
+            agents.map(agent => (
+              <DataCard key={agent.id} variant={agent.enabled ? 'default' : 'default'}>
+                <div className="flex items-start gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className={`inline-flex rounded-full h-2 w-2 shrink-0 ${agent.enabled ? 'bg-emerald-500' : 'bg-slate-600'}`} />
+                      <h3 className="text-sm font-medium text-white">{agent.label}</h3>
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded border ${
+                        agent.enabled
+                          ? 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20'
+                          : 'text-slate-500 bg-slate-500/10 border-slate-500/20'
+                      }`}>
+                        {agent.enabled ? 'Active' : 'Disabled'}
+                      </span>
+                    </div>
+                    <p className="text-xs text-slate-400 mb-2">{agent.description}</p>
+                    <div className="flex items-center gap-4 text-[11px]">
+                      <span className="text-slate-600">
+                        <span className="text-slate-500">Schedule:</span> {agent.schedule || 'On demand'}
+                      </span>
+                    </div>
+                    {/* Actions row */}
+                    <div className="flex items-center gap-3 mt-3 pt-3 border-t border-white/5">
+                      <a
+                        href={`/history?agent=${agent.id}`}
+                        className="text-[11px] text-indigo-400 hover:text-indigo-300 transition-colors"
+                      >
+                        View history
+                      </a>
+                      <a
+                        href={`/runs?agent=${agent.id}`}
+                        className="text-[11px] text-indigo-400 hover:text-indigo-300 transition-colors"
+                      >
+                        View runs
+                      </a>
+                      <a
+                        href={`/inbox`}
+                        className="text-[11px] text-indigo-400 hover:text-indigo-300 transition-colors"
+                      >
+                        Pending approvals
+                      </a>
+                    </div>
+                  </div>
+                  <div className="shrink-0 flex flex-col items-end gap-2">
+                    <Toggle
+                      checked={agent.enabled}
+                      onChange={v => handleToggleAgent(agent.id, v)}
+                    />
+                  </div>
+                </div>
+              </DataCard>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* ────────────── 4. Safety ────────────── */}
+      {activeTab === 'Safety' && (
+        <div className="space-y-5">
+          <DataCard>
+            <div className="space-y-4">
+              <SectionTitle>Safety Rules</SectionTitle>
+              <p className="text-xs text-slate-500">
+                Safety rules are defined per-workflow in code. This is a read-only summary of the current posture.
+              </p>
+            </div>
+          </DataCard>
+
+          {!workflows || workflows.length === 0 ? (
+            <DataCard>
+              <p className="text-sm text-slate-500">No workflow definitions loaded.</p>
+            </DataCard>
+          ) : (
+            <>
+              {/* Outbound defaults summary */}
+              <DataCard>
+                <SectionTitle>Outbound Defaults</SectionTitle>
+                <div className="mt-3 space-y-2.5">
+                  {workflows.map(wf => (
+                    <div key={wf.workflow_id} className="flex items-center justify-between">
+                      <span className="text-sm text-slate-300">{wf.name}</span>
+                      <StatusBadge
+                        status={
+                          wf.safety_rules.outbound_default === 'blocked' ? 'critical'
+                            : wf.safety_rules.outbound_default === 'draft' ? 'warning'
+                            : 'ok'
+                        }
+                        label={wf.safety_rules.outbound_default}
+                        size="sm"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </DataCard>
+
+              {/* Preview recommendations */}
+              <DataCard>
+                <SectionTitle>Preview Recommendations</SectionTitle>
+                <div className="mt-3 space-y-2.5">
+                  {workflows.map(wf => (
+                    <div key={wf.workflow_id} className="flex items-center justify-between">
+                      <span className="text-sm text-slate-300">{wf.name}</span>
+                      <div className="flex items-center gap-2">
+                        {wf.safety_rules.preview_available ? (
+                          <span className="text-xs text-emerald-400">Available</span>
+                        ) : (
+                          <span className="text-xs text-slate-600">N/A</span>
+                        )}
+                        {wf.safety_rules.preview_recommended && (
+                          <span className="text-[10px] bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5">
+                            Recommended
+                          </span>
+                        )}
                       </div>
-                    ))}
+                    </div>
+                  ))}
+                </div>
+              </DataCard>
+
+              {/* Retry policies */}
+              <DataCard>
+                <SectionTitle>Retry Policies</SectionTitle>
+                <div className="mt-3 space-y-2.5">
+                  {workflows.map(wf => (
+                    <div key={wf.workflow_id} className="flex items-center justify-between">
+                      <span className="text-sm text-slate-300">{wf.name}</span>
+                      <div className="flex items-center gap-2">
+                        {wf.safety_rules.retry_safe ? (
+                          <span className="text-xs text-emerald-400">Retry safe</span>
+                        ) : (
+                          <span className="text-xs text-red-400">Not retry safe</span>
+                        )}
+                        {wf.safety_rules.retry_requires_approval && (
+                          <span className="text-[10px] bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5">
+                            Needs approval
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </DataCard>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* ────────────── 5. Models ────────────── */}
+      {activeTab === 'Models' && (
+        <div className="space-y-5">
+          <DataCard>
+            <div className="space-y-4">
+              <SectionTitle>Model Configuration</SectionTitle>
+
+              <div>
+                <FieldLabel>Default Model</FieldLabel>
+                <SelectInput
+                  value={(config.default_model as string) ?? ''}
+                  onChange={v => updateConfig('default_model', v)}
+                  options={models.map(m => ({ value: m.id, label: m.name ?? m.id }))}
+                  placeholder="Select a model..."
+                />
+              </div>
+
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider pt-2">
+                Inference Tiers
+              </h3>
+              <p className="text-xs text-slate-600 mb-2">
+                Assign a model to each performance tier. Workflows select tiers based on task complexity.
+              </p>
+              {([
+                { key: 'haiku', label: 'Fast', desc: 'Quick tasks, low cost — summaries, lookups, simple checks' },
+                { key: 'sonnet', label: 'Standard', desc: 'Most workflows — analysis, drafting, monitoring' },
+                { key: 'opus', label: 'Powerful', desc: 'Complex reasoning — contract review, compliance, proposals' },
+              ] as const).map(tier => (
+                <div key={tier.key}>
+                  <FieldLabel>{tier.label}</FieldLabel>
+                  <p className="text-[10px] text-slate-600 mb-1">{tier.desc}</p>
+                  <SelectInput
+                    value={modelTiers?.[tier.key] ?? ''}
+                    onChange={v => updateNestedConfig('model_tiers', tier.key, v)}
+                    options={models.map(m => ({ value: m.id, label: m.name ?? m.id }))}
+                    placeholder="Default"
+                  />
+                </div>
+              ))}
+            </div>
+          </DataCard>
+
+          {/* Model Health */}
+          <DataCard>
+            <div className="flex items-center justify-between mb-3">
+              <SectionTitle>Model Health</SectionTitle>
+              <button
+                onClick={() => refetchModelHealth()}
+                className="text-xs text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+              >
+                Refresh
+              </button>
+            </div>
+            {!modelHealth ? (
+              <p className="text-sm text-slate-500">Unable to load model health.</p>
+            ) : (
+              <div className="space-y-3">
+                {modelHealth.degraded && (
+                  <div className="bg-amber-500/5 border border-amber-500/15 rounded-lg px-4 py-2.5">
+                    <p className="text-xs text-amber-300">One or more runtimes are degraded.</p>
                   </div>
                 )}
-
-                {/* Config form (editing) */}
-                {isEditing && (
-                  <div className="space-y-2.5 mt-2 pt-3 border-t border-gray-800">
-                    {integration.fields.map(field => (
-                      <div key={field}>
-                        <label className="text-[10px] text-gray-500 uppercase tracking-wider block mb-1">{field.replace(/_/g, ' ')}</label>
-                        <input
-                          value={String(integrationConfig[field] ?? '')}
-                          onChange={e => {
-                            const current = (config.integrations ?? {}) as Record<string, Record<string, unknown>>
-                            const updated = {
-                              ...current,
-                              [integration.key]: { ...(current[integration.key] ?? {}), [field]: e.target.value }
-                            }
-                            setConfig(prev => ({ ...prev, integrations: updated }))
-                          }}
-                          placeholder={`Enter ${field.replace(/_/g, ' ')}`}
-                          className="w-full text-xs bg-gray-800 border border-gray-700 rounded-lg px-2.5 py-2 text-gray-300 placeholder-gray-600 focus:outline-none focus:border-indigo-500 font-mono"
+                {modelHealth.runtimes.map(rt => (
+                  <div key={rt.name} className="bg-slate-900/50 border border-white/5 rounded-lg p-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <h4 className="text-sm font-medium text-white">{rt.name}</h4>
+                        <StatusBadge
+                          status={rt.connected ? 'ok' : 'critical'}
+                          label={rt.connected ? 'Connected' : 'Disconnected'}
+                          size="sm"
                         />
                       </div>
-                    ))}
+                      <span className="text-xs text-slate-600 font-mono">{rt.url}</span>
+                    </div>
+                    {rt.error && (
+                      <p className="text-xs text-red-400 mb-2">{rt.error}</p>
+                    )}
+                    <p className="text-xs text-slate-500">
+                      {rt.models.length} model{rt.models.length !== 1 ? 's' : ''} available
+                    </p>
+                    {rt.models.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5 mt-2">
+                        {rt.models.map(m => (
+                          <span key={m} className="text-[10px] bg-slate-800 text-slate-400 border border-white/5 rounded px-2 py-0.5 font-mono">
+                            {m}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </DataCard>
+        </div>
+      )}
+
+      {/* ────────────── 6. Integrations ────────────── */}
+      {activeTab === 'Integrations' && (
+        <div className="space-y-4">
+          <DataCard>
+            <p className="text-xs text-slate-500">
+              Connect Jarvis to external services. Each integration requires credentials — keep secrets private.
+            </p>
+          </DataCard>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {INTEGRATIONS.map(integration => {
+              const integrationConfig = integrations?.[integration.key] ?? {}
+              const isConfigured = Object.keys(integrationConfig).length > 0
+              const isEditing = editingIntegration === integration.key
+              return (
+                <DataCard key={integration.key}>
+                  <div className="flex items-center gap-3 mb-2">
+                    <div className={`w-9 h-9 rounded-lg flex items-center justify-center text-sm font-bold ${
+                      isConfigured ? 'bg-indigo-900/60 text-indigo-400' : 'bg-slate-800 text-slate-600'
+                    }`}>
+                      {integration.icon}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-sm font-medium text-white">{integration.label}</h3>
+                      <span className={`text-xs ${isConfigured ? 'text-emerald-400' : 'text-slate-600'}`}>
+                        {isConfigured ? 'Connected' : 'Not set up'}
+                      </span>
+                    </div>
                     <button
-                      onClick={() => { handleSave(); setEditingIntegration(null) }}
-                      className="w-full text-xs px-3 py-2 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-500 text-white transition-colors mt-1"
+                      onClick={() => setEditingIntegration(isEditing ? null : integration.key)}
+                      className={`text-xs px-3 py-1.5 rounded-lg font-medium transition-colors cursor-pointer ${
+                        isEditing
+                          ? 'bg-slate-700 text-slate-300'
+                          : isConfigured
+                          ? 'bg-slate-800 text-slate-400 hover:text-white hover:bg-slate-700'
+                          : 'bg-indigo-600 hover:bg-indigo-500 text-white'
+                      }`}
                     >
-                      Save Integration
+                      {isEditing ? 'Cancel' : isConfigured ? 'Edit' : 'Set up'}
                     </button>
                   </div>
+                  <p className="text-[11px] text-slate-600 mb-3">{integration.description}</p>
+
+                  {/* Config display (read-only) */}
+                  {isConfigured && !isEditing && (
+                    <div className="bg-slate-900/50 rounded-lg p-3 space-y-1.5">
+                      {integration.fields.map(field => {
+                        const val = String(integrationConfig[field.key] ?? '')
+                        const masked = field.sensitive && val ? val.slice(0, 4) + '****' + val.slice(-4) : val
+                        return (
+                          <div key={field.key} className="flex items-center justify-between text-xs">
+                            <span className="text-slate-500">{field.label}</span>
+                            <span className="text-slate-400 font-mono text-[11px] truncate max-w-[200px]">
+                              {masked || '—'}
+                            </span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+
+                  {/* Config form (editing) */}
+                  {isEditing && (
+                    <div className="space-y-3 mt-2 pt-3 border-t border-white/5">
+                      {integration.fields.map(field => (
+                        <div key={field.key}>
+                          <label className="text-xs text-slate-400 block mb-1 font-medium">
+                            {field.label}
+                          </label>
+                          <input
+                            type={field.sensitive ? 'password' : 'text'}
+                            value={String(integrationConfig[field.key] ?? '')}
+                            onChange={e => {
+                              const current = (config.integrations ?? {}) as Record<string, Record<string, unknown>>
+                              const updated = {
+                                ...current,
+                                [integration.key]: { ...(current[integration.key] ?? {}), [field.key]: e.target.value },
+                              }
+                              setConfig(prev => ({ ...prev, integrations: updated }))
+                            }}
+                            placeholder={field.help}
+                            className="w-full text-xs bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-slate-300 placeholder-slate-600 focus:outline-none focus:border-indigo-500 font-mono transition-colors"
+                          />
+                          <p className="text-[10px] text-slate-600 mt-1">{field.help}</p>
+                        </div>
+                      ))}
+                      <button
+                        onClick={() => { handleSave(); setEditingIntegration(null) }}
+                        className="w-full text-xs px-3 py-2.5 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-500 text-white transition-colors mt-1 cursor-pointer"
+                      >
+                        Save {integration.label}
+                      </button>
+                    </div>
+                  )}
+                </DataCard>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* ────────────── 7. Backup & Recovery ────────────── */}
+      {activeTab === 'Backup' && (
+        <div className="space-y-5">
+          {/* Last backup info */}
+          <DataCard>
+            <SectionTitle>Last Backup</SectionTitle>
+            <div className="mt-3 space-y-2">
+              {backupStatus ? (
+                <>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-slate-500">Date</span>
+                    <span className="text-sm text-slate-300">
+                      {backupStatus.last_backup_at
+                        ? new Date(backupStatus.last_backup_at).toLocaleString()
+                        : 'Never'}
+                    </span>
+                  </div>
+                  {backupStatus.last_backup_path && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-slate-500">Path</span>
+                      <span className="text-xs text-slate-400 font-mono truncate max-w-[300px]">
+                        {backupStatus.last_backup_path}
+                      </span>
+                    </div>
+                  )}
+                  {backupStatus.size_mb != null && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-slate-500">Size</span>
+                      <span className="text-sm text-slate-300">{backupStatus.size_mb} MB</span>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-slate-500">No backup information available.</p>
+              )}
+            </div>
+            <div className="mt-4">
+              <button
+                onClick={() => {
+                  setConfirmDialog({
+                    open: true,
+                    title: 'Create Backup',
+                    message: 'This will create a full backup of all Jarvis state databases.',
+                    variant: 'default',
+                    onConfirm: async () => {
+                      setConfirmDialog(prev => ({ ...prev, open: false }))
+                      setBackupBusy(true)
+                      try {
+                        await apiFetch('/api/backup', { method: 'POST' })
+                        refetchBackup()
+                      } catch { /* swallow */ }
+                      setBackupBusy(false)
+                    },
+                  })
+                }}
+                disabled={backupBusy}
+                className="text-sm px-4 py-2 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors cursor-pointer"
+              >
+                {backupBusy ? 'Creating...' : 'Create Backup'}
+              </button>
+            </div>
+          </DataCard>
+
+          {/* Restore */}
+          <DataCard>
+            <SectionTitle>Restore from Backup</SectionTitle>
+            <p className="text-xs text-slate-500 mt-1 mb-3">
+              Provide the path to a backup file to restore. This will overwrite current state.
+            </p>
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <TextInput
+                  value={restorePath}
+                  onChange={setRestorePath}
+                  placeholder="/path/to/backup.tar.gz"
+                />
+              </div>
+              <button
+                onClick={() => {
+                  if (!restorePath.trim()) return
+                  setConfirmDialog({
+                    open: true,
+                    title: 'Restore Backup',
+                    message: `Restore from: ${restorePath}`,
+                    warning: 'This will replace all current databases with the backup contents. This action cannot be undone.',
+                    variant: 'danger',
+                    onConfirm: async () => {
+                      setConfirmDialog(prev => ({ ...prev, open: false }))
+                      setBackupBusy(true)
+                      try {
+                        await apiFetch('/api/backup/restore', {
+                          method: 'POST',
+                          body: { path: restorePath },
+                        })
+                        setRestorePath('')
+                        fetchData()
+                        refetchBackup()
+                      } catch { /* swallow */ }
+                      setBackupBusy(false)
+                    },
+                  })
+                }}
+                disabled={backupBusy || !restorePath.trim()}
+                className="text-sm px-4 py-2 rounded-lg font-medium bg-red-600 hover:bg-red-500 text-white disabled:opacity-50 transition-colors cursor-pointer shrink-0"
+              >
+                {backupBusy ? 'Restoring...' : 'Restore'}
+              </button>
+            </div>
+          </DataCard>
+        </div>
+      )}
+
+      {/* ────────────── 8. Repair ────────────── */}
+      {activeTab === 'Repair' && (
+        <div className="space-y-5">
+          {/* Overall status banner */}
+          {repairReport ? (
+            <>
+              <DataCard
+                variant={
+                  repairReport.status === 'healthy' ? 'success'
+                    : repairReport.status === 'degraded' ? 'warning'
+                    : 'error'
+                }
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <RepairStatusIcon status={repairReport.status === 'healthy' ? 'ok' : repairReport.status === 'degraded' ? 'warning' : 'critical'} />
+                    <div>
+                      <h3 className="text-sm font-medium text-white">
+                        System {repairReport.status.charAt(0).toUpperCase() + repairReport.status.slice(1)}
+                      </h3>
+                      <p className="text-xs text-slate-500">
+                        {repairReport.checks.filter(c => c.status === 'ok').length} / {repairReport.checks.length} checks passing
+                        {repairReport.safe_mode && ' -- Safe mode active'}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => refetchRepair()}
+                    className="text-xs text-slate-500 hover:text-slate-300 transition-colors cursor-pointer"
+                  >
+                    Re-check
+                  </button>
+                </div>
+              </DataCard>
+
+              {/* Individual checks */}
+              <div className="space-y-2">
+                {repairReport.checks.map((check: RepairCheck) => (
+                  <DataCard key={check.name}>
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 shrink-0">
+                        <RepairStatusIcon status={check.status} />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-0.5">
+                          <h4 className="text-sm font-medium text-white">{check.name}</h4>
+                          <StatusBadge status={check.status} size="sm" />
+                        </div>
+                        <p className="text-xs text-slate-500">{check.message}</p>
+                        {check.fix_action && (
+                          <div className="mt-2 bg-slate-900/60 border border-white/5 rounded-lg px-3 py-2">
+                            <p className="text-[10px] text-slate-600 uppercase tracking-wider mb-0.5">Fix</p>
+                            <p className="text-xs text-slate-400">{check.fix_action.description}</p>
+                            {check.fix_action.example && (
+                              <p className="text-xs text-slate-600 font-mono mt-1">{check.fix_action.example}</p>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </DataCard>
+                ))}
+              </div>
+
+              {/* Recommended actions */}
+              {repairReport.recommended_actions.length > 0 && (
+                <DataCard variant="warning">
+                  <SectionTitle>Recommended Actions</SectionTitle>
+                  <div className="mt-3 space-y-3">
+                    {repairReport.recommended_actions.map((ra, i) => (
+                      <div key={i} className="flex items-start gap-2.5">
+                        <span className="text-xs text-amber-400 font-mono shrink-0 mt-0.5">{i + 1}.</span>
+                        <div>
+                          <p className="text-sm text-slate-300">{ra.check}</p>
+                          <p className="text-xs text-slate-500">{ra.action.description}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </DataCard>
+              )}
+            </>
+          ) : (
+            <DataCard>
+              <p className="text-sm text-slate-500">Unable to load repair report.</p>
+            </DataCard>
+          )}
+        </div>
+      )}
+
+      {/* ────────────── 9. Advanced ────────────── */}
+      {activeTab === 'Advanced' && (
+        <div className="space-y-5">
+          {/* Social limits */}
+          <DataCard>
+            <SectionTitle>Social Engagement Limits</SectionTitle>
+            <p className="text-xs text-slate-600 mt-1 mb-4">
+              Rate limits per agent run to stay within platform guidelines.
+            </p>
+            {[
+              { key: 'likes_per_run', label: 'Likes per run', defaultVal: 10 },
+              { key: 'comments_per_run', label: 'Comments per run', defaultVal: 5 },
+              { key: 'reposts_per_run', label: 'Reposts per run', defaultVal: 3 },
+            ].map(field => (
+              <div key={field.key} className="mb-3">
+                <FieldLabel>{field.label}</FieldLabel>
+                <input
+                  type="number"
+                  min="0"
+                  max="50"
+                  value={(social?.[field.key] as number) ?? field.defaultVal}
+                  onChange={e => updateNestedConfig('social', field.key, Number(e.target.value))}
+                  className="w-full text-sm bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-slate-300 focus:outline-none focus:border-indigo-500 transition-colors"
+                />
+              </div>
+            ))}
+          </DataCard>
+
+          {/* Restart policy */}
+          <DataCard>
+            <SectionTitle>Restart Policy</SectionTitle>
+            {restartPolicy ? (
+              <div className="mt-3 space-y-2.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-slate-500">Max retries</span>
+                  <span className="text-sm text-slate-300">{restartPolicy.max_retries}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-slate-500">Restart delay</span>
+                  <span className="text-sm text-slate-300">{restartPolicy.restart_delay_ms} ms</span>
+                </div>
+                {restartPolicy.description && (
+                  <p className="text-xs text-slate-500 mt-2 pt-2 border-t border-white/5">
+                    {restartPolicy.description}
+                  </p>
                 )}
               </div>
-            )
-          })}
+            ) : (
+              <p className="text-sm text-slate-500 mt-2">Unable to load restart policy.</p>
+            )}
+          </DataCard>
         </div>
       )}
 
-      {/* Social Tab */}
-      {activeTab === 'Social' && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 space-y-4">
-          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">Social Engagement Limits</h2>
-          <p className="text-xs text-gray-600">Rate limits per agent run to stay within platform guidelines.</p>
-
-          {[
-            { key: 'likes_per_run', label: 'Likes per run', defaultVal: 10 },
-            { key: 'comments_per_run', label: 'Comments per run', defaultVal: 5 },
-            { key: 'reposts_per_run', label: 'Reposts per run', defaultVal: 3 },
-          ].map(field => (
-            <div key={field.key}>
-              <label className="text-xs text-gray-500 block mb-1.5">{field.label}</label>
-              <input
-                type="number"
-                min="0"
-                max="50"
-                value={(social?.[field.key] as number) ?? field.defaultVal}
-                onChange={e => updateNestedConfig('social', field.key, Number(e.target.value))}
-                className="w-full text-sm bg-gray-800 border border-gray-700 rounded-lg px-3 py-2.5 text-gray-300 focus:outline-none focus:border-indigo-500"
-              />
-            </div>
-          ))}
-        </div>
-      )}
+      {/* ── Confirm Dialog ─────────────────────────────────────── */}
+      <ConfirmDialog
+        open={confirmDialog.open}
+        title={confirmDialog.title}
+        message={confirmDialog.message}
+        warning={confirmDialog.warning}
+        variant={confirmDialog.variant}
+        confirmLabel={confirmDialog.variant === 'danger' ? 'Restore' : 'Confirm'}
+        onConfirm={confirmDialog.onConfirm}
+        onCancel={() => setConfirmDialog(prev => ({ ...prev, open: false }))}
+      />
     </div>
   )
 }

--- a/packages/jarvis-dashboard/src/ui/pages/Support.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Support.tsx
@@ -1,0 +1,404 @@
+import { useState, useCallback } from 'react'
+import { useApi } from '../hooks/useApi.ts'
+import PageHeader from '../shared/PageHeader.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import { timeAgo, agentLabel, formatUptime } from '../types/index.ts'
+
+/* ── Page-local types ────────────────────────────────────── */
+
+interface SupportBundle {
+  system: {
+    node_version: string
+    platform: string
+    uptime: number
+    memory: {
+      rss?: number
+      heapUsed?: number
+      heapTotal?: number
+      [key: string]: number | undefined
+    }
+  }
+  recent_runs: Array<{
+    run_id: string
+    agent_id: string
+    status: string
+    started_at: string
+    completed_at?: string | null
+  }>
+  failed_events: Array<{
+    run_id: string
+    agent_id: string
+    error?: string
+    timestamp: string
+  }>
+  audit_log: Array<{
+    id: string
+    action: string
+    actor: string
+    timestamp: string
+    details?: string
+  }>
+  pending_approvals: Array<{
+    id: string
+    action: string
+    agent: string
+    created_at?: string
+  }>
+  daemon_heartbeat: {
+    timestamp: string
+    status: string
+  } | null
+}
+
+/* ── Main Component ──────────────────────────────────────── */
+
+export default function Support() {
+  const { data: bundle, loading, error, refetch } = useApi<SupportBundle>('/api/support/bundle')
+
+  const [exporting, setExporting] = useState(false)
+
+  const handleExport = useCallback(async () => {
+    setExporting(true)
+    try {
+      const resp = await fetch('/api/support/bundle')
+      if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`)
+      const blob = await resp.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `jarvis-support-bundle-${new Date().toISOString().slice(0, 10)}.json`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } catch {
+      // export failed — user can retry
+    } finally {
+      setExporting(false)
+    }
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <PageHeader title="Support" subtitle="Diagnostics and support tools" />
+        <LoadingSpinner message="Collecting diagnostics..." />
+      </div>
+    )
+  }
+
+  if (error || !bundle) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <PageHeader title="Support" subtitle="Diagnostics and support tools" />
+        <DataCard variant="error" hover={false}>
+          <p className="text-sm text-red-400">Failed to load support bundle</p>
+          <p className="text-xs text-red-300/60 mt-1">{error ?? 'Unknown error'}</p>
+          <button
+            onClick={refetch}
+            className="mt-3 text-xs px-3 py-1.5 bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors cursor-pointer"
+          >
+            Retry
+          </button>
+        </DataCard>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="Support"
+        subtitle="Diagnostics and support tools"
+        actions={
+          <button
+            onClick={handleExport}
+            disabled={exporting}
+            className="text-sm px-4 py-2 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            {exporting ? 'Exporting...' : 'Export Bundle'}
+          </button>
+        }
+      />
+
+      {/* ── System Info ──────────────────────────────────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <SystemInfoCard system={bundle.system} />
+        <HeartbeatCard heartbeat={bundle.daemon_heartbeat} />
+      </div>
+
+      {/* ── Recent Runs Summary ──────────────────────────────── */}
+      <div className="mb-6">
+        <RecentRunsSummary runs={bundle.recent_runs} />
+      </div>
+
+      {/* ── Pending Approvals ────────────────────────────────── */}
+      <div className="mb-6">
+        <PendingApprovalsCard approvals={bundle.pending_approvals} />
+      </div>
+
+      {/* ── Failed Events ────────────────────────────────────── */}
+      <div className="mb-6">
+        <FailedEventsCard events={bundle.failed_events} />
+      </div>
+
+      {/* ── Audit Log ────────────────────────────────────────── */}
+      <div className="mb-6">
+        <AuditLogTable entries={bundle.audit_log} />
+      </div>
+    </div>
+  )
+}
+
+/* ── Section Components ──────────────────────────────────── */
+
+function SystemInfoCard({ system }: { system: SupportBundle['system'] }) {
+  const memMb = (bytes: number | undefined) =>
+    bytes != null ? `${(bytes / (1024 * 1024)).toFixed(1)} MB` : '--'
+
+  return (
+    <DataCard hover={false}>
+      <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+        System Info
+      </h2>
+      <div className="grid grid-cols-2 gap-3">
+        <StatItem label="Node Version" value={system.node_version} />
+        <StatItem label="Platform" value={system.platform} />
+        <StatItem label="Uptime" value={formatUptime(system.uptime)} />
+        <StatItem label="Memory (RSS)" value={memMb(system.memory.rss)} />
+        <StatItem label="Heap Used" value={memMb(system.memory.heapUsed)} />
+        <StatItem label="Heap Total" value={memMb(system.memory.heapTotal)} />
+      </div>
+    </DataCard>
+  )
+}
+
+function HeartbeatCard({ heartbeat }: { heartbeat: SupportBundle['daemon_heartbeat'] }) {
+  const alive = heartbeat != null
+  const statusKey = heartbeat?.status ?? 'offline'
+
+  return (
+    <DataCard variant={alive ? 'default' : 'warning'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
+          Daemon Heartbeat
+        </h2>
+        <StatusBadge
+          status={alive ? 'ok' : 'warning'}
+          label={alive ? 'Alive' : 'No Heartbeat'}
+          size="sm"
+        />
+      </div>
+
+      {alive ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-slate-500">Status</span>
+            <StatusBadge status={statusKey} size="sm" />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-slate-500">Last Beat</span>
+            <span className="text-sm text-slate-200 font-medium">{timeAgo(heartbeat.timestamp)}</span>
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-slate-500">No daemon heartbeat detected. The daemon may not be running.</p>
+      )}
+    </DataCard>
+  )
+}
+
+function RecentRunsSummary({ runs }: { runs: SupportBundle['recent_runs'] }) {
+  const total = runs.length
+  const byStatus: Record<string, number> = {}
+  for (const r of runs) {
+    byStatus[r.status] = (byStatus[r.status] ?? 0) + 1
+  }
+
+  return (
+    <DataCard hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
+          Recent Runs
+        </h2>
+        <span className="text-xs text-slate-500 font-mono">
+          Last {total}
+        </span>
+      </div>
+
+      {total === 0 ? (
+        <EmptyState title="No recent runs" subtitle="Runs will appear here after agents execute." />
+      ) : (
+        <>
+          {/* Status breakdown */}
+          <div className="flex flex-wrap gap-2 mb-4">
+            {Object.entries(byStatus).map(([status, count]) => (
+              <div
+                key={status}
+                className="bg-slate-900/40 border border-white/5 rounded-lg px-3 py-2 flex items-center gap-2"
+              >
+                <StatusBadge status={status} size="sm" />
+                <span className="text-sm text-slate-200 font-mono font-medium">{count}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Compact run list */}
+          <div className="max-h-48 overflow-y-auto space-y-1">
+            {runs.map(r => (
+              <div
+                key={r.run_id}
+                className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-slate-900/30 transition-colors"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <StatusBadge status={r.status} size="sm" />
+                  <span className="text-xs text-slate-300 truncate">{agentLabel(r.agent_id)}</span>
+                </div>
+                <span className="text-[11px] text-slate-600 shrink-0 ml-2">{timeAgo(r.started_at)}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </DataCard>
+  )
+}
+
+function PendingApprovalsCard({ approvals }: { approvals: SupportBundle['pending_approvals'] }) {
+  return (
+    <DataCard
+      variant={approvals.length > 0 ? 'warning' : 'default'}
+      hover={false}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
+          Pending Approvals
+        </h2>
+        <StatusBadge
+          status={approvals.length > 0 ? 'pending' : 'ok'}
+          label={`${approvals.length}`}
+          size="sm"
+        />
+      </div>
+
+      {approvals.length === 0 ? (
+        <EmptyState title="No pending approvals" subtitle="All approval requests have been resolved." />
+      ) : (
+        <div className="space-y-2">
+          {approvals.map(a => (
+            <div
+              key={a.id}
+              className="bg-slate-900/40 border border-white/5 rounded-lg px-4 py-3 flex items-center justify-between"
+            >
+              <div className="min-w-0">
+                <span className="text-sm text-slate-200 block">{a.action}</span>
+                <span className="text-[11px] text-slate-500">{agentLabel(a.agent)}</span>
+              </div>
+              <span className="text-[11px] text-slate-600 shrink-0 ml-2">{timeAgo(a.created_at ?? null)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+function FailedEventsCard({ events }: { events: SupportBundle['failed_events'] }) {
+  return (
+    <DataCard variant={events.length > 0 ? 'error' : 'default'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">
+          Failed Events
+        </h2>
+        <StatusBadge
+          status={events.length > 0 ? 'critical' : 'ok'}
+          label={`${events.length} failure${events.length !== 1 ? 's' : ''}`}
+          size="sm"
+        />
+      </div>
+
+      {events.length === 0 ? (
+        <EmptyState title="No failed events" subtitle="No recent failures recorded." />
+      ) : (
+        <div className="max-h-64 overflow-y-auto space-y-1.5">
+          {events.map((ev, i) => (
+            <div
+              key={`${ev.run_id}-${i}`}
+              className="bg-slate-900/40 border border-red-500/10 rounded-lg px-4 py-3"
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs text-slate-300 font-medium">{agentLabel(ev.agent_id)}</span>
+                <span className="text-[11px] text-slate-600">{timeAgo(ev.timestamp)}</span>
+              </div>
+              {ev.error && (
+                <p className="text-[11px] text-red-400/80 font-mono break-words">{ev.error}</p>
+              )}
+              <p className="text-[10px] text-slate-600 font-mono mt-1">Run: {ev.run_id}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+function AuditLogTable({ entries }: { entries: SupportBundle['audit_log'] }) {
+  return (
+    <DataCard hover={false}>
+      <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+        Audit Log
+      </h2>
+
+      {entries.length === 0 ? (
+        <EmptyState title="No audit entries" subtitle="Audit log entries will appear here as actions are performed." />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-white/5">
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Action</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Actor</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 pr-4">Details</th>
+                <th className="text-[10px] text-slate-600 uppercase tracking-wider pb-2 text-right">Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(entry => (
+                <tr key={entry.id} className="border-b border-white/[0.03] last:border-0">
+                  <td className="py-2.5 pr-4">
+                    <span className="text-sm text-slate-200">{entry.action}</span>
+                  </td>
+                  <td className="py-2.5 pr-4">
+                    <span className="text-xs text-slate-400">{entry.actor}</span>
+                  </td>
+                  <td className="py-2.5 pr-4">
+                    <span className="text-xs text-slate-500 truncate block max-w-[300px]">
+                      {entry.details ?? '--'}
+                    </span>
+                  </td>
+                  <td className="py-2.5 text-right">
+                    <span className="text-xs text-slate-500">{timeAgo(entry.timestamp)}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+/* ── Utility sub-component ───────────────────────────────── */
+
+function StatItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-slate-900/40 rounded-lg px-3 py-2">
+      <span className="text-[10px] text-slate-600 uppercase tracking-wider block">{label}</span>
+      <span className="text-sm text-slate-200 font-mono font-medium">{value}</span>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/System.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/System.tsx
@@ -1,0 +1,475 @@
+import { useState, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { useDashboardStore } from '../stores/dashboard-store.ts'
+import { useApi, apiFetch } from '../hooks/useApi.ts'
+import PageHeader from '../shared/PageHeader.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import TimelineItem from '../shared/TimelineItem.tsx'
+import ConfirmDialog from '../shared/ConfirmDialog.tsx'
+import { IconWarning, IconCheck, IconError, IconClock } from '../shared/icons.tsx'
+import type { ModelHealthReport, HistoryResponse, HistoryEvent } from '../types/index.ts'
+import { formatUptime, timeAgo } from '../types/index.ts'
+
+/* ── API response shapes (page-local) ────────────────────── */
+
+interface ServiceStatusResponse {
+  daemon: { running: boolean; pid: number | null; uptime_seconds: number | null }
+  dashboard: { version: string; uptime_seconds: number | null }
+}
+
+interface BackupStatusResponse {
+  last_backup: string | null
+  path: string | null
+  files: string[]
+  size: number
+}
+
+/* ── Main Component ──────────────────────────────────────── */
+
+export default function System() {
+  const { daemon, safeMode } = useDashboardStore()
+
+  const { data: modelHealth, loading: modelsLoading, error: modelsError } =
+    useApi<ModelHealthReport>('/api/models/health')
+  const { data: serviceStatus, loading: serviceLoading } =
+    useApi<ServiceStatusResponse>('/api/service/status')
+  const { data: backupStatus, loading: backupLoading, refetch: refetchBackup } =
+    useApi<BackupStatusResponse>('/api/backup/status')
+  const { data: historyData, loading: historyLoading } =
+    useApi<HistoryResponse>('/api/history?type=system&limit=10')
+
+  const [backupConfirm, setBackupConfirm] = useState(false)
+  const [backupRunning, setBackupRunning] = useState(false)
+
+  const handleBackup = useCallback(async () => {
+    setBackupConfirm(false)
+    setBackupRunning(true)
+    try {
+      await apiFetch('/api/backup', { method: 'POST' })
+      refetchBackup()
+    } catch {
+      // Backup failed silently — user sees stale timestamp
+    } finally {
+      setBackupRunning(false)
+    }
+  }, [refetchBackup])
+
+  const isSafeMode = safeMode?.safe_mode_recommended
+  const events = historyData?.events ?? []
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="System"
+        subtitle="Infrastructure health and diagnostics"
+        actions={
+          <StatusBadge
+            status={isSafeMode ? 'critical' : daemon?.running ? 'healthy' : 'offline'}
+            label={isSafeMode ? 'Safe Mode' : daemon?.running ? 'Operational' : 'Offline'}
+            pulse={isSafeMode || (daemon?.running ?? false)}
+            variant="dot"
+            size="md"
+          />
+        }
+      />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+        {/* ── 1. Daemon Status ─────────────────────────────── */}
+        <DaemonCard />
+
+        {/* ── 2. Safe Mode ─────────────────────────────────── */}
+        <SafeModeCard />
+      </div>
+
+      {/* ── 3. Model / Runtime Health ──────────────────────── */}
+      <div className="mb-4">
+        <ModelHealthCard
+          data={modelHealth}
+          loading={modelsLoading}
+          error={modelsError}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+        {/* ── 4. Service Status ────────────────────────────── */}
+        <ServiceStatusCard data={serviceStatus} loading={serviceLoading} />
+
+        {/* ── 5. Backup Status ─────────────────────────────── */}
+        <BackupCard
+          data={backupStatus}
+          loading={backupLoading}
+          running={backupRunning}
+          onBackupRequest={() => setBackupConfirm(true)}
+        />
+      </div>
+
+      {/* ── 6. Recent System Events ────────────────────────── */}
+      <div className="mb-4">
+        <SystemEventsCard events={events} loading={historyLoading} />
+      </div>
+
+      {/* ── Backup confirm dialog ──────────────────────────── */}
+      <ConfirmDialog
+        open={backupConfirm}
+        title="Create Backup"
+        message="This will create a new backup of all Jarvis databases and configuration files."
+        confirmLabel="Create Backup"
+        onConfirm={handleBackup}
+        onCancel={() => setBackupConfirm(false)}
+      />
+    </div>
+  )
+}
+
+/* ── Section Components ──────────────────────────────────── */
+
+function DaemonCard() {
+  const { daemon } = useDashboardStore()
+  const running = daemon?.running ?? false
+  const activeRuns = daemon?.active_runs?.length ?? 0
+
+  return (
+    <DataCard variant={running ? 'success' : 'error'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Daemon</h2>
+        <span className="relative flex h-2.5 w-2.5">
+          {running && (
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+          )}
+          <span className={`relative inline-flex rounded-full h-2.5 w-2.5 ${running ? 'bg-emerald-500' : 'bg-red-500'}`} />
+        </span>
+      </div>
+
+      {/* Status line */}
+      <div className="flex items-center gap-2 mb-4">
+        <span className={`text-lg font-bold ${running ? 'text-emerald-400' : 'text-red-400'}`}>
+          {running ? 'Connected' : 'Offline'}
+        </span>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatItem label="PID" value={daemon?.pid != null ? String(daemon.pid) : '--'} />
+        <StatItem label="Uptime" value={formatUptime(daemon?.uptime_seconds ?? null)} />
+        <StatItem label="Agents" value={String(daemon?.agents_registered ?? 0)} />
+        <StatItem label="Schedules" value={String(daemon?.schedules_active ?? 0)} />
+      </div>
+
+      {activeRuns > 0 && (
+        <div className="mt-3 pt-3 border-t border-white/5 flex items-center gap-2">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-400" />
+          </span>
+          <span className="text-xs text-amber-300 font-medium">
+            {activeRuns} active run{activeRuns !== 1 ? 's' : ''}
+          </span>
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+function SafeModeCard() {
+  const { safeMode } = useDashboardStore()
+  const active = safeMode?.safe_mode_recommended ?? false
+  const reasons = safeMode?.reasons ?? []
+
+  return (
+    <DataCard variant={active ? 'error' : 'success'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Safe Mode</h2>
+        {active ? (
+          <span className="text-red-400"><IconWarning size={18} /></span>
+        ) : (
+          <span className="text-emerald-400"><IconCheck size={18} /></span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 mb-2">
+        <span className={`text-lg font-bold ${active ? 'text-red-400' : 'text-emerald-400'}`}>
+          {active ? 'Recommended' : 'Normal Operation'}
+        </span>
+      </div>
+
+      {active ? (
+        <>
+          <p className="text-xs text-red-300/60 mb-3">
+            Outbound actions are restricted until issues are resolved.
+          </p>
+          {reasons.length > 0 && (
+            <ul className="space-y-1.5 mb-3">
+              {reasons.map((reason, i) => (
+                <li key={i} className="flex items-start gap-2 text-xs text-red-300/80">
+                  <span className="text-red-500 mt-0.5 shrink-0"><IconError size={12} /></span>
+                  <span>{reason}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Link
+            to="/recovery"
+            className="inline-flex items-center gap-1.5 text-xs text-red-400 hover:text-red-300 bg-red-500/10 border border-red-500/20 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Open Recovery Center
+          </Link>
+        </>
+      ) : (
+        <p className="text-xs text-slate-500">
+          All systems operating within normal parameters. No restrictions active.
+        </p>
+      )}
+    </DataCard>
+  )
+}
+
+function ModelHealthCard({
+  data, loading, error,
+}: {
+  data: ModelHealthReport | null
+  loading: boolean
+  error: string | null
+}) {
+  if (loading) return <DataCard hover={false}><LoadingSpinner message="Checking runtimes..." /></DataCard>
+
+  if (error || !data) {
+    return (
+      <DataCard variant="error" hover={false}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Model Runtimes</h2>
+          <StatusBadge status="critical" label="Unreachable" />
+        </div>
+        <p className="text-xs text-red-300/60">{error ?? 'Failed to fetch model health data.'}</p>
+      </DataCard>
+    )
+  }
+
+  const runtimes = data.runtimes ?? []
+
+  return (
+    <DataCard variant={data.degraded ? 'warning' : 'default'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Model Runtimes</h2>
+        {data.degraded && <StatusBadge status="degraded" label="Degraded" />}
+        {!data.degraded && runtimes.length > 0 && <StatusBadge status="healthy" label="All Connected" />}
+      </div>
+
+      {runtimes.length === 0 ? (
+        <EmptyState title="No runtimes configured" subtitle="Add model runtimes to enable agent execution." />
+      ) : (
+        <div className="space-y-2">
+          {runtimes.map((rt) => (
+            <div
+              key={rt.name}
+              className="bg-slate-900/40 border border-white/5 rounded-lg px-4 py-3 flex items-center justify-between"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="relative flex h-2 w-2 shrink-0">
+                  <span className={`relative inline-flex rounded-full h-2 w-2 ${rt.connected ? 'bg-emerald-500' : 'bg-red-500'}`} />
+                </span>
+                <div className="min-w-0">
+                  <span className="text-sm font-medium text-slate-200 block truncate">{rt.name}</span>
+                  <span className="text-[11px] text-slate-600 font-mono block truncate">{rt.url}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                {rt.error ? (
+                  <span className="text-[11px] text-red-400 max-w-[180px] truncate">{rt.error}</span>
+                ) : (
+                  <span className="text-xs text-slate-500 font-mono">
+                    {rt.models.length} model{rt.models.length !== 1 ? 's' : ''}
+                  </span>
+                )}
+                <StatusBadge
+                  status={rt.connected ? 'ok' : 'critical'}
+                  label={rt.connected ? 'Connected' : 'Down'}
+                  size="sm"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+function ServiceStatusCard({
+  data, loading,
+}: {
+  data: ServiceStatusResponse | null
+  loading: boolean
+}) {
+  if (loading) return <DataCard hover={false}><LoadingSpinner message="Checking services..." /></DataCard>
+
+  const daemonOk = data?.daemon?.running ?? false
+  const dashVersion = data?.dashboard?.version ?? '--'
+  const dashUptime = data?.dashboard?.uptime_seconds ?? null
+
+  return (
+    <DataCard hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Services</h2>
+      </div>
+
+      <div className="space-y-3">
+        {/* Daemon service */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <span className={`inline-flex rounded-full h-2 w-2 ${daemonOk ? 'bg-emerald-500' : 'bg-red-500'}`} />
+            <span className="text-sm text-slate-200 font-medium">Daemon Process</span>
+          </div>
+          <div className="flex items-center gap-2">
+            {data?.daemon?.pid && (
+              <span className="text-xs text-slate-600 font-mono">PID {data.daemon.pid}</span>
+            )}
+            <StatusBadge
+              status={daemonOk ? 'ok' : 'critical'}
+              label={daemonOk ? 'Running' : 'Stopped'}
+              size="sm"
+            />
+          </div>
+        </div>
+
+        <div className="border-t border-white/5" />
+
+        {/* Dashboard service */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <span className="inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+            <span className="text-sm text-slate-200 font-medium">Dashboard</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-slate-600 font-mono">v{dashVersion}</span>
+            <StatusBadge status="ok" label="Running" size="sm" />
+          </div>
+        </div>
+
+        {dashUptime != null && (
+          <div className="pt-2 border-t border-white/5">
+            <span className="text-[11px] text-slate-600">
+              Dashboard uptime: {formatUptime(dashUptime)}
+            </span>
+          </div>
+        )}
+      </div>
+    </DataCard>
+  )
+}
+
+function BackupCard({
+  data, loading, running, onBackupRequest,
+}: {
+  data: BackupStatusResponse | null
+  loading: boolean
+  running: boolean
+  onBackupRequest: () => void
+}) {
+  if (loading) return <DataCard hover={false}><LoadingSpinner message="Checking backups..." /></DataCard>
+
+  const lastBackup = data?.last_backup ?? null
+  const backupPath = data?.path ?? null
+  const fileCount = data?.files?.length ?? 0
+  const sizeBytes = data?.size ?? 0
+  const sizeMb = sizeBytes > 0 ? (sizeBytes / (1024 * 1024)).toFixed(1) : '0'
+
+  // Warn if no backup in 24h
+  const stale = lastBackup
+    ? (Date.now() - new Date(lastBackup).getTime()) > 24 * 60 * 60 * 1000
+    : true
+
+  return (
+    <DataCard variant={stale ? 'warning' : 'default'} hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Backups</h2>
+        {stale && <StatusBadge status="warning" label="Stale" size="sm" />}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-slate-500">Last Backup</span>
+          <span className="text-sm text-slate-200 font-medium">{timeAgo(lastBackup)}</span>
+        </div>
+
+        {backupPath && (
+          <div className="flex items-start justify-between gap-4">
+            <span className="text-xs text-slate-500 shrink-0">Path</span>
+            <span className="text-[11px] text-slate-400 font-mono text-right truncate">{backupPath}</span>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-slate-500">Files</span>
+          <span className="text-xs text-slate-400 font-mono">{fileCount} files / {sizeMb} MB</span>
+        </div>
+
+        <div className="pt-3 border-t border-white/5">
+          <button
+            onClick={onBackupRequest}
+            disabled={running}
+            className="w-full text-sm px-4 py-2 rounded-lg font-medium bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+          >
+            {running ? 'Creating Backup...' : 'Create Backup'}
+          </button>
+        </div>
+      </div>
+    </DataCard>
+  )
+}
+
+function SystemEventsCard({ events, loading }: { events: HistoryEvent[]; loading: boolean }) {
+  if (loading) return <DataCard hover={false}><LoadingSpinner message="Loading events..." /></DataCard>
+
+  const typeIcon = (type: string) => {
+    switch (type) {
+      case 'system': return <IconClock size={14} />
+      case 'backup': return <IconCheck size={14} />
+      case 'recovery': return <IconWarning size={14} />
+      default: return <IconClock size={14} />
+    }
+  }
+
+  return (
+    <DataCard hover={false}>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider">Recent System Events</h2>
+        <Link to="/history" className="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
+          View all
+        </Link>
+      </div>
+
+      {events.length === 0 ? (
+        <EmptyState title="No recent system events" subtitle="System events will appear here as they occur." />
+      ) : (
+        <div className="mt-2">
+          {events.map((event, i) => (
+            <TimelineItem
+              key={event.id}
+              timestamp={event.timestamp}
+              title={event.title}
+              subtitle={event.subtitle}
+              status={event.status}
+              typeIcon={typeIcon(event.type)}
+              typeLabel={event.type}
+              last={i === events.length - 1}
+            />
+          ))}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+/* ── Utility sub-component ───────────────────────────────── */
+
+function StatItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-slate-900/40 rounded-lg px-3 py-2">
+      <span className="text-[10px] text-slate-600 uppercase tracking-wider block">{label}</span>
+      <span className="text-sm text-slate-200 font-mono font-medium">{value}</span>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/pages/Workflows.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Workflows.tsx
@@ -1,0 +1,794 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useApi, apiFetch } from '../hooks/useApi.ts'
+import PageHeader from '../shared/PageHeader.tsx'
+import DataCard from '../shared/DataCard.tsx'
+import StatusBadge from '../shared/StatusBadge.tsx'
+import EmptyState from '../shared/EmptyState.tsx'
+import LoadingSpinner from '../shared/LoadingSpinner.tsx'
+import { IconChevronLeft, IconArrowRight, IconCheck, IconWarning, IconError, IconClock } from '../shared/icons.tsx'
+import type { WorkflowDefinition, WorkflowInput, WorkflowSafetyRules } from '../types/index.ts'
+import { timeAgo } from '../types/index.ts'
+
+/* ── Result types (API response shapes) ─────────────────────── */
+
+interface WorkflowRunResult {
+  run_id: string
+  workflow_id: string
+  status: string
+  started_at: string
+  completed_at?: string | null
+  error?: string
+  outputs?: Record<string, unknown>
+}
+
+interface RetryGuidance {
+  retry_safe: boolean
+  retry_requires_approval: boolean
+  message: string
+}
+
+/* ── Page views ─────────────────────────────────────────────── */
+
+type View =
+  | { kind: 'catalog' }
+  | { kind: 'start'; workflowId: string }
+  | { kind: 'results'; workflowId: string }
+
+/* ── Main page ──────────────────────────────────────────────── */
+
+export default function Workflows() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { data: workflows, loading, error } = useApi<WorkflowDefinition[]>('/api/workflows')
+  const [view, setView] = useState<View>({ kind: 'catalog' })
+
+  // Handle ?start= query param on mount and when workflows load
+  useEffect(() => {
+    const startId = searchParams.get('start')
+    if (startId && workflows) {
+      const found = workflows.find(w => w.workflow_id === startId)
+      if (found) {
+        setView({ kind: 'start', workflowId: startId })
+        // Clear param so back-nav doesn't re-trigger
+        setSearchParams({}, { replace: true })
+      }
+    }
+  }, [searchParams, workflows, setSearchParams])
+
+  const navigateTo = useCallback((v: View) => {
+    setView(v)
+    // Clean up query params when navigating
+    if (searchParams.has('start')) {
+      setSearchParams({}, { replace: true })
+    }
+  }, [searchParams, setSearchParams])
+
+  if (loading) return <LoadingSpinner message="Loading workflows..." />
+
+  if (error) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <PageHeader title="Workflows" subtitle="Launch and manage workflows" />
+        <EmptyState
+          icon={<IconError size={24} />}
+          title="Failed to load workflows"
+          subtitle={error}
+        />
+      </div>
+    )
+  }
+
+  if (!workflows || workflows.length === 0) {
+    return (
+      <div className="p-6 max-w-6xl mx-auto">
+        <PageHeader title="Workflows" subtitle="Launch and manage workflows" />
+        <EmptyState
+          title="No workflows available"
+          subtitle="Workflow definitions have not been configured yet."
+        />
+      </div>
+    )
+  }
+
+  const activeWorkflow = view.kind !== 'catalog'
+    ? workflows.find(w => w.workflow_id === view.workflowId) ?? null
+    : null
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <PageHeader
+        title="Workflows"
+        subtitle="Launch and manage workflows"
+        actions={view.kind !== 'catalog' ? (
+          <button
+            onClick={() => navigateTo({ kind: 'catalog' })}
+            className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors cursor-pointer"
+          >
+            <IconChevronLeft />
+            All workflows
+          </button>
+        ) : undefined}
+      />
+
+      {view.kind === 'catalog' && (
+        <WorkflowCatalog workflows={workflows} onNavigate={navigateTo} />
+      )}
+
+      {view.kind === 'start' && activeWorkflow && (
+        <StartForm workflow={activeWorkflow} onBack={() => navigateTo({ kind: 'catalog' })} />
+      )}
+
+      {view.kind === 'results' && activeWorkflow && (
+        <ResultsView workflow={activeWorkflow} onBack={() => navigateTo({ kind: 'catalog' })} />
+      )}
+    </div>
+  )
+}
+
+/* ── Catalog ────────────────────────────────────────────────── */
+
+function WorkflowCatalog({
+  workflows,
+  onNavigate,
+}: {
+  workflows: WorkflowDefinition[]
+  onNavigate: (v: View) => void
+}) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {workflows.map(wf => (
+        <DataCard key={wf.workflow_id} className="flex flex-col">
+          {/* Header */}
+          <div className="flex items-start justify-between mb-3">
+            <h3 className="text-base font-semibold text-white leading-tight">{wf.name}</h3>
+            <SafetyPostureBadge rules={wf.safety_rules} />
+          </div>
+
+          {/* Description */}
+          <p className="text-sm text-slate-400 leading-relaxed mb-4 flex-1 line-clamp-3">
+            {wf.description || wf.expected_output}
+          </p>
+
+          {/* Badges row */}
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            {wf.safety_rules.preview_available && (
+              <span className="text-[10px] text-blue-400/70 bg-blue-500/10 border border-blue-500/15 px-2 py-0.5 rounded font-medium">
+                Preview
+              </span>
+            )}
+            {wf.safety_rules.retry_safe && (
+              <span className="text-[10px] text-emerald-400/70 bg-emerald-500/10 border border-emerald-500/15 px-2 py-0.5 rounded font-medium">
+                Retry safe
+              </span>
+            )}
+          </div>
+
+          {/* Approval summary */}
+          <p className="text-xs text-slate-500 mb-4 leading-relaxed">
+            {wf.approval_summary}
+          </p>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 pt-3 border-t border-white/5">
+            <button
+              onClick={() => onNavigate({ kind: 'start', workflowId: wf.workflow_id })}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-400 hover:text-white bg-indigo-600/10 hover:bg-indigo-600/30 border border-indigo-500/20 hover:border-indigo-500/40 px-4 py-2 rounded-lg transition-all duration-200 cursor-pointer"
+            >
+              Start
+              <IconArrowRight />
+            </button>
+            <button
+              onClick={() => onNavigate({ kind: 'results', workflowId: wf.workflow_id })}
+              className="text-sm text-slate-500 hover:text-slate-300 px-3 py-2 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+            >
+              Results
+            </button>
+          </div>
+        </DataCard>
+      ))}
+    </div>
+  )
+}
+
+/* ── Start Form ─────────────────────────────────────────────── */
+
+interface FormState {
+  values: Record<string, string | boolean>
+  errors: Record<string, string>
+  submitting: boolean
+  submitted: boolean
+  submitError: string | null
+  result: WorkflowRunResult | null
+}
+
+function StartForm({
+  workflow,
+  onBack,
+}: {
+  workflow: WorkflowDefinition
+  onBack: () => void
+}) {
+  const [form, setForm] = useState<FormState>({
+    values: buildInitialValues(workflow.inputs),
+    errors: {},
+    submitting: false,
+    submitted: false,
+    submitError: null,
+    result: null,
+  })
+  const [previewMode, setPreviewMode] = useState(workflow.safety_rules.preview_recommended)
+
+  function buildInitialValues(inputs: WorkflowInput[]): Record<string, string | boolean> {
+    const vals: Record<string, string | boolean> = {}
+    for (const input of inputs) {
+      const key = inputFieldKey(input)
+      vals[key] = input.type === 'checkbox' ? false : ''
+    }
+    return vals
+  }
+
+  function handleChange(key: string, value: string | boolean) {
+    setForm(prev => ({
+      ...prev,
+      values: { ...prev.values, [key]: value },
+      errors: { ...prev.errors, [key]: '' },
+    }))
+  }
+
+  function validate(): Record<string, string> {
+    const errs: Record<string, string> = {}
+    for (const input of workflow.inputs) {
+      const key = inputFieldKey(input)
+      const val = form.values[key]
+      if (input.required) {
+        if (input.type === 'checkbox') {
+          // checkboxes are optional regardless
+        } else if (!val || (typeof val === 'string' && val.trim() === '')) {
+          errs[key] = `${input.label} is required`
+        }
+      }
+    }
+    return errs
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const errs = validate()
+    if (Object.keys(errs).length > 0) {
+      setForm(prev => ({ ...prev, errors: errs }))
+      return
+    }
+
+    setForm(prev => ({ ...prev, submitting: true, submitError: null }))
+
+    try {
+      const body: Record<string, unknown> = {
+        inputs: form.values,
+        preview: previewMode,
+      }
+      const result = await apiFetch<WorkflowRunResult>(
+        `/api/workflows/${workflow.workflow_id}/start`,
+        { body }
+      )
+      setForm(prev => ({ ...prev, submitting: false, submitted: true, result }))
+    } catch (err) {
+      setForm(prev => ({
+        ...prev,
+        submitting: false,
+        submitError: err instanceof Error ? err.message : 'Workflow failed to start',
+      }))
+    }
+  }
+
+  // Success state
+  if (form.submitted && form.result) {
+    return (
+      <div className="max-w-2xl">
+        <DataCard variant="success">
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-emerald-400"><IconCheck size={20} /></span>
+            <h3 className="text-lg font-semibold text-white">Workflow Started</h3>
+          </div>
+          <div className="space-y-3">
+            <InfoRow label="Workflow" value={workflow.name} />
+            <InfoRow label="Run ID" value={form.result.run_id} mono />
+            <InfoRow label="Status" value={form.result.status} />
+            {previewMode && (
+              <div className="bg-blue-500/5 border border-blue-500/15 rounded-lg px-4 py-2.5 mt-3">
+                <p className="text-xs text-blue-300">
+                  Running in preview mode -- no outbound actions will be executed.
+                </p>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-3 mt-6 pt-4 border-t border-white/5">
+            <button
+              onClick={onBack}
+              className="text-sm text-slate-400 hover:text-white px-4 py-2 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+            >
+              Back to workflows
+            </button>
+            <button
+              onClick={() => setForm({
+                values: buildInitialValues(workflow.inputs),
+                errors: {},
+                submitting: false,
+                submitted: false,
+                submitError: null,
+                result: null,
+              })}
+              className="text-sm text-indigo-400 hover:text-white px-4 py-2 rounded-lg hover:bg-indigo-600/20 transition-colors cursor-pointer"
+            >
+              Start another
+            </button>
+          </div>
+        </DataCard>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl">
+      {/* Workflow header */}
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-1">
+          <h2 className="text-xl font-bold text-white">{workflow.name}</h2>
+          <SafetyPostureBadge rules={workflow.safety_rules} />
+        </div>
+        <p className="text-sm text-slate-400">{workflow.description || workflow.expected_output}</p>
+      </div>
+
+      {/* Form */}
+      <form onSubmit={handleSubmit}>
+        <DataCard>
+          <div className="space-y-5">
+            {workflow.inputs.map(input => {
+              const key = inputFieldKey(input)
+              return (
+                <FormField
+                  key={key}
+                  input={input}
+                  value={form.values[key]}
+                  error={form.errors[key]}
+                  onChange={(val) => handleChange(key, val)}
+                />
+              )
+            })}
+
+            {/* Preview toggle */}
+            {workflow.safety_rules.preview_available && (
+              <div className="pt-3 border-t border-white/5">
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <div className="relative">
+                    <input
+                      type="checkbox"
+                      checked={previewMode}
+                      onChange={e => setPreviewMode(e.target.checked)}
+                      className="sr-only peer"
+                    />
+                    <div className="w-9 h-5 bg-slate-700 peer-checked:bg-indigo-600 rounded-full transition-colors" />
+                    <div className="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-4" />
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-slate-200 group-hover:text-white transition-colors">
+                      Preview mode
+                    </span>
+                    <p className="text-xs text-slate-500 mt-0.5">
+                      Dry run without outbound actions
+                    </p>
+                  </div>
+                  {workflow.safety_rules.preview_recommended && (
+                    <span className="text-[10px] text-amber-400/70 bg-amber-500/10 border border-amber-500/15 px-2 py-0.5 rounded font-medium ml-auto">
+                      Recommended
+                    </span>
+                  )}
+                </label>
+              </div>
+            )}
+          </div>
+        </DataCard>
+
+        {/* Safety summary bar */}
+        <SafetySummaryBar rules={workflow.safety_rules} previewMode={previewMode} />
+
+        {/* Submit error */}
+        {form.submitError && (
+          <div className="bg-red-500/5 border border-red-500/15 rounded-xl px-5 py-3 mt-4 flex items-center gap-3">
+            <span className="text-red-400 shrink-0"><IconError /></span>
+            <p className="text-sm text-red-300">{form.submitError}</p>
+          </div>
+        )}
+
+        {/* Submit button */}
+        <div className="flex items-center gap-3 mt-6">
+          <button
+            type="submit"
+            disabled={form.submitting}
+            className="inline-flex items-center gap-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-500 disabled:bg-indigo-600/50 disabled:text-white/50 px-6 py-2.5 rounded-lg transition-colors cursor-pointer disabled:cursor-not-allowed"
+          >
+            {form.submitting ? (
+              <>
+                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                Starting...
+              </>
+            ) : (
+              <>
+                Start Workflow
+                <IconArrowRight />
+              </>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-sm text-slate-500 hover:text-slate-300 px-4 py-2.5 rounded-lg hover:bg-slate-700/50 transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+/* ── Form Field ─────────────────────────────────────────────── */
+
+function FormField({
+  input,
+  value,
+  error,
+  onChange,
+}: {
+  input: WorkflowInput
+  value: string | boolean | undefined
+  error?: string
+  onChange: (val: string | boolean) => void
+}) {
+  const key = inputFieldKey(input)
+  const baseInputClasses =
+    'w-full bg-slate-900/60 border rounded-lg px-3.5 py-2.5 text-sm text-slate-200 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 focus:border-indigo-500/60 transition-colors'
+  const errorBorder = error ? 'border-red-500/40' : 'border-white/10'
+
+  if (input.type === 'checkbox') {
+    return (
+      <label className="flex items-center gap-3 cursor-pointer group">
+        <input
+          type="checkbox"
+          checked={!!value}
+          onChange={e => onChange(e.target.checked)}
+          className="w-4 h-4 rounded border-white/20 bg-slate-900/60 text-indigo-600 focus:ring-indigo-500/40 focus:ring-offset-0 cursor-pointer"
+        />
+        <span className="text-sm text-slate-300 group-hover:text-slate-200 transition-colors">
+          {input.label}
+        </span>
+        {input.required && <span className="text-red-400 text-xs">*</span>}
+      </label>
+    )
+  }
+
+  if (input.type === 'select') {
+    return (
+      <div>
+        <label htmlFor={key} className="block text-sm font-medium text-slate-300 mb-1.5">
+          {input.label}
+          {input.required && <span className="text-red-400 ml-0.5">*</span>}
+        </label>
+        <select
+          id={key}
+          value={typeof value === 'string' ? value : ''}
+          onChange={e => onChange(e.target.value)}
+          className={`${baseInputClasses} ${errorBorder} cursor-pointer`}
+        >
+          <option value="" className="bg-slate-900">
+            {input.placeholder || `Select ${input.label.toLowerCase()}...`}
+          </option>
+          {input.options?.map(opt => (
+            <option key={opt} value={opt} className="bg-slate-900">{opt}</option>
+          ))}
+        </select>
+        {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+      </div>
+    )
+  }
+
+  if (input.type === 'date') {
+    return (
+      <div>
+        <label htmlFor={key} className="block text-sm font-medium text-slate-300 mb-1.5">
+          {input.label}
+          {input.required && <span className="text-red-400 ml-0.5">*</span>}
+        </label>
+        <input
+          id={key}
+          type="date"
+          value={typeof value === 'string' ? value : ''}
+          onChange={e => onChange(e.target.value)}
+          className={`${baseInputClasses} ${errorBorder}`}
+        />
+        {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+      </div>
+    )
+  }
+
+  // text, file (rendered as text input for file path)
+  return (
+    <div>
+      <label htmlFor={key} className="block text-sm font-medium text-slate-300 mb-1.5">
+        {input.label}
+        {input.required && <span className="text-red-400 ml-0.5">*</span>}
+        {input.type === 'file' && (
+          <span className="text-xs text-slate-600 ml-2 font-normal">File path</span>
+        )}
+      </label>
+      <input
+        id={key}
+        type="text"
+        value={typeof value === 'string' ? value : ''}
+        onChange={e => onChange(e.target.value)}
+        placeholder={input.placeholder}
+        className={`${baseInputClasses} ${errorBorder}`}
+      />
+      {error && <p className="text-xs text-red-400 mt-1">{error}</p>}
+    </div>
+  )
+}
+
+/* ── Safety Summary Bar ─────────────────────────────────────── */
+
+function SafetySummaryBar({
+  rules,
+  previewMode,
+}: {
+  rules: WorkflowSafetyRules
+  previewMode: boolean
+}) {
+  const items: Array<{ icon: React.ReactNode; text: string; color: string }> = []
+
+  if (previewMode) {
+    items.push({
+      icon: <IconCheck size={14} />,
+      text: 'Preview mode -- no outbound actions',
+      color: 'text-blue-400',
+    })
+  } else {
+    const outboundLabels = {
+      draft: 'Outbound actions create drafts only',
+      send: 'Outbound actions will execute live',
+      blocked: 'Outbound actions are blocked',
+    }
+    const outboundColors = { draft: 'text-emerald-400', send: 'text-amber-400', blocked: 'text-red-400' }
+    const outboundIcons = {
+      draft: <IconCheck size={14} />,
+      send: <IconWarning size={14} />,
+      blocked: <IconError size={14} />,
+    }
+    items.push({
+      icon: outboundIcons[rules.outbound_default],
+      text: outboundLabels[rules.outbound_default],
+      color: outboundColors[rules.outbound_default],
+    })
+  }
+
+  if (rules.retry_safe) {
+    items.push({ icon: <IconCheck size={14} />, text: 'Safe to retry', color: 'text-emerald-400' })
+  }
+  if (rules.retry_requires_approval) {
+    items.push({ icon: <IconWarning size={14} />, text: 'Retry requires approval', color: 'text-amber-400' })
+  }
+
+  return (
+    <div className="bg-slate-800/30 border border-white/5 rounded-xl px-5 py-3 mt-4">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+        {items.map((item, i) => (
+          <span key={i} className={`inline-flex items-center gap-1.5 text-xs ${item.color}`}>
+            {item.icon}
+            {item.text}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ── Results View ───────────────────────────────────────────── */
+
+function ResultsView({
+  workflow,
+  onBack,
+}: {
+  workflow: WorkflowDefinition
+  onBack: () => void
+}) {
+  const { data: results, loading, error } = useApi<WorkflowRunResult[]>(
+    `/api/workflows/${workflow.workflow_id}/results`
+  )
+  const { data: retryGuidance } = useApi<RetryGuidance>(
+    `/api/workflows/${workflow.workflow_id}/retry-guidance`
+  )
+
+  return (
+    <div className="max-w-3xl">
+      {/* Header */}
+      <div className="mb-6">
+        <h2 className="text-xl font-bold text-white mb-1">{workflow.name}</h2>
+        <p className="text-sm text-slate-500">Recent runs and results</p>
+      </div>
+
+      {/* Retry guidance */}
+      {retryGuidance && (
+        <div className={`border rounded-xl px-5 py-3 mb-5 backdrop-blur-sm ${
+          retryGuidance.retry_safe
+            ? 'bg-emerald-500/5 border-emerald-500/15'
+            : 'bg-amber-500/5 border-amber-500/15'
+        }`}>
+          <div className="flex items-center gap-2">
+            <span className={retryGuidance.retry_safe ? 'text-emerald-400' : 'text-amber-400'}>
+              {retryGuidance.retry_safe ? <IconCheck size={14} /> : <IconWarning size={14} />}
+            </span>
+            <span className={`text-xs font-medium ${
+              retryGuidance.retry_safe ? 'text-emerald-300' : 'text-amber-300'
+            }`}>
+              {retryGuidance.message}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && <LoadingSpinner message="Loading results..." />}
+
+      {/* Error */}
+      {error && (
+        <EmptyState
+          icon={<IconError size={24} />}
+          title="Failed to load results"
+          subtitle={error}
+        />
+      )}
+
+      {/* Empty */}
+      {!loading && !error && (!results || results.length === 0) && (
+        <EmptyState
+          title="No runs yet"
+          subtitle={`${workflow.name} has not been started yet.`}
+          action={
+            <button
+              onClick={onBack}
+              className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors cursor-pointer"
+            >
+              Back to workflows
+            </button>
+          }
+        />
+      )}
+
+      {/* Results list */}
+      {results && results.length > 0 && (
+        <div className="space-y-3">
+          {results.map(run => (
+            <RunCard key={run.run_id} run={run} outputFields={workflow.output_fields} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── Run Card ───────────────────────────────────────────────── */
+
+function RunCard({
+  run,
+  outputFields,
+}: {
+  run: WorkflowRunResult
+  outputFields: WorkflowDefinition['output_fields']
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  const hasOutputs = run.outputs && Object.keys(run.outputs).length > 0
+
+  return (
+    <DataCard
+      variant={run.status === 'failed' ? 'error' : run.status === 'completed' ? 'success' : 'default'}
+      hover={false}
+    >
+      <div
+        className={`flex items-center justify-between ${hasOutputs ? 'cursor-pointer' : ''}`}
+        onClick={() => hasOutputs && setExpanded(!expanded)}
+      >
+        <div className="flex items-center gap-3">
+          <StatusBadge status={run.status} />
+          <span className="text-xs text-slate-500 font-mono">{run.run_id.slice(0, 12)}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-slate-500">
+            <span className="inline-flex items-center gap-1">
+              <IconClock size={12} />
+              {timeAgo(run.started_at)}
+            </span>
+          </span>
+          {hasOutputs && (
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
+              fill="none"
+              className={`text-slate-500 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+            >
+              <path d="M3 5l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          )}
+        </div>
+      </div>
+
+      {/* Error message */}
+      {run.status === 'failed' && run.error && (
+        <div className="mt-3 bg-red-500/5 border border-red-500/10 rounded-lg px-3.5 py-2.5">
+          <p className="text-xs text-red-400">{run.error}</p>
+        </div>
+      )}
+
+      {/* Expanded outputs */}
+      {expanded && hasOutputs && (
+        <div className="mt-4 pt-4 border-t border-white/5 space-y-2.5">
+          {outputFields.length > 0 ? (
+            outputFields.map(field => {
+              const val = run.outputs?.[field.field]
+              if (val === undefined) return null
+              return (
+                <InfoRow
+                  key={field.field}
+                  label={field.label}
+                  value={typeof val === 'string' ? val : JSON.stringify(val)}
+                />
+              )
+            })
+          ) : (
+            Object.entries(run.outputs!).map(([k, v]) => (
+              <InfoRow
+                key={k}
+                label={k}
+                value={typeof v === 'string' ? v : JSON.stringify(v)}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </DataCard>
+  )
+}
+
+/* ── Shared sub-components ──────────────────────────────────── */
+
+function SafetyPostureBadge({ rules }: { rules: WorkflowSafetyRules }) {
+  const styles = {
+    draft: 'text-emerald-400/80 bg-emerald-500/10 border-emerald-500/15',
+    send: 'text-amber-400/80 bg-amber-500/10 border-amber-500/15',
+    blocked: 'text-red-400/80 bg-red-500/10 border-red-500/15',
+  }
+  const labels = { draft: 'Draft', send: 'Live', blocked: 'Blocked' }
+
+  return (
+    <span className={`text-[10px] font-medium border px-2 py-0.5 rounded ${styles[rules.outbound_default]}`}>
+      {labels[rules.outbound_default]}
+    </span>
+  )
+}
+
+function InfoRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="text-xs text-slate-500 w-24 shrink-0 pt-0.5">{label}</span>
+      <span className={`text-sm text-slate-300 break-all ${mono ? 'font-mono text-xs' : ''}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/* ── Utilities ──────────────────────────────────────────────── */
+
+/** Handle both `field` and `name` on WorkflowInput. Runtime uses `name`, types declare `field`. */
+function inputFieldKey(input: WorkflowInput): string {
+  return input.field || (input as unknown as { name: string }).name || 'unknown'
+}

--- a/packages/jarvis-dashboard/src/ui/shared/ConfirmDialog.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/ConfirmDialog.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  message: string
+  warning?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'warning' | 'default'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmDialog({
+  open, title, message, warning, confirmLabel = 'Confirm', cancelLabel = 'Cancel',
+  variant = 'default', onConfirm, onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    if (open) dialogRef.current?.showModal()
+    else dialogRef.current?.close()
+  }, [open])
+
+  if (!open) return null
+
+  const confirmColors = {
+    danger: 'bg-red-600 hover:bg-red-500 text-white',
+    warning: 'bg-amber-600 hover:bg-amber-500 text-white',
+    default: 'bg-indigo-600 hover:bg-indigo-500 text-white',
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onCancel}
+      className="bg-transparent p-0 m-0 max-w-md w-full backdrop:bg-black/60 backdrop:backdrop-blur-sm"
+    >
+      <div className="bg-slate-900 border border-white/10 rounded-xl p-6 shadow-2xl">
+        <h2 className="text-lg font-semibold text-white mb-2">{title}</h2>
+        <p className="text-sm text-slate-400 mb-4">{message}</p>
+        {warning && (
+          <div className="bg-amber-500/5 border border-amber-500/15 rounded-lg px-4 py-3 mb-4">
+            <p className="text-xs text-amber-300">{warning}</p>
+          </div>
+        )}
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="text-sm px-4 py-2 rounded-lg font-medium bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors cursor-pointer"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            className={`text-sm px-4 py-2 rounded-lg font-medium transition-colors cursor-pointer ${confirmColors[variant]}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/DataCard.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/DataCard.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+
+interface DataCardProps {
+  children: ReactNode
+  className?: string
+  variant?: 'default' | 'warning' | 'error' | 'success'
+  hover?: boolean
+  onClick?: () => void
+}
+
+const VARIANTS = {
+  default: 'border-white/5 hover:border-white/10',
+  warning: 'border-amber-500/15 hover:border-amber-500/30',
+  error: 'border-red-500/15 hover:border-red-500/30',
+  success: 'border-emerald-500/15 hover:border-emerald-500/30',
+}
+
+export default function DataCard({
+  children, className = '', variant = 'default', hover = true, onClick,
+}: DataCardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className={`bg-slate-800/50 backdrop-blur-sm border rounded-xl p-5 transition-all duration-200 ${
+        VARIANTS[variant]
+      } ${hover ? '' : 'hover:border-inherit'} ${onClick ? 'cursor-pointer' : ''} ${className}`}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/EmptyState.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/EmptyState.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+interface EmptyStateProps {
+  icon?: ReactNode
+  title: string
+  subtitle?: string
+  action?: ReactNode
+}
+
+export default function EmptyState({ icon, title, subtitle, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      {icon && <div className="text-slate-600 mb-3">{icon}</div>}
+      <h3 className="text-sm font-medium text-slate-400">{title}</h3>
+      {subtitle && <p className="text-xs text-slate-600 mt-1 max-w-sm">{subtitle}</p>}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/FilterBar.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/FilterBar.tsx
@@ -1,0 +1,43 @@
+interface SelectFilter {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  options: Array<{ value: string; label: string }>
+}
+
+interface FilterBarProps {
+  filters: SelectFilter[]
+  search?: {
+    value: string
+    onChange: (value: string) => void
+    placeholder?: string
+  }
+}
+
+export default function FilterBar({ filters, search }: FilterBarProps) {
+  return (
+    <div className="flex items-center gap-3 mb-5">
+      {search && (
+        <input
+          type="text"
+          value={search.value}
+          onChange={e => search.onChange(e.target.value)}
+          placeholder={search.placeholder ?? 'Search...'}
+          className="text-sm bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-slate-300 placeholder-slate-600 focus:outline-none focus:border-indigo-500 flex-1 max-w-xs"
+        />
+      )}
+      {filters.map(filter => (
+        <select
+          key={filter.label}
+          value={filter.value}
+          onChange={e => filter.onChange(e.target.value)}
+          className="text-sm bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-slate-300 focus:outline-none focus:border-indigo-500"
+        >
+          {filter.options.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      ))}
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/LoadingSpinner.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/LoadingSpinner.tsx
@@ -1,0 +1,14 @@
+interface LoadingSpinnerProps {
+  message?: string
+}
+
+export default function LoadingSpinner({ message = 'Loading...' }: LoadingSpinnerProps) {
+  return (
+    <div className="flex items-center justify-center h-full min-h-[200px]">
+      <div className="flex flex-col items-center gap-3">
+        <div className="w-8 h-8 border-2 border-indigo-500/30 border-t-indigo-500 rounded-full animate-spin" />
+        <span className="text-sm text-slate-500 font-medium">{message}</span>
+      </div>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/PageHeader.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/PageHeader.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+
+interface PageHeaderProps {
+  title: string
+  subtitle?: string
+  actions?: ReactNode
+}
+
+export default function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div>
+        <h1 className="text-2xl font-bold text-white tracking-tight">{title}</h1>
+        {subtitle && <p className="text-sm text-slate-500 mt-0.5">{subtitle}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-3">{actions}</div>}
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/StatusBadge.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/StatusBadge.tsx
@@ -1,0 +1,40 @@
+import { STATUS_COLORS, STATUS_DOT_COLORS, STATUS_LABELS } from '../types/index.ts'
+
+interface StatusBadgeProps {
+  status: string
+  label?: string
+  pulse?: boolean
+  size?: 'sm' | 'md'
+  variant?: 'pill' | 'dot'
+}
+
+export default function StatusBadge({ status, label, pulse, size = 'sm', variant = 'pill' }: StatusBadgeProps) {
+  const displayLabel = label ?? STATUS_LABELS[status] ?? status
+  const dotColor = STATUS_DOT_COLORS[status] ?? 'bg-slate-500'
+
+  if (variant === 'dot') {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <span className="relative flex h-2 w-2 shrink-0">
+          {pulse && (
+            <span className={`animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 ${dotColor}`} />
+          )}
+          <span className={`relative inline-flex rounded-full h-2 w-2 ${dotColor}`} />
+        </span>
+        <span className={`font-medium ${size === 'sm' ? 'text-xs' : 'text-sm'} text-slate-300`}>
+          {displayLabel}
+        </span>
+      </span>
+    )
+  }
+
+  const pillColor = STATUS_COLORS[status] ?? 'bg-slate-500/10 text-slate-400 border-slate-500/20'
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 border rounded-full font-medium ${pillColor} ${
+      size === 'sm' ? 'text-xs px-2 py-0.5' : 'text-sm px-3 py-1'
+    }`}>
+      {displayLabel}
+    </span>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/TabBar.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/TabBar.tsx
@@ -1,0 +1,59 @@
+interface TabBarProps<T extends string> {
+  tabs: readonly T[]
+  active: T
+  onChange: (tab: T) => void
+  badges?: Partial<Record<T, number>>
+  variant?: 'pill' | 'underline'
+}
+
+export default function TabBar<T extends string>({
+  tabs, active, onChange, badges, variant = 'pill',
+}: TabBarProps<T>) {
+  if (variant === 'underline') {
+    return (
+      <div className="flex gap-6 border-b border-white/5 mb-6">
+        {tabs.map(tab => (
+          <button
+            key={tab}
+            onClick={() => onChange(tab)}
+            className={`pb-2.5 text-sm font-medium transition-colors relative cursor-pointer ${
+              active === tab
+                ? 'text-indigo-400 border-b-2 border-indigo-500 -mb-px'
+                : 'text-slate-500 hover:text-slate-300'
+            }`}
+          >
+            {tab}
+            {badges?.[tab] != null && badges[tab]! > 0 && (
+              <span className="ml-1.5 bg-amber-500/90 text-black text-[10px] font-bold px-1.5 py-0.5 rounded-full min-w-[18px] text-center">
+                {badges[tab]}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-1.5 mb-6">
+      {tabs.map(tab => (
+        <button
+          key={tab}
+          onClick={() => onChange(tab)}
+          className={`text-xs px-3.5 py-1.5 rounded-full font-medium transition-colors cursor-pointer ${
+            active === tab
+              ? 'bg-indigo-600 text-white'
+              : 'bg-slate-800 text-slate-400 hover:text-white hover:bg-slate-700'
+          }`}
+        >
+          {tab}
+          {badges?.[tab] != null && badges[tab]! > 0 && (
+            <span className="ml-1.5 bg-amber-500/90 text-black text-[10px] font-bold px-1 py-0.5 rounded-full min-w-[16px] text-center inline-block">
+              {badges[tab]}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/TimelineItem.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/TimelineItem.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react'
+import { STATUS_DOT_COLORS } from '../types/index.ts'
+
+interface TimelineItemProps {
+  timestamp: string
+  title: string
+  subtitle?: string
+  status?: string
+  typeIcon?: ReactNode
+  typeLabel?: string
+  actions?: ReactNode
+  children?: ReactNode
+  last?: boolean
+}
+
+export default function TimelineItem({
+  timestamp, title, subtitle, status, typeIcon, typeLabel, actions, children, last,
+}: TimelineItemProps) {
+  const dotColor = status ? (STATUS_DOT_COLORS[status] ?? 'bg-slate-500') : 'bg-indigo-500'
+  const time = new Date(timestamp)
+  const timeStr = time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  const dateStr = time.toLocaleDateString([], { month: 'short', day: 'numeric' })
+
+  return (
+    <div className={`relative pl-8 ${last ? '' : 'mb-4'}`}>
+      {/* Vertical connector line */}
+      {!last && <div className="absolute left-[11px] top-[18px] bottom-0 w-px bg-slate-800" />}
+
+      {/* Timeline dot */}
+      <div className={`absolute left-[6px] top-[6px] w-3 h-3 rounded-full ${dotColor} border-2 border-slate-950`} />
+
+      <div className="bg-slate-800/50 backdrop-blur-sm border border-white/5 rounded-xl p-4 hover:border-white/10 transition-all duration-200">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              {typeIcon && <span className="text-slate-500 shrink-0">{typeIcon}</span>}
+              {typeLabel && (
+                <span className="text-[10px] text-slate-600 uppercase tracking-wider font-medium">{typeLabel}</span>
+              )}
+              <span className="text-[10px] text-slate-600 font-mono">{dateStr} {timeStr}</span>
+            </div>
+            <h3 className="text-sm font-medium text-slate-200 truncate">{title}</h3>
+            {subtitle && <p className="text-xs text-slate-500 mt-0.5 truncate">{subtitle}</p>}
+          </div>
+          {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+        </div>
+        {children && <div className="mt-3 pt-3 border-t border-white/5">{children}</div>}
+      </div>
+    </div>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/shared/icons.tsx
+++ b/packages/jarvis-dashboard/src/ui/shared/icons.tsx
@@ -1,0 +1,145 @@
+/* ── SVG Icon Components ──────────────────────────────────── */
+/* Consolidated from App.tsx + Home.tsx inline icons.          */
+/* All icons: 20x20 viewBox, stroke-based, currentColor.      */
+
+import type { ReactNode } from 'react'
+
+const I = ({ children }: { children: ReactNode }) => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    {children}
+  </svg>
+)
+
+/* ── Navigation icons ─────────────────────────────────────── */
+
+export function IconHome() {
+  return <I><path d="M3 10.5L10 4l7 6.5" /><path d="M5 9.5V16a1 1 0 001 1h3v-4h2v4h3a1 1 0 001-1V9.5" /></I>
+}
+
+export function IconWorkflow() {
+  return <I><path d="M4 6h5M4 10h3M4 14h5" /><circle cx="14" cy="6" r="2" /><circle cx="14" cy="14" r="2" /><path d="M12 6H9M12 14H9M14 8v4" /></I>
+}
+
+export function IconInbox() {
+  return <I><path d="M3 10l3-3h8l3 3" /><rect x="3" y="10" width="14" height="7" rx="1" /><path d="M3 10h4l1 2h4l1-2h4" /></I>
+}
+
+export function IconHistory() {
+  return <I><circle cx="10" cy="10" r="7" /><path d="M10 6v4l3 2" /><path d="M3 10H1M10 3V1" /></I>
+}
+
+export function IconSystem() {
+  return <I><rect x="4" y="3" width="12" height="10" rx="1" /><path d="M7 16h6M10 13v3" /><circle cx="10" cy="8" r="1.5" /></I>
+}
+
+export function IconRecovery() {
+  return <I><path d="M4 10a6 6 0 0111.3-2.7" /><path d="M16 10a6 6 0 01-11.3 2.7" /><path d="M15 4v3.3h-3.3" /><path d="M5 16v-3.3h3.3" /></I>
+}
+
+export function IconSettings() {
+  return <I><circle cx="10" cy="10" r="3" /><path d="M10 2v2M10 16v2M3.5 5.5l1.4 1.4M15.1 13.1l1.4 1.4M2 10h2M16 10h2M3.5 14.5l1.4-1.4M15.1 6.9l1.4-1.4" /></I>
+}
+
+export function IconGodmode() {
+  return <I><path d="M10 2L3 7v6l7 5 7-5V7z" /><circle cx="10" cy="10" r="3" /><path d="M10 7v6M7 10h6" /></I>
+}
+
+export function IconRuns() {
+  return <I><path d="M3 10h2l2-5 3 10 2-5h5" /></I>
+}
+
+export function IconModels() {
+  return <I><rect x="3" y="3" width="6" height="6" rx="1" /><rect x="11" y="3" width="6" height="6" rx="1" /><rect x="3" y="11" width="6" height="6" rx="1" /><rect x="11" y="11" width="6" height="6" rx="1" /></I>
+}
+
+export function IconQueue() {
+  return <I><path d="M4 5h12M4 9h10M4 13h8" /><circle cx="16" cy="13" r="1" /></I>
+}
+
+export function IconSupport() {
+  return <I><circle cx="10" cy="10" r="7" /><path d="M10 7v3M10 13v.5" /></I>
+}
+
+/* ── Expert-only / legacy nav icons ───────────────────────── */
+
+export function IconCrm() {
+  return <I><rect x="2" y="3" width="16" height="14" rx="2" /><path d="M2 7h16" /><path d="M7 7v10" /></I>
+}
+
+export function IconKnowledge() {
+  return <I><path d="M4 4h4l2 2h6a1 1 0 011 1v8a1 1 0 01-1 1H4a1 1 0 01-1-1V5a1 1 0 011-1z" /></I>
+}
+
+export function IconDecisions() {
+  return <I><path d="M10 3v14" /><path d="M3 10h14" /><circle cx="10" cy="10" r="7" /></I>
+}
+
+export function IconSchedule() {
+  return <I><rect x="3" y="4" width="14" height="13" rx="2" /><path d="M3 8h14" /><path d="M7 2v4M13 2v4" /></I>
+}
+
+export function IconPlugins() {
+  return <I><path d="M8 3v3M12 3v3" /><rect x="4" y="6" width="12" height="11" rx="2" /><path d="M8 17v-3h4v3" /></I>
+}
+
+export function IconGraph() {
+  return <I><circle cx="10" cy="5" r="2" /><circle cx="5" cy="14" r="2" /><circle cx="15" cy="14" r="2" /><path d="M10 7v3M8.5 11.5L6.5 12.5M11.5 11.5l2 1" /></I>
+}
+
+export function IconAnalytics() {
+  return <I><path d="M5 16V10M10 16V6M15 16V3" /></I>
+}
+
+/* ── Inline utility icons (smaller, for badges/actions) ───── */
+
+export function IconWarning({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18" fill="none">
+      <path d="M9 2L16.5 15H1.5L9 2Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <path d="M9 7v3M9 12v.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function IconError({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18" fill="none">
+      <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M6.5 6.5l5 5M11.5 6.5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+export function IconCheck({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18" fill="none">
+      <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M6 9l2 2 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function IconArrowRight({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none">
+      <path d="M2 7h10M8 3l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function IconChevronLeft({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 14 14" fill="none">
+      <path d="M9 3L5 7l4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function IconClock({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 18 18" fill="none">
+      <circle cx="9" cy="9" r="7" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M9 5v4l3 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}

--- a/packages/jarvis-dashboard/src/ui/stores/dashboard-store.ts
+++ b/packages/jarvis-dashboard/src/ui/stores/dashboard-store.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand'
+import type { AttentionData, DaemonStatus, SafeModeStatus, HealthData } from '../types/index.ts'
+
+type SystemHealth = 'healthy' | 'needs_attention' | 'offline'
+
+interface DashboardState {
+  /* ── Data ───────────────────────────────────────────────── */
+  attention: AttentionData | null
+  daemon: DaemonStatus | null
+  safeMode: SafeModeStatus | null
+  health: HealthData | null
+
+  /* ── Derived ────────────────────────────────────────────── */
+  systemHealth: SystemHealth
+  pendingApprovals: number
+  failedRuns: number
+
+  /* ── Polling ────────────────────────────────────────────── */
+  _interval: ReturnType<typeof setInterval> | null
+  fetchAll: () => void
+  startPolling: (intervalMs?: number) => void
+  stopPolling: () => void
+}
+
+export const useDashboardStore = create<DashboardState>((set, get) => ({
+  attention: null,
+  daemon: null,
+  safeMode: null,
+  health: null,
+
+  systemHealth: 'offline',
+  pendingApprovals: 0,
+  failedRuns: 0,
+
+  _interval: null,
+
+  fetchAll: () => {
+    Promise.all([
+      fetch('/api/attention').then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch('/api/daemon/status').then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch('/api/safemode').then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch('/api/health').then(r => r.ok ? r.json() : null).catch(() => null),
+    ]).then(([attention, daemon, safeMode, health]) => {
+      let systemHealth: SystemHealth = 'offline'
+      let pendingApprovals = 0
+      let failedRuns = 0
+
+      if (attention) {
+        pendingApprovals = attention.needs_attention?.pending_approvals ?? 0
+        failedRuns = attention.needs_attention?.failed_runs ?? 0
+        if (attention.system_status === 'healthy') systemHealth = 'healthy'
+        else if (attention.system_status === 'needs_attention') systemHealth = 'needs_attention'
+      }
+
+      if (safeMode?.safe_mode_recommended) {
+        systemHealth = 'needs_attention'
+      }
+
+      set({ attention, daemon, safeMode, health, systemHealth, pendingApprovals, failedRuns })
+    })
+  },
+
+  startPolling: (intervalMs = 10_000) => {
+    const { fetchAll, _interval } = get()
+    if (_interval) clearInterval(_interval)
+    fetchAll()
+    set({ _interval: setInterval(fetchAll, intervalMs) })
+  },
+
+  stopPolling: () => {
+    const { _interval } = get()
+    if (_interval) clearInterval(_interval)
+    set({ _interval: null })
+  },
+}))

--- a/packages/jarvis-dashboard/src/ui/types/index.ts
+++ b/packages/jarvis-dashboard/src/ui/types/index.ts
@@ -1,0 +1,390 @@
+/* ── Shared TypeScript interfaces for the Jarvis Dashboard ── */
+
+/* ── Health & System ──────────────────────────────────────── */
+
+export interface HealthData {
+  ok: boolean
+  status: string
+  uptime_seconds: number
+  crm: { contacts: number }
+  knowledge: { documents: number; playbooks: number }
+  runtime: Record<string, unknown>
+  daemon: Record<string, unknown>
+  disk_free_gb: number
+}
+
+export interface DaemonCurrentRun {
+  agent_id: string
+  status: string
+  step: number
+  total_steps: number
+  current_action: string
+  started_at: string
+}
+
+export interface DaemonStatus {
+  running: boolean
+  pid: number | null
+  uptime_seconds: number | null
+  agents_registered: number
+  schedules_active: number
+  last_run: { agent_id: string; status: string; completed_at: string } | null
+  /** @deprecated Use active_runs instead */
+  current_run: DaemonCurrentRun | null
+  active_runs?: DaemonCurrentRun[]
+}
+
+export interface SafeModeStatus {
+  safe_mode_recommended: boolean
+  reasons: string[]
+}
+
+/* ── Attention ────────────────────────────────────────────── */
+
+export interface AttentionNeedsAttention {
+  pending_approvals: number
+  failed_runs: number
+  overdue_schedules: number
+}
+
+export interface AttentionActiveWork {
+  run_id?: string
+  agent_id: string
+  status: string
+  current_step: number
+  total_steps: number
+  started_at?: string
+}
+
+export interface AttentionRecentCompletion {
+  run_id?: string
+  agent_id: string
+  status: string
+  completed_at: string
+  current_step?: number
+}
+
+export interface AttentionData {
+  needs_attention: AttentionNeedsAttention
+  active_work: AttentionActiveWork[]
+  recent_completions: AttentionRecentCompletion[]
+  recommended_actions: string[]
+  system_status: 'healthy' | 'needs_attention' | 'unknown'
+}
+
+/* ── Runs ─────────────────────────────────────────────────── */
+
+export interface Run {
+  run_id: string
+  agent_id: string
+  trigger: string
+  status: string
+  goal?: string
+  current_step?: number
+  total_steps?: number
+  error?: string
+  started_at: string
+  completed_at?: string | null
+  plan?: {
+    steps?: Array<{
+      action?: string
+      reasoning?: string
+      outcome?: string
+      started_at?: string
+      completed_at?: string
+    }>
+  } | null
+}
+
+export interface RunExplanation {
+  summary: string
+  trigger: string
+  data_sources: string[]
+  decisions_made: number
+  approvals_required: number
+  steps_completed: number
+  steps_total: number
+  outcome: string
+  failure?: {
+    probable_cause: string
+    outbound_effects_may_have_occurred: boolean
+    retry_recommendation: string
+  }
+  preview_mode?: {
+    enabled: boolean
+    skipped_actions: string[]
+  }
+}
+
+/* ── Approvals ────────────────────────────────────────────── */
+
+export interface LinkedRun {
+  run_id: string
+  agent_id: string
+  status: string
+  goal?: string
+  current_step?: number
+  total_steps?: number
+}
+
+export interface EnrichedApproval {
+  id: string
+  action: string
+  agent: string
+  severity: string
+  status: string
+  risk: { level: string; label: string; reversible: boolean } | null
+  linked_run: LinkedRun | null
+  timeout_at: string | null
+  time_remaining_ms: number | null
+  what_happens_if_nothing: string | null
+  created_at?: string
+}
+
+/* ── Workflows ────────────────────────────────────────────── */
+
+export interface WorkflowInput {
+  field: string
+  type: 'text' | 'file' | 'select' | 'date' | 'checkbox'
+  label: string
+  required: boolean
+  placeholder?: string
+  options?: string[]
+}
+
+export interface WorkflowSafetyRules {
+  outbound_default: 'draft' | 'send' | 'blocked'
+  preview_available: boolean
+  preview_recommended: boolean
+  retry_safe: boolean
+  retry_requires_approval: boolean
+}
+
+export interface WorkflowOutputField {
+  field: string
+  label: string
+  type: string
+}
+
+export interface WorkflowDefinition {
+  workflow_id: string
+  name: string
+  description?: string
+  inputs: WorkflowInput[]
+  agent_ids: string[]
+  safety_rules: WorkflowSafetyRules
+  expected_output: string
+  approval_summary: string
+  output_fields: WorkflowOutputField[]
+}
+
+/* ── Repair ───────────────────────────────────────────────── */
+
+export interface FixAction {
+  type: string
+  field?: string
+  description: string
+  example?: string
+}
+
+export interface RepairCheck {
+  name: string
+  status: 'ok' | 'warning' | 'critical'
+  message: string
+  severity: number
+  fix_action: FixAction | null
+}
+
+export interface RepairReport {
+  status: 'healthy' | 'degraded' | 'broken'
+  checks: RepairCheck[]
+  recommended_actions: Array<{ check: string; action: FixAction }>
+  safe_mode: boolean
+}
+
+/* ── History ──────────────────────────────────────────────── */
+
+export type HistoryEventType =
+  | 'run'
+  | 'approval'
+  | 'workflow_start'
+  | 'system'
+  | 'settings_change'
+  | 'recovery'
+  | 'backup'
+
+export interface HistoryEvent {
+  id: string
+  type: HistoryEventType
+  title: string
+  subtitle?: string
+  status: string
+  source: string
+  timestamp: string
+  agent_id?: string
+  workflow_id?: string
+  run_id?: string
+  approval_id?: string
+  outcome?: string
+  payload?: Record<string, unknown>
+}
+
+export interface HistoryResponse {
+  events: HistoryEvent[]
+  total: number
+  has_more: boolean
+}
+
+/* ── Agents ───────────────────────────────────────────────── */
+
+export interface AgentData {
+  agentId: string
+  label: string
+  description: string
+  schedule: string
+  lastRun: string | null
+  lastOutcome: string | null
+}
+
+export interface AgentSetting {
+  id: string
+  label: string
+  description: string
+  schedule: string
+  enabled: boolean
+}
+
+/* ── Models ────────────────────────────────────────────────── */
+
+export interface ModelInfo {
+  id: string
+  name?: string
+  runtime?: string
+  enabled?: boolean
+  capabilities?: string[]
+  last_seen_at?: string
+}
+
+export interface ModelHealthReport {
+  runtimes: Array<{
+    name: string
+    url: string
+    connected: boolean
+    models: string[]
+    error?: string
+  }>
+  degraded: boolean
+}
+
+/* ── Utilities ────────────────────────────────────────────── */
+
+export const AGENT_LABELS: Record<string, string> = {
+  'bd-pipeline': 'BD Pipeline',
+  'proposal-engine': 'Proposal Engine',
+  'evidence-auditor': 'Evidence Auditor',
+  'contract-reviewer': 'Contract Reviewer',
+  'staffing-monitor': 'Staffing Monitor',
+  'content-engine': 'Content Engine',
+  'portfolio-monitor': 'Portfolio Monitor',
+  'garden-calendar': 'Garden Calendar',
+  'email-campaign': 'Email Campaign',
+  'social-engagement': 'Social Engagement',
+  'security-monitor': 'Security Monitor',
+  'drive-watcher': 'Drive Watcher',
+  'invoice-generator': 'Invoice Generator',
+  'meeting-transcriber': 'Meeting Transcriber',
+}
+
+export function agentLabel(id: string): string {
+  return AGENT_LABELS[id] ?? id
+}
+
+export const STATUS_LABELS: Record<string, string> = {
+  planning: 'Planning',
+  executing: 'Running',
+  awaiting_approval: 'Awaiting Approval',
+  completed: 'Completed',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+  queued: 'Queued',
+}
+
+export const STATUS_COLORS: Record<string, string> = {
+  completed: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  running: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  executing: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  planning: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  awaiting_approval: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  failed: 'bg-red-500/10 text-red-400 border-red-500/20',
+  cancelled: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
+  queued: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  pending: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  approved: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  rejected: 'bg-red-500/10 text-red-400 border-red-500/20',
+  ok: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  warning: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  critical: 'bg-red-500/10 text-red-400 border-red-500/20',
+  healthy: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  degraded: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  broken: 'bg-red-500/10 text-red-400 border-red-500/20',
+}
+
+export const STATUS_DOT_COLORS: Record<string, string> = {
+  completed: 'bg-emerald-500',
+  running: 'bg-amber-400',
+  executing: 'bg-amber-400',
+  planning: 'bg-blue-400',
+  awaiting_approval: 'bg-amber-400',
+  failed: 'bg-red-500',
+  cancelled: 'bg-slate-500',
+  queued: 'bg-blue-400',
+  pending: 'bg-amber-400',
+  approved: 'bg-emerald-500',
+  rejected: 'bg-red-500',
+  ok: 'bg-emerald-500',
+  warning: 'bg-amber-400',
+  critical: 'bg-red-500',
+  healthy: 'bg-emerald-500',
+  degraded: 'bg-amber-400',
+  broken: 'bg-red-500',
+  offline: 'bg-slate-600',
+}
+
+/* ── Time formatting ──────────────────────────────────────── */
+
+export function formatUptime(seconds: number | null): string {
+  if (seconds === null || seconds < 0) return '--'
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  if (hours < 24) return `${hours}h ${remMins}m`
+  const days = Math.floor(hours / 24)
+  return `${days}d ${hours % 24}h`
+}
+
+export function timeAgo(iso: string | null): string {
+  if (!iso) return 'Never'
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'Just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export function formatDuration(start: string, end?: string | null): string {
+  if (!end) return '--'
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  if (ms < 0) return '--'
+  const secs = Math.floor(ms / 1000)
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  const remSecs = secs % 60
+  if (mins < 60) return `${mins}m ${remSecs}s`
+  const hrs = Math.floor(mins / 60)
+  return `${hrs}h ${mins % 60}m`
+}


### PR DESCRIPTION
## Summary

- Redesign entire Jarvis dashboard from agent-framework UI into personal operations console
- Navigation restructured: Simple mode (Home, Workflows, Inbox, History, System, Settings) + Expert mode (Godmode, Runs, Models, Queue, Support, legacy Data pages)
- 11 new/rewritten pages, 10 shared components, centralized Zustand store, new History API endpoint
- JarvisChat upgraded with multi-session history (localStorage, topic switching)
- Settings expanded to 9 tabs with generic tier names, friendly integrations, agent action links
- Schedule page adds enable/disable toggles, last run info, and task descriptions

## Test plan

- [ ] Run `npm run build --workspace=jarvis-dashboard` — verify clean build
- [ ] Start full stack with `npm run dev --workspace=jarvis-dashboard` and verify all pages render
- [ ] Test simple/expert mode toggle — sidebar items should change
- [ ] Test each page: Home, Workflows, Inbox, History, System, Settings, Recovery
- [ ] Test JarvisChat multi-session: create chats, switch between them, delete
- [ ] Test Schedule page: toggle tasks on/off, run now
- [ ] Verify `/approvals` redirects to `/inbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)