### PR TITLE
Rework README, CLAUDE.md, and USAGE.md documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Jarvis is an autonomous agent system for **Thinking in Code**, Daniel's automotive safety consulting firm (ISO 26262, ASPICE, AUTOSAR, cybersecurity). It runs 14 domain agents that handle BD pipeline intelligence, proposal generation, compliance auditing, contract review, staffing monitoring, LinkedIn content, crypto portfolio, garden management, email campaigns, social engagement, security monitoring, drive watching, invoice generation, and meeting transcription.
 
-The system runs on **OpenClaw** (`^2026.4.5`) as a plugin pack. OpenClaw provides the chat OS layer (session routing, plugin lifecycle, tool execution, model abstraction, Telegram channel). Jarvis provides 17 domain plugins, 14 agent definitions, and a contract-validated job queue.
+The system runs on **OpenClaw** (`^2026.4.5`) as a plugin pack. OpenClaw provides the chat OS layer (session routing, plugin lifecycle, tool execution, model abstraction, Telegram channel). Jarvis provides 19 domain plugins, 14 agent definitions, and a contract-validated job queue.
 
 ## Quick Start
 
@@ -58,14 +58,16 @@ OpenClaw is the plugin gateway. Jarvis plugins register tools, commands, and hoo
 
 ```
 OpenClaw Gateway (WebSocket + HTTP, plugin host)
-    |-- 17 Jarvis Plugins
+    |-- 19 Jarvis Plugins
     |     |-- @jarvis/core     -- planning, approvals, model selection
     |     |-- @jarvis/jobs     -- job queue (claim/heartbeat/callback HTTP routes)
     |     |-- @jarvis/dispatch -- cross-session messaging
+    |     |-- @jarvis/agent    -- agent registration and execution
     |     |-- @jarvis/office   -- Excel/Word/PowerPoint automation
     |     |-- @jarvis/device   -- Windows desktop automation
+    |     |-- @jarvis/system   -- system monitoring and platform hooks
     |     |-- @jarvis/email    -- email management
-    |     '-- ... (11 more plugins)
+    |     '-- ... (10 more plugins)
     |-- Job Queue (submit -> claim -> heartbeat -> callback)
     |-- Worker Pool (in-process and child-process workers)
     '-- Model Router (TaskProfile -> SelectionPolicy -> local model)
@@ -84,31 +86,31 @@ OpenClaw Gateway (WebSocket + HTTP, plugin host)
 ## Packages (43)
 
 ### Core & Framework
-- `jarvis-shared` -- base types, OpenClaw SDK integration, gateway utilities
-- `jarvis-core` -- policy engine: planning, approvals, model selection
-- `jarvis-agent-framework` -- agent runtime, memory, knowledge, entity graph, lesson capture
-- `jarvis-agents` -- 14 agent definitions with system prompts
-- `jarvis-runtime` -- standalone daemon
+- `@jarvis/shared` -- base types, OpenClaw SDK integration, gateway utilities
+- `@jarvis/core` -- policy engine: planning, approvals, model selection
+- `@jarvis/agent-framework` -- agent runtime, memory, knowledge, entity graph, lesson capture
+- `@jarvis/agents` -- 14 agent definitions with system prompts
+- `@jarvis/runtime` -- standalone daemon
 
 ### Infrastructure
-- `jarvis-jobs`, `jarvis-dispatch`, `jarvis-scheduler`, `jarvis-supervisor`
-- `jarvis-inference`, `jarvis-interpreter`, `jarvis-security`, `jarvis-system`, `jarvis-voice`, `jarvis-device`
+- `@jarvis/jobs`, `@jarvis/dispatch`, `@jarvis/scheduler`, `@jarvis/supervisor`
+- `@jarvis/inference`, `@jarvis/interpreter`, `@jarvis/security`, `@jarvis/system`, `@jarvis/voice`, `@jarvis/device`
 
 ### Plugins (6)
-- `jarvis-agent-plugin`, `jarvis-email-plugin`, `jarvis-calendar-plugin`
-- `jarvis-crm-plugin`, `jarvis-web-plugin`, `jarvis-document-plugin`
+- `@jarvis/agent-plugin`, `@jarvis/email-plugin`, `@jarvis/calendar-plugin`
+- `@jarvis/crm-plugin`, `@jarvis/web-plugin`, `@jarvis/document-plugin`
 
 ### Workers (17)
-- `jarvis-agent-worker`, `jarvis-email-worker`, `jarvis-calendar-worker`, `jarvis-crm-worker`
-- `jarvis-web-worker`, `jarvis-document-worker`, `jarvis-browser-worker`, `jarvis-office-worker`
-- `jarvis-inference-worker`, `jarvis-interpreter-worker`, `jarvis-security-worker`, `jarvis-system-worker`
-- `jarvis-voice-worker`, `jarvis-social-worker`, `jarvis-time-worker`, `jarvis-drive-worker`
-- `jarvis-desktop-host-worker`
+- `@jarvis/agent-worker`, `@jarvis/email-worker`, `@jarvis/calendar-worker`, `@jarvis/crm-worker`
+- `@jarvis/web-worker`, `@jarvis/document-worker`, `@jarvis/browser-worker`, `@jarvis/office-worker`
+- `@jarvis/inference-worker`, `@jarvis/interpreter-worker`, `@jarvis/security-worker`, `@jarvis/system-worker`
+- `@jarvis/voice-worker`, `@jarvis/social-worker`, `@jarvis/time-worker`, `@jarvis/drive-worker`
+- `@jarvis/desktop-host-worker`
 
 ### Services
 - `jarvis-dashboard` -- React web dashboard
 - `jarvis-telegram` -- Telegram bot
-- `jarvis-browser`, `jarvis-office`, `jarvis-files`
+- `@jarvis/browser`, `@jarvis/office`, `@jarvis/files`
 
 ## Key Directories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
-# Jarvis — Autonomous Agent System
+# Jarvis -- Autonomous Agent System
 
 Jarvis is an autonomous agent system for **Thinking in Code**, Daniel's automotive safety consulting firm (ISO 26262, ASPICE, AUTOSAR, cybersecurity). It runs 14 domain agents that handle BD pipeline intelligence, proposal generation, compliance auditing, contract review, staffing monitoring, LinkedIn content, crypto portfolio, garden management, email campaigns, social engagement, security monitoring, drive watching, invoice generation, and meeting transcription.
+
+The system runs on **OpenClaw** (`^2026.4.5`) as a plugin pack. OpenClaw provides the chat OS layer (session routing, plugin lifecycle, tool execution, model abstraction, Telegram channel). Jarvis provides 17 domain plugins, 14 agent definitions, and a contract-validated job queue.
 
 ## Quick Start
 
@@ -35,55 +37,114 @@ Agents with schedules run automatically via scheduled tasks. Manual agents run o
 
 ## Architecture
 
-Claude Code is the runtime. Jarvis provides domain knowledge, state persistence, and agent definitions.
+Jarvis has two execution modes:
+
+### Claude Code Mode (Interactive)
+
+Claude Code is the runtime. Jarvis provides domain knowledge, state persistence, and agent definitions as skills.
 
 ```
 Claude Code (LLM reasoning + MCP integrations)
-    ├── Skills (.claude/skills/*.md) — agent workflows
-    ├── Gmail MCP — email search, read, draft, send
-    ├── Chrome MCP — browser automation
-    ├── WebSearch/WebFetch — web intelligence
-    └── Scheduled Tasks MCP — cron triggers
-Jarvis State (SQLite)
-    ├── ~/.jarvis/crm.db — CRM pipeline (contacts, notes, stages)
-    └── ~/.jarvis/knowledge.db — knowledge store (documents, playbooks, entities, decisions)
-Jarvis Packages (29 packages, typed infrastructure)
-    ├── Agent definitions + prompts (packages/jarvis-agents/)
-    ├── Agent framework (packages/jarvis-agent-framework/)
-    ├── Job contracts + schemas (contracts/jarvis/v1/)
-    └── Workers + plugins (packages/jarvis-*-worker/, packages/jarvis-*-plugin/)
+    |-- Skills (.claude/skills/*.md) -- agent workflows
+    |-- Gmail MCP -- email search, read, draft, send
+    |-- Chrome MCP -- browser automation
+    |-- WebSearch/WebFetch -- web intelligence
+    '-- Scheduled Tasks MCP -- cron triggers
 ```
+
+### OpenClaw Mode (Autonomous)
+
+OpenClaw is the plugin gateway. Jarvis plugins register tools, commands, and hooks. Workers execute jobs asynchronously.
+
+```
+OpenClaw Gateway (WebSocket + HTTP, plugin host)
+    |-- 17 Jarvis Plugins
+    |     |-- @jarvis/core     -- planning, approvals, model selection
+    |     |-- @jarvis/jobs     -- job queue (claim/heartbeat/callback HTTP routes)
+    |     |-- @jarvis/dispatch -- cross-session messaging
+    |     |-- @jarvis/office   -- Excel/Word/PowerPoint automation
+    |     |-- @jarvis/device   -- Windows desktop automation
+    |     |-- @jarvis/email    -- email management
+    |     '-- ... (11 more plugins)
+    |-- Job Queue (submit -> claim -> heartbeat -> callback)
+    |-- Worker Pool (in-process and child-process workers)
+    '-- Model Router (TaskProfile -> SelectionPolicy -> local model)
+```
+
+### Shared State (SQLite)
+
+```
+~/.jarvis/
+    |-- runtime.db    -- control plane: runs, approvals, jobs, heartbeats, model registry, agent memory
+    |-- crm.db        -- CRM pipeline: contacts, notes, stages
+    |-- knowledge.db  -- knowledge store: documents, playbooks, entities, decisions
+    '-- config.json   -- configuration
+```
+
+## Packages (43)
+
+### Core & Framework
+- `jarvis-shared` -- base types, OpenClaw SDK integration, gateway utilities
+- `jarvis-core` -- policy engine: planning, approvals, model selection
+- `jarvis-agent-framework` -- agent runtime, memory, knowledge, entity graph, lesson capture
+- `jarvis-agents` -- 14 agent definitions with system prompts
+- `jarvis-runtime` -- standalone daemon
+
+### Infrastructure
+- `jarvis-jobs`, `jarvis-dispatch`, `jarvis-scheduler`, `jarvis-supervisor`
+- `jarvis-inference`, `jarvis-interpreter`, `jarvis-security`, `jarvis-system`, `jarvis-voice`, `jarvis-device`
+
+### Plugins (6)
+- `jarvis-agent-plugin`, `jarvis-email-plugin`, `jarvis-calendar-plugin`
+- `jarvis-crm-plugin`, `jarvis-web-plugin`, `jarvis-document-plugin`
+
+### Workers (17)
+- `jarvis-agent-worker`, `jarvis-email-worker`, `jarvis-calendar-worker`, `jarvis-crm-worker`
+- `jarvis-web-worker`, `jarvis-document-worker`, `jarvis-browser-worker`, `jarvis-office-worker`
+- `jarvis-inference-worker`, `jarvis-interpreter-worker`, `jarvis-security-worker`, `jarvis-system-worker`
+- `jarvis-voice-worker`, `jarvis-social-worker`, `jarvis-time-worker`, `jarvis-drive-worker`
+- `jarvis-desktop-host-worker`
+
+### Services
+- `jarvis-dashboard` -- React web dashboard
+- `jarvis-telegram` -- Telegram bot
+- `jarvis-browser`, `jarvis-office`, `jarvis-files`
 
 ## Key Directories
 
-- `packages/jarvis-agents/src/definitions/` — 14 agent definition files (TypeScript)
-- `packages/jarvis-agents/src/prompts/` — 14 system prompt files (Markdown)
-- `packages/jarvis-agents/src/data/` — Garden beds + planting calendar (JSON)
-- `packages/jarvis-agent-framework/src/` — Runtime, memory, knowledge, entity graph, lesson capture
-- `contracts/jarvis/v1/` — JSON schemas, examples, catalog, plugin surface
-- `tests/` — ~33 test files, 769+ tests
-- `scripts/` — Contract validation, DB initialization
-- `.claude/skills/` — Claude Code skill files for each agent
+- `packages/jarvis-agents/src/definitions/` -- 14 agent definition files (TypeScript)
+- `packages/jarvis-agents/src/prompts/` -- 14 system prompt files (Markdown)
+- `packages/jarvis-agents/src/data/` -- Garden beds + planting calendar (JSON)
+- `packages/jarvis-agent-framework/src/` -- Runtime, memory, knowledge, entity graph, lesson capture
+- `contracts/jarvis/v1/` -- JSON schemas (22 families), 144 examples, job catalog (143 types), plugin surface
+- `tests/` -- 48 test files, 1159 tests
+- `scripts/` -- Setup, contract validation, DB initialization, ops (health, backup, recovery)
+- `scripts/runtime/` -- OpenClaw gateway bootstrap and smoke harness
+- `docs/` -- Architecture, usage guide, production target, release gates, specs, runbooks
+- `.claude/skills/` -- Claude Code skill files for each agent
 
 ## Testing
 
 ```bash
 npm run check                    # Full pipeline: contracts + tests + build
-npm test                         # Tests only (~33 files)
+npm test                         # Tests only (48 files, 1159 tests)
 npm run build                    # TypeScript compilation
-npm run validate:contracts       # Schema + example validation
+npm run validate:contracts       # Schema + example validation (143 job types)
+npm run smoke:runtime            # OpenClaw + LM Studio integration smoke test
 ```
 
 ## CRM Pipeline Stages
 
-prospect → qualified → contacted → meeting → proposal → negotiation → won | lost | parked
+prospect -> qualified -> contacted -> meeting -> proposal -> negotiation -> won | lost | parked
 
 ## Approval Rules
 
-- `email.send` — always requires approval (critical)
-- `publish_post` / `post_comment` — always requires approval (critical)
-- `trade_execute` — always requires approval (critical)
-- `crm.move_stage` — requires approval (warning)
-- `document.generate_report` — requires approval (warning)
+- `email.send` -- always requires approval (critical)
+- `publish_post` / `post_comment` -- always requires approval (critical)
+- `trade_execute` -- always requires approval (critical)
+- `crm.move_stage` -- requires approval (warning)
+- `document.generate_report` -- requires approval (warning)
+
+Of 143 total job types: 17 always require approval, 33 are conditional, 93 never require approval.
 
 Read-only operations (search, analyze, list) never require approval.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dashboard: **http://localhost:4242**
 
 | Requirement | Minimum | Recommended |
 |---|---|---|
-| Node.js | 22+ | 22 LTS |
+| Node.js | >=22.5.0 | 22 LTS |
 | OpenClaw | ^2026.4.5 | Latest |
 | RAM | 8 GB | 16+ GB |
 | Disk | 2 GB free | 10+ GB |
@@ -46,22 +46,24 @@ ollama pull qwen2.5:14b     # Better reasoning, needs 16GB+ RAM
 
 ## Architecture
 
-Jarvis is a plugin pack for OpenClaw. OpenClaw provides the chat OS layer (session routing, plugin lifecycle, tool execution, model abstraction, channel integration). Jarvis provides 17 domain plugins that sit on top.
+Jarvis is a plugin pack for OpenClaw. OpenClaw provides the chat OS layer (session routing, plugin lifecycle, tool execution, model abstraction, channel integration). Jarvis provides 19 domain plugins that sit on top.
 
 ```
 Channels (Telegram, CLI, Web, API)
         |
 OpenClaw Gateway (WebSocket + HTTP)
-  |-- Plugin Manager
+  |-- Plugin Manager (19 plugins)
   |     |-- @jarvis/core        Planning, approvals, model selection
   |     |-- @jarvis/jobs        Job queue (submit, claim, heartbeat, callback)
   |     |-- @jarvis/dispatch    Cross-session messaging
+  |     |-- @jarvis/agent       Agent registration and execution
   |     |-- @jarvis/office      Excel, Word, PowerPoint automation
   |     |-- @jarvis/device      Windows desktop automation
   |     |-- @jarvis/email       Gmail search, read, draft, send
   |     |-- @jarvis/calendar    Calendar intelligence
   |     |-- @jarvis/browser     Chrome automation
   |     |-- @jarvis/files       Safe file operations
+  |     |-- @jarvis/system      System monitoring and platform hooks
   |     |-- @jarvis/inference   Local LLM routing
   |     |-- @jarvis/crm         CRM pipeline management
   |     |-- @jarvis/web         Web intelligence
@@ -85,7 +87,7 @@ Data: ~/.jarvis/
 ### How It Works
 
 1. **Agents** define what to do (system prompts, capabilities, approval gates, schedules)
-2. **Plugins** expose tools to agents via the OpenClaw plugin SDK (`definePluginEntry`)
+2. **Plugins** (19 total) expose tools to agents via the OpenClaw plugin SDK (`definePluginEntry`)
 3. **Tools** submit deterministic job specs to the **job queue**
 4. **Workers** claim jobs via HTTP, execute, and return results via callback
 5. **Model routing** matches agent needs (TaskProfile) to available local models (SelectionPolicy)
@@ -110,9 +112,9 @@ Jarvis supports two execution modes:
 | **portfolio-monitor** | Check crypto prices, calculate drift, recommend rebalance | Daily 8 AM + 8 PM | Operational |
 | **garden-calendar** | Generate weekly garden brief based on date + weather | Mondays 7:00 AM | Operational |
 | **email-campaign** | Manage drip campaigns, follow-up sequences | Manual | Trusted |
-| **social-engagement** | Monitor and respond to social media interactions | Manual | Operational |
-| **security-monitor** | Track security advisories, vulnerability alerts | Manual | Operational |
-| **drive-watcher** | Watch shared drives for new/changed documents | Manual | Operational |
+| **social-engagement** | Monitor and respond to social media interactions | Weekdays 8:30 AM + 6 PM | Operational |
+| **security-monitor** | Track security advisories, vulnerability alerts | Daily 3:00 AM | Operational |
+| **drive-watcher** | Watch shared drives for new/changed documents | Every 5 minutes | Operational |
 | **invoice-generator** | Generate and track invoices for client engagements | Manual | Trusted |
 | **meeting-transcriber** | Transcribe and summarize meeting recordings | Manual | Operational |
 
@@ -129,59 +131,59 @@ Jarvis supports two execution modes:
 
 | Package | Purpose |
 |---|---|
-| `jarvis-shared` | Base types, OpenClaw runtime foundation, gateway utilities |
-| `jarvis-core` | Policy engine: planning, approvals, model selection |
-| `jarvis-agent-framework` | Agent runtime, memory, knowledge, entity graph, lesson capture |
-| `jarvis-agents` | 14 agent definitions with system prompts and registry |
-| `jarvis-runtime` | Standalone daemon for autonomous agent execution |
+| `@jarvis/shared` | Base types, OpenClaw runtime foundation, gateway utilities |
+| `@jarvis/core` | Policy engine: planning, approvals, model selection |
+| `@jarvis/agent-framework` | Agent runtime, memory, knowledge, entity graph, lesson capture |
+| `@jarvis/agents` | 14 agent definitions with system prompts and registry |
+| `@jarvis/runtime` | Standalone daemon for autonomous agent execution |
 
 ### Infrastructure
 
 | Package | Purpose |
 |---|---|
-| `jarvis-jobs` | Job queue: submission, claiming, callbacks, retries |
-| `jarvis-dispatch` | Cross-session messaging and follow-ups |
-| `jarvis-scheduler` | Cron scheduling and alert management |
-| `jarvis-supervisor` | Agent supervision and governance |
-| `jarvis-inference` | LLM inference coordination and model routing |
-| `jarvis-interpreter` | Code/prompt interpretation |
-| `jarvis-security` | Security policies and validation |
-| `jarvis-system` | System monitoring (CPU, memory, disk, processes) |
-| `jarvis-voice` | Voice I/O (Whisper STT, Piper TTS) |
-| `jarvis-device` | Device integration and notifications |
+| `@jarvis/jobs` | Job queue: submission, claiming, callbacks, retries |
+| `@jarvis/dispatch` | Cross-session messaging and follow-ups |
+| `@jarvis/scheduler` | Cron scheduling and alert management |
+| `@jarvis/supervisor` | Agent supervision and governance |
+| `@jarvis/inference` | LLM inference coordination and model routing |
+| `@jarvis/interpreter` | Code/prompt interpretation |
+| `@jarvis/security` | Security policies and validation |
+| `@jarvis/system` | System monitoring (CPU, memory, disk, processes) |
+| `@jarvis/voice` | Voice I/O (Whisper STT, Piper TTS) |
+| `@jarvis/device` | Device integration and notifications |
 
 ### Plugins (Agent-Facing Interfaces)
 
 | Package | Purpose |
 |---|---|
-| `jarvis-agent-plugin` | Agent orchestration plugin |
-| `jarvis-email-plugin` | Email operations (Gmail) |
-| `jarvis-calendar-plugin` | Calendar operations |
-| `jarvis-crm-plugin` | CRM pipeline management |
-| `jarvis-web-plugin` | Web intelligence and scraping |
-| `jarvis-document-plugin` | Document analysis and compliance checking |
+| `@jarvis/agent-plugin` | Agent orchestration plugin |
+| `@jarvis/email-plugin` | Email operations (Gmail) |
+| `@jarvis/calendar-plugin` | Calendar operations |
+| `@jarvis/crm-plugin` | CRM pipeline management |
+| `@jarvis/web-plugin` | Web intelligence and scraping |
+| `@jarvis/document-plugin` | Document analysis and compliance checking |
 
 ### Workers (Async Job Processors)
 
 | Package | Purpose |
 |---|---|
-| `jarvis-agent-worker` | Agent execution |
-| `jarvis-email-worker` | Email sending/receiving |
-| `jarvis-calendar-worker` | Calendar sync |
-| `jarvis-crm-worker` | CRM operations |
-| `jarvis-web-worker` | Web scraping and search |
-| `jarvis-document-worker` | Document processing |
-| `jarvis-browser-worker` | Chrome automation |
-| `jarvis-office-worker` | Office document handling |
-| `jarvis-inference-worker` | LLM inference execution |
-| `jarvis-interpreter-worker` | Code/prompt execution |
-| `jarvis-security-worker` | Security checks |
-| `jarvis-system-worker` | System commands |
-| `jarvis-voice-worker` | Voice I/O processing |
-| `jarvis-social-worker` | Social media monitoring |
-| `jarvis-time-worker` | Time/timezone utilities |
-| `jarvis-drive-worker` | Google Drive monitoring |
-| `jarvis-desktop-host-worker` | Windows desktop automation |
+| `@jarvis/agent-worker` | Agent execution |
+| `@jarvis/email-worker` | Email sending/receiving |
+| `@jarvis/calendar-worker` | Calendar sync |
+| `@jarvis/crm-worker` | CRM operations |
+| `@jarvis/web-worker` | Web scraping and search |
+| `@jarvis/document-worker` | Document processing |
+| `@jarvis/browser-worker` | Chrome automation |
+| `@jarvis/office-worker` | Office document handling |
+| `@jarvis/inference-worker` | LLM inference execution |
+| `@jarvis/interpreter-worker` | Code/prompt execution |
+| `@jarvis/security-worker` | Security checks |
+| `@jarvis/system-worker` | System commands |
+| `@jarvis/voice-worker` | Voice I/O processing |
+| `@jarvis/social-worker` | Social media monitoring |
+| `@jarvis/time-worker` | Time/timezone utilities |
+| `@jarvis/drive-worker` | Google Drive monitoring |
+| `@jarvis/desktop-host-worker` | Windows desktop automation |
 
 ### Services
 
@@ -189,16 +191,16 @@ Jarvis supports two execution modes:
 |---|---|
 | `jarvis-dashboard` | Web dashboard (React) at http://localhost:4242 |
 | `jarvis-telegram` | Telegram bot integration |
-| `jarvis-browser` | Chrome DevTools Protocol integration |
-| `jarvis-office` | Office (Word, Excel, PowerPoint) operations |
-| `jarvis-files` | File system operations |
+| `@jarvis/browser` | Chrome DevTools Protocol integration |
+| `@jarvis/office` | Office (Word, Excel, PowerPoint) operations |
+| `@jarvis/files` | File system operations |
 
 ## Contract System
 
 All job types, tool responses, and worker callbacks conform to the `jarvis.v1` contract — a frozen JSON Schema specification.
 
 - **143 job types** across **22 families**: agent, browser, calendar, crm, device, document, drive, email, files, inference, interpreter, office, python, scheduler, scrape, search, security, social, system, time, voice, web
-- **Schema validation** via `npm run validate:contracts` — validates all schemas and 144 example payloads
+- **Schema validation** via `npm run validate:contracts` — validates schemas and 144 example payloads (some newer job types temporarily excluded from full envelope/result validation)
 - **Contract files** live in `contracts/jarvis/v1/`
 
 ### Job Lifecycle

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Autonomous agent system for [Thinking in Code](https://thinking-in-code.com)** — an automotive safety consulting firm specializing in ISO 26262, ASPICE, AUTOSAR, and cybersecurity.
 
-Jarvis runs 14 domain agents that handle business development, proposal generation, compliance auditing, contract review, staffing, content creation, portfolio management, and more — all powered by local LLMs via Ollama or LM Studio.
+Jarvis runs 14 domain agents that handle business development, proposal generation, compliance auditing, contract review, staffing, content creation, portfolio management, and more. It runs on [OpenClaw](https://openclaw.dev) as a plugin pack, with local LLM inference via Ollama or LM Studio.
 
 ## Quick Start
 
@@ -26,6 +26,7 @@ Dashboard: **http://localhost:4242**
 | Requirement | Minimum | Recommended |
 |---|---|---|
 | Node.js | 22+ | 22 LTS |
+| OpenClaw | ^2026.4.5 | Latest |
 | RAM | 8 GB | 16+ GB |
 | Disk | 2 GB free | 10+ GB |
 | Model Runtime | Ollama **or** LM Studio | Both |
@@ -43,88 +44,234 @@ ollama pull llama3.2        # Fast, good for most agents
 ollama pull qwen2.5:14b     # Better reasoning, needs 16GB+ RAM
 ```
 
+## Architecture
+
+Jarvis is a plugin pack for OpenClaw. OpenClaw provides the chat OS layer (session routing, plugin lifecycle, tool execution, model abstraction, channel integration). Jarvis provides 17 domain plugins that sit on top.
+
+```
+Channels (Telegram, CLI, Web, API)
+        |
+OpenClaw Gateway (WebSocket + HTTP)
+  |-- Plugin Manager
+  |     |-- @jarvis/core        Planning, approvals, model selection
+  |     |-- @jarvis/jobs        Job queue (submit, claim, heartbeat, callback)
+  |     |-- @jarvis/dispatch    Cross-session messaging
+  |     |-- @jarvis/office      Excel, Word, PowerPoint automation
+  |     |-- @jarvis/device      Windows desktop automation
+  |     |-- @jarvis/email       Gmail search, read, draft, send
+  |     |-- @jarvis/calendar    Calendar intelligence
+  |     |-- @jarvis/browser     Chrome automation
+  |     |-- @jarvis/files       Safe file operations
+  |     |-- @jarvis/inference   Local LLM routing
+  |     |-- @jarvis/crm         CRM pipeline management
+  |     |-- @jarvis/web         Web intelligence
+  |     |-- @jarvis/document    Document analysis
+  |     |-- @jarvis/security    Security monitoring
+  |     |-- @jarvis/scheduler   Cron scheduling
+  |     |-- @jarvis/interpreter Multi-step automation
+  |     '-- @jarvis/voice       Voice I/O
+  |-- Native Tools (browser, fetch, exec)
+  '-- Agent Execution (TaskProfile -> model routing)
+        |                       |
+   LM Studio (:1234)     Ollama (:11434)
+
+Data: ~/.jarvis/
+  |-- runtime.db     Control plane (runs, approvals, jobs, model registry)
+  |-- crm.db         CRM pipeline (contacts, notes, stages)
+  |-- knowledge.db   Knowledge store (documents, entities, decisions)
+  '-- config.json    Configuration
+```
+
+### How It Works
+
+1. **Agents** define what to do (system prompts, capabilities, approval gates, schedules)
+2. **Plugins** expose tools to agents via the OpenClaw plugin SDK (`definePluginEntry`)
+3. **Tools** submit deterministic job specs to the **job queue**
+4. **Workers** claim jobs via HTTP, execute, and return results via callback
+5. **Model routing** matches agent needs (TaskProfile) to available local models (SelectionPolicy)
+
+### Dual Execution Model
+
+Jarvis supports two execution modes:
+
+- **Claude Code mode** — Agents run as Claude Code skills (`.claude/skills/*.md`), using MCP integrations (Gmail, Chrome, WebSearch) directly. Good for interactive use.
+- **OpenClaw mode** — Agents run through the OpenClaw gateway with the full plugin stack, job queue, and worker pool. Good for autonomous scheduled execution.
+
 ## Agents
 
-| Agent | What it does | Maturity |
-|---|---|---|
-| **bd-pipeline** | Scan for BD signals, enrich leads, draft outreach, update CRM | Trusted |
-| **proposal-engine** | Analyze RFQ/SOW, build quote structure, draft proposal | High-stakes |
-| **evidence-auditor** | Scan project for ISO 26262 work products, produce gap matrix | Trusted |
-| **contract-reviewer** | Analyze NDA/MSA clauses, produce sign/negotiate/escalate recommendation | High-stakes |
-| **staffing-monitor** | Calculate team utilization, forecast gaps, match skills to pipeline | Operational |
-| **content-engine** | Draft LinkedIn post for today's content pillar | Operational |
-| **portfolio-monitor** | Check crypto prices, calculate drift, recommend rebalance | Operational |
-| **garden-calendar** | Generate weekly garden brief based on date + weather | Operational |
-| **email-campaign** | Manage drip campaigns, follow-up sequences | Trusted |
-| **social-engagement** | Monitor and respond to social media interactions | Operational |
-| **security-monitor** | Track security advisories, vulnerability alerts | Operational |
-| **drive-watcher** | Watch shared drives for new/changed documents | Operational |
-| **invoice-generator** | Generate and track invoices for client engagements | Trusted |
-| **meeting-transcriber** | Transcribe and summarize meeting recordings | Operational |
+| Agent | What it does | Schedule | Maturity |
+|---|---|---|---|
+| **bd-pipeline** | Scan for BD signals, enrich leads, draft outreach, update CRM | Weekdays 8:00 AM | Trusted |
+| **proposal-engine** | Analyze RFQ/SOW, build quote structure, draft proposal | Manual | High-stakes |
+| **evidence-auditor** | Scan project for ISO 26262 work products, produce gap matrix | Mondays 9:00 AM | Trusted |
+| **contract-reviewer** | Analyze NDA/MSA clauses, produce sign/negotiate/escalate recommendation | Manual | High-stakes |
+| **staffing-monitor** | Calculate team utilization, forecast gaps, match skills to pipeline | Mondays 9:00 AM | Operational |
+| **content-engine** | Draft LinkedIn post for today's content pillar | Mon/Wed/Thu 7:00 AM | Operational |
+| **portfolio-monitor** | Check crypto prices, calculate drift, recommend rebalance | Daily 8 AM + 8 PM | Operational |
+| **garden-calendar** | Generate weekly garden brief based on date + weather | Mondays 7:00 AM | Operational |
+| **email-campaign** | Manage drip campaigns, follow-up sequences | Manual | Trusted |
+| **social-engagement** | Monitor and respond to social media interactions | Manual | Operational |
+| **security-monitor** | Track security advisories, vulnerability alerts | Manual | Operational |
+| **drive-watcher** | Watch shared drives for new/changed documents | Manual | Operational |
+| **invoice-generator** | Generate and track invoices for client engagements | Manual | Trusted |
+| **meeting-transcriber** | Transcribe and summarize meeting recordings | Manual | Operational |
 
 **Maturity levels:**
 - **High-stakes**: Every mutating action requires human approval
 - **Trusted**: Runs autonomously, outputs reviewed post-hoc
 - **Operational**: Runs on schedule, standard approval gates
 
-## Architecture
+## Packages
+
+43 TypeScript packages organized as an npm workspace monorepo.
+
+### Core & Framework
+
+| Package | Purpose |
+|---|---|
+| `jarvis-shared` | Base types, OpenClaw runtime foundation, gateway utilities |
+| `jarvis-core` | Policy engine: planning, approvals, model selection |
+| `jarvis-agent-framework` | Agent runtime, memory, knowledge, entity graph, lesson capture |
+| `jarvis-agents` | 14 agent definitions with system prompts and registry |
+| `jarvis-runtime` | Standalone daemon for autonomous agent execution |
+
+### Infrastructure
+
+| Package | Purpose |
+|---|---|
+| `jarvis-jobs` | Job queue: submission, claiming, callbacks, retries |
+| `jarvis-dispatch` | Cross-session messaging and follow-ups |
+| `jarvis-scheduler` | Cron scheduling and alert management |
+| `jarvis-supervisor` | Agent supervision and governance |
+| `jarvis-inference` | LLM inference coordination and model routing |
+| `jarvis-interpreter` | Code/prompt interpretation |
+| `jarvis-security` | Security policies and validation |
+| `jarvis-system` | System monitoring (CPU, memory, disk, processes) |
+| `jarvis-voice` | Voice I/O (Whisper STT, Piper TTS) |
+| `jarvis-device` | Device integration and notifications |
+
+### Plugins (Agent-Facing Interfaces)
+
+| Package | Purpose |
+|---|---|
+| `jarvis-agent-plugin` | Agent orchestration plugin |
+| `jarvis-email-plugin` | Email operations (Gmail) |
+| `jarvis-calendar-plugin` | Calendar operations |
+| `jarvis-crm-plugin` | CRM pipeline management |
+| `jarvis-web-plugin` | Web intelligence and scraping |
+| `jarvis-document-plugin` | Document analysis and compliance checking |
+
+### Workers (Async Job Processors)
+
+| Package | Purpose |
+|---|---|
+| `jarvis-agent-worker` | Agent execution |
+| `jarvis-email-worker` | Email sending/receiving |
+| `jarvis-calendar-worker` | Calendar sync |
+| `jarvis-crm-worker` | CRM operations |
+| `jarvis-web-worker` | Web scraping and search |
+| `jarvis-document-worker` | Document processing |
+| `jarvis-browser-worker` | Chrome automation |
+| `jarvis-office-worker` | Office document handling |
+| `jarvis-inference-worker` | LLM inference execution |
+| `jarvis-interpreter-worker` | Code/prompt execution |
+| `jarvis-security-worker` | Security checks |
+| `jarvis-system-worker` | System commands |
+| `jarvis-voice-worker` | Voice I/O processing |
+| `jarvis-social-worker` | Social media monitoring |
+| `jarvis-time-worker` | Time/timezone utilities |
+| `jarvis-drive-worker` | Google Drive monitoring |
+| `jarvis-desktop-host-worker` | Windows desktop automation |
+
+### Services
+
+| Package | Purpose |
+|---|---|
+| `jarvis-dashboard` | Web dashboard (React) at http://localhost:4242 |
+| `jarvis-telegram` | Telegram bot integration |
+| `jarvis-browser` | Chrome DevTools Protocol integration |
+| `jarvis-office` | Office (Word, Excel, PowerPoint) operations |
+| `jarvis-files` | File system operations |
+
+## Contract System
+
+All job types, tool responses, and worker callbacks conform to the `jarvis.v1` contract — a frozen JSON Schema specification.
+
+- **143 job types** across **22 families**: agent, browser, calendar, crm, device, document, drive, email, files, inference, interpreter, office, python, scheduler, scrape, search, security, social, system, time, voice, web
+- **Schema validation** via `npm run validate:contracts` — validates all schemas and 144 example payloads
+- **Contract files** live in `contracts/jarvis/v1/`
+
+### Job Lifecycle
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                    Jarvis Dashboard                      │
-│              http://localhost:4242                        │
-│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐          │
-│  │ CRM  │ │Agents│ │ Runs │ │Models│ │ Chat │          │
-│  └──────┘ └──────┘ └──────┘ └──────┘ └──────┘          │
-└─────────────────────┬───────────────────────────────────┘
-                      │ REST API
-┌─────────────────────┴───────────────────────────────────┐
-│                   Jarvis Daemon                          │
-│  ┌──────────┐ ┌───────────┐ ┌──────────┐               │
-│  │Scheduler │ │Orchestrator│ │  Queue   │               │
-│  └──────────┘ └───────────┘ └──────────┘               │
-│  ┌──────────────────────────────────────┐               │
-│  │  Multi-viewpoint Planner             │               │
-│  │  single │ critic │ multi             │               │
-│  └──────────────────────────────────────┘               │
-└──────────┬──────────────────┬───────────────────────────┘
-           │                  │
-    ┌──────┴──────┐    ┌──────┴──────┐
-    │ Ollama      │    │ LM Studio   │
-    │ localhost:  │    │ localhost:   │
-    │ 11434       │    │ 1234         │
-    └─────────────┘    └─────────────┘
-
-Data: ~/.jarvis/
-  ├── crm.db         CRM pipeline
-  ├── knowledge.db   Knowledge store + entities
-  ├── runtime.db     Control plane (runs, approvals, commands)
-  └── config.json    Configuration
+Agent calls tool -> submitJob(type, input)
+  -> Job queued in SQLite (status: queued)
+    -> Worker claims via POST /jarvis/jobs/claim (status: running)
+      -> Worker sends heartbeats to renew lease
+        -> Worker posts result to POST /jarvis/jobs/callback (status: completed|failed)
+          -> Agent notified via dispatch
 ```
+
+### Versioning Rules
+
+- Additive optional fields are allowed within v1
+- Breaking changes (field meaning, required fields, enum values, job types, tool names) require v2
+
+## Approval Rules
+
+High-stakes actions require human approval before execution. Of 143 job types:
+
+| Approval | Count | Examples |
+|---|---|---|
+| **Required** (always) | 17 | `email.send`, `device.click`, `device.type_text`, `python.run`, `security.lockdown`, `calendar.create_event` |
+| **Conditional** (policy-gated) | 33 | `crm.move_stage`, `document.generate_report`, `device.open_app`, `files.write` |
+| **Not required** (read-only) | 93 | `email.search`, `crm.list_pipeline`, `device.snapshot`, `system.cpu_usage` |
+
+Agents with `high_stakes_manual_gate` maturity require approval for **every** mutating action.
+
+## CRM Pipeline
+
+```
+prospect -> qualified -> contacted -> meeting -> proposal -> negotiation -> won | lost | parked
+```
+
+Stage transitions require approval (warning severity).
+
+## Dashboard
+
+Start the web dashboard:
+
+```bash
+npm run dashboard          # Production (http://localhost:4242)
+npm run dashboard:dev      # Development (API :4242, UI hot-reload :4243)
+```
+
+Pages: Home (agent cards), CRM Pipeline (kanban), Knowledge Base (search), Decisions (audit trail), Schedule (cron tasks).
+
+## Telegram Bot
+
+Get agent updates and approve actions from Telegram. See [docs/USAGE.md](docs/USAGE.md#telegram-bot-setup) for setup instructions.
+
+Available commands: `/status`, `/crm`, `/portfolio`, `/garden`, `/bd`, `/content`, `/approve <id>`, `/reject <id>`.
 
 ## CLI Reference
 
 ```bash
 # Getting Started
-jarvis setup              # Interactive setup wizard
-jarvis doctor             # Check system health
-jarvis doctor --fix       # Auto-fix what's possible
-jarvis config             # View configuration
+npm run jarvis setup          # Interactive setup wizard
+npm run jarvis -- doctor      # Check system health
+npm run jarvis -- doctor --fix  # Auto-fix what's possible
+npm run jarvis -- config      # View configuration
 
 # Running
-npm start                 # Start daemon + dashboard
-jarvis start              # Start daemon only
-jarvis dashboard          # Start dashboard only
-jarvis stop               # Stop daemon
-jarvis status             # Show daemon status
-jarvis logs               # Tail daemon logs
+npm start                     # Start daemon + dashboard
+npm run daemon                # Start daemon only
+npm run dashboard             # Start dashboard only
 
 # Operations
-jarvis backup             # Create backup bundle
-jarvis restore            # Restore from backup
-jarvis benchmark-models   # Benchmark local models
-jarvis health             # Ops health check
-jarvis migrate            # Run pending DB migrations
+npm run ops:health            # Ops health check
+npm run ops:backup            # Create backup bundle
+npm run ops:recover           # Restore from backup
 ```
 
 ## Configuration
@@ -144,19 +291,16 @@ Config lives at `~/.jarvis/config.json`. Use the setup wizard or edit directly:
 
 Environment variables override config file values. See `.env.example` for all options.
 
-## Approval Rules
+## Development
 
-High-stakes actions require human approval before execution:
-
-| Action | Severity | Gate |
-|---|---|---|
-| `email.send` | Critical | Always requires approval |
-| `publish_post` | Critical | Always requires approval |
-| `trade_execute` | Critical | Always requires approval |
-| `crm.move_stage` | Warning | Requires approval |
-| `document.generate_report` | Warning | Requires approval |
-
-Agents with `high_stakes_manual_gate` maturity require approval for **every** mutating action.
+```bash
+npm run check              # Full pipeline: contracts + tests + build
+npm test                   # Run tests (48 files, 1159 tests)
+npm run build              # TypeScript compilation
+npm run validate:contracts # Schema + example validation (143 job types)
+npm run dashboard:dev      # Dashboard dev mode (hot reload)
+npm run smoke:runtime      # OpenClaw + LM Studio integration smoke test
+```
 
 ## Docker
 
@@ -168,19 +312,9 @@ docker compose up -d
 # Make sure your model runtime is running before starting
 ```
 
-## Development
-
-```bash
-npm run check              # Full pipeline: contracts + tests + build
-npm test                   # Run tests (1019 tests)
-npm run build              # TypeScript compilation
-npm run dashboard:dev      # Dashboard dev mode (hot reload)
-npm run validate:contracts # Schema + example validation
-```
-
 ## Troubleshooting
 
-**"Jarvis cannot start — setup required"**
+**"Jarvis cannot start -- setup required"**
 Run `npm run jarvis setup` to initialize databases and config.
 
 **Dashboard shows "Not Built" page**
@@ -194,17 +328,43 @@ Check the dashboard approvals page, or use the Telegram bot to approve/reject.
 
 **Database corruption**
 ```bash
-jarvis backup              # Backup current state
-jarvis doctor --fix        # Attempt auto-repair
+npm run ops:backup         # Backup current state
+npm run jarvis -- doctor --fix  # Attempt auto-repair
 # If that fails:
 rm ~/.jarvis/runtime.db    # Delete and reinit
-jarvis setup
+npm run jarvis setup
 ```
 
 **Port 4242 already in use**
 Set `PORT=4243` in your `.env` file.
 
-For more help: `jarvis doctor`
+For more help: `npm run jarvis -- doctor`
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [USAGE.md](docs/USAGE.md) | Detailed agent usage with examples, Telegram setup, CRM guide |
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Five-plane architecture, database layout, execution model |
+| [PRODUCTION-TARGET.md](docs/PRODUCTION-TARGET.md) | Deployment model, trust boundaries, non-goals |
+| [RELEASE-GATES.md](docs/RELEASE-GATES.md) | Four release gates (A-D) with pass criteria |
+| [alpha-operating-guide.md](docs/alpha-operating-guide.md) | Daily workflow, failure taxonomy, metrics |
+
+### Specs
+
+| Spec | Description |
+|---|---|
+| [jarvis-plugin-api-v1.md](docs/specs/jarvis-plugin-api-v1.md) | Plugin SDK contract and tool registration |
+| [jarvis-device-agent-v1.md](docs/specs/jarvis-device-agent-v1.md) | Device control plugin specification |
+| [local-model-runtime-strategy.md](docs/specs/local-model-runtime-strategy.md) | LM Studio/Ollama integration and model selection |
+| [v1-workflows.md](docs/specs/v1-workflows.md) | Five production workflows |
+
+### Runbooks
+
+| Runbook | Description |
+|---|---|
+| [jarvis-recovery.md](docs/runbooks/jarvis-recovery.md) | Recovery procedures, backup/restore |
+| [openclaw-lmstudio-smoke.md](docs/runbooks/openclaw-lmstudio-smoke.md) | Integration smoke test harness |
 
 ## License
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -259,7 +259,7 @@ npm run telegram-bot
 - `/help` — Command list
 
 ### How push notifications work
-After each agent run, a digest is queued in the `notifications` table in `~/.jarvis/runtime.db`. The bot process sends it to your Telegram chat within 30 seconds.
+After each agent run, a digest is queued in the `notifications` table in `~/.jarvis/runtime.db`. The bot process sends it to your Telegram chat within 30 seconds. (Older skill files may still reference the deprecated `~/.jarvis/telegram-queue.json` path -- this is a legacy mechanism superseded by the DB-backed queue.)
 
 ### How approvals work via Telegram
 For scheduled agents (those running automatically at 8am etc.), when they hit an approval gate, the bot sends:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,8 +1,8 @@
 # Jarvis — Usage Guide
 
-Jarvis is an autonomous agent system for Thinking in Code. It runs 8 domain agents that handle BD pipeline intelligence, proposal generation, compliance auditing, contract review, staffing monitoring, LinkedIn content, crypto portfolio, and garden management.
+Jarvis is an autonomous agent system for Thinking in Code. It runs 14 domain agents that handle BD pipeline intelligence, proposal generation, compliance auditing, contract review, staffing monitoring, LinkedIn content, crypto portfolio, garden management, email campaigns, social engagement, security monitoring, drive watching, invoice generation, and meeting transcription.
 
-Claude Code is the runtime. Jarvis provides domain knowledge, state persistence (SQLite), and agent definitions (skill files).
+Claude Code is the interactive runtime. Jarvis provides domain knowledge, state persistence (SQLite), and agent definitions (skill files). For autonomous execution, Jarvis also runs as an OpenClaw plugin pack with a full job queue and worker pool.
 
 ---
 
@@ -26,7 +26,7 @@ npm install
 npx tsx scripts/init-jarvis.ts
 
 # 3. Verify everything works
-npm run check     # 769 tests, 0 errors
+npm run check     # 1159 tests, 0 errors
 
 # 4. Check system health
 /health           # (in Claude Code session)
@@ -259,7 +259,7 @@ npm run telegram-bot
 - `/help` — Command list
 
 ### How push notifications work
-After each agent run, a digest is queued in `~/.jarvis/telegram-queue.json`. The bot process sends it to your Telegram chat within 30 seconds.
+After each agent run, a digest is queued in the `notifications` table in `~/.jarvis/runtime.db`. The bot process sends it to your Telegram chat within 30 seconds.
 
 ### How approvals work via Telegram
 For scheduled agents (those running automatically at 8am etc.), when they hit an approval gate, the bot sends:


### PR DESCRIPTION
## Summary
- **README.md**: Full rewrite — added OpenClaw architecture, complete 43-package inventory, contract system (143 job types across 22 families), expanded approval rules (17/33/93 breakdown), agent schedules, dual execution model explanation, and documentation index linking all specs/runbooks
- **CLAUDE.md**: Added OpenClaw context, fixed stale counts (29→43 packages, 33→48 test files, 769→1159 tests), added missing runtime.db to database list, rewrote architecture section with both execution modes
- **docs/USAGE.md**: Fixed intro (8→14 agents), replaced deprecated telegram-queue.json reference with DB-backed notifications table, updated test count

## Test plan
- [x] `npm run check` passes (contracts + 1159 tests + build)
- [x] No code changes — documentation only
- [x] Cross-checked all numbers against actual codebase (package count, test count, job type count, approval counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)