### PR TITLE
Y2-Q2: Introduce multi-viewpoint planning with severity-aware disagreement

### DIFF
--- a/docs/quarters/y2-q2/migration-plan.md
+++ b/docs/quarters/y2-q2/migration-plan.md
@@ -1,0 +1,3 @@
+# Y2-Q2 Multi-Viewpoint Planning — Migration Plan
+
+No database migration. DisagreementPolicy is a runtime type. The orchestrator uses it at plan evaluation time.

--- a/docs/quarters/y2-q2/release-notes.md
+++ b/docs/quarters/y2-q2/release-notes.md
@@ -1,0 +1,25 @@
+# Y2-Q2 Multi-Viewpoint Planning — Release Notes
+
+## Summary
+
+Multi-viewpoint disagreement handling is now severity-aware. The orchestrator classifies disagreements as minor/moderate/severe and responds accordingly: minor logs and proceeds, moderate flags for review and proceeds, severe blocks execution and escalates to operator.
+
+## What Changed
+
+### DisagreementPolicy
+- New `DisagreementPolicy` type with configurable thresholds and severity response
+- Three presets: DEFAULT (severe blocks), MODERATE (flags for review), MINOR (log only)
+- `classifyDisagreement()` maps detection results to severity levels
+- Substantial disagreement (both action and step heuristics) always escalates as severe
+
+### Orchestrator
+- Emits `disagreement_classified` event with severity, reason, planner metadata
+- Severe: blocks execution, requests approval (existing behavior, now explicit)
+- Moderate: proceeds but sends review notification via Telegram
+- Minor: logs and proceeds silently
+
+### Backward Compatible
+No database migration. Existing multi-viewpoint behavior is preserved under DEFAULT policy.
+
+## Rollback
+Revert code. Disagreement handling reverts to pre-severity behavior (all disagreements block).

--- a/packages/jarvis-runtime/src/disagreement-policy.ts
+++ b/packages/jarvis-runtime/src/disagreement-policy.ts
@@ -1,0 +1,83 @@
+/**
+ * Disagreement policy: configures how the orchestrator responds to
+ * multi-viewpoint planner disagreements.
+ *
+ * Severity levels:
+ *   - minor: log and proceed with best plan (no operator involvement)
+ *   - moderate: flag in output, proceed but mark run for review
+ *   - severe: block execution, escalate to operator for approval
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type DisagreementSeverity = "minor" | "moderate" | "severe";
+
+export type DisagreementPolicy = {
+  /** Unique action threshold: fraction of actions unique to a single plan that triggers disagreement. Default: 0.3 */
+  action_threshold: number;
+  /** Step count ratio threshold: max/min ratio that triggers disagreement. Default: 1.5 */
+  step_ratio_threshold: number;
+  /** How to handle detected disagreement */
+  on_disagreement: DisagreementSeverity;
+  /** Timeout for approval wait (ms). Only used when on_disagreement is "severe". Default: 4h */
+  approval_timeout_ms: number;
+};
+
+// ─── Defaults ───────────────────────────────────────────────────────────────
+
+/** Default policy: severe disagreement blocks execution. */
+export const DEFAULT_DISAGREEMENT_POLICY: DisagreementPolicy = {
+  action_threshold: 0.3,
+  step_ratio_threshold: 1.5,
+  on_disagreement: "severe",
+  approval_timeout_ms: 4 * 60 * 60 * 1000, // 4 hours
+};
+
+/** Relaxed policy for less critical workflows: moderate disagreement flags but proceeds. */
+export const MODERATE_DISAGREEMENT_POLICY: DisagreementPolicy = {
+  action_threshold: 0.3,
+  step_ratio_threshold: 1.5,
+  on_disagreement: "moderate",
+  approval_timeout_ms: 4 * 60 * 60 * 1000,
+};
+
+/** Permissive policy: log disagreement but never block. */
+export const MINOR_DISAGREEMENT_POLICY: DisagreementPolicy = {
+  action_threshold: 0.3,
+  step_ratio_threshold: 1.5,
+  on_disagreement: "minor",
+  approval_timeout_ms: 0,
+};
+
+// ─── Resolution ─────────────────────────────────────────────────────────────
+
+/**
+ * Classify disagreement severity from detection result.
+ * Both heuristics firing = severe; action-only or step-only = moderate.
+ */
+export function classifyDisagreement(
+  detected: { disagreement: boolean; reason: string },
+  policy: DisagreementPolicy,
+): DisagreementSeverity {
+  if (!detected.disagreement) return "minor";
+
+  // Both structural and action disagreement = always severe
+  if (detected.reason.includes("substantially")) return "severe";
+
+  // Single-dimension disagreement = use policy setting
+  return policy.on_disagreement;
+}
+
+/**
+ * Determine whether a disagreement should block execution.
+ */
+export function shouldBlockExecution(severity: DisagreementSeverity): boolean {
+  return severity === "severe";
+}
+
+/**
+ * Determine whether a disagreement should flag the run for review.
+ */
+export function shouldFlagForReview(severity: DisagreementSeverity): boolean {
+  return severity === "moderate" || severity === "severe";
+}

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -32,3 +32,8 @@ export { getExecutionPolicy, WORKER_EXECUTION_POLICIES, type WorkerIsolation, ty
 export { validatePath, defaultFilesystemPolicy, loadFilesystemPolicy, type FilesystemPolicy, type PathValidationResult } from "./filesystem-policy.js";
 export { WorkerHealthMonitor, type WorkerHealthStatus, type WorkerHealthEntry } from "./worker-health.js";
 export { setWorkerHealthProvider } from "./health.js";
+export {
+  classifyDisagreement, shouldBlockExecution, shouldFlagForReview,
+  DEFAULT_DISAGREEMENT_POLICY, MODERATE_DISAGREEMENT_POLICY, MINOR_DISAGREEMENT_POLICY,
+  type DisagreementSeverity, type DisagreementPolicy,
+} from "./disagreement-policy.js";

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -11,6 +11,7 @@ import { buildEnvelope, type WorkerRegistry } from "./worker-registry.js";
 import { writeTelegramQueue } from "./notify.js";
 import { RunStore } from "./run-store.js";
 import { isReadOnlyAction } from "./action-classifier.js";
+import { classifyDisagreement, shouldBlockExecution, shouldFlagForReview, DEFAULT_DISAGREEMENT_POLICY } from "./disagreement-policy.js";
 import { isActionPermitted, type PluginPermission } from "./plugin-loader.js";
 import type { ChannelStore } from "./channel-store.js";
 import type { RagPipeline } from "./rag-pipeline.js";
@@ -126,10 +127,28 @@ export async function runAgent(
         },
       });
 
-      // Disagreement-aware escalation: if planners disagree substantially,
-      // request human approval before proceeding with the selected plan
-      if (result.disagreement.disagreement && runtimeDb) {
-        log.warn(`Planner disagreement: ${result.disagreement.reason}`);
+      // Disagreement-aware escalation with severity classification
+      const disagreementSeverity = classifyDisagreement(result.disagreement, DEFAULT_DISAGREEMENT_POLICY);
+
+      // Emit disagreement classification event for operator visibility
+      if (result.disagreement.disagreement) {
+        runStore?.emitEvent(run.run_id, agentId, "disagreement_classified", {
+          details: {
+            severity: disagreementSeverity,
+            reason: result.disagreement.reason,
+            unique_actions: result.disagreement.details.unique_actions,
+            step_count_range: result.disagreement.details.step_count_range,
+            planner_mode: plannerMode,
+            candidate_count: result.candidates.length,
+            selected_score: result.scores[0]?.total,
+            blocked: shouldBlockExecution(disagreementSeverity),
+            flagged_for_review: shouldFlagForReview(disagreementSeverity),
+          },
+        });
+      }
+
+      if (shouldBlockExecution(disagreementSeverity) && runtimeDb) {
+        log.warn(`Planner disagreement (${disagreementSeverity}): ${result.disagreement.reason}`);
         const approvalPayload = [
           `Multi-viewpoint planners disagreed: ${result.disagreement.reason}`,
           `Unique actions: ${result.disagreement.details.unique_actions.join(", ")}`,
@@ -190,6 +209,10 @@ export async function runAgent(
         run.status = "executing";
         run.updated_at = new Date().toISOString();
         log.info("Disagreement escalation approved — proceeding with selected plan");
+      } else if (shouldFlagForReview(disagreementSeverity)) {
+        // Moderate disagreement: proceed but flag for post-hoc review
+        log.info(`Planner disagreement (${disagreementSeverity}): flagged for review, proceeding`);
+        writeTelegramQueue(agentId, `[REVIEW] Planner disagreement (${disagreementSeverity}): ${result.disagreement.reason}. Run proceeding — review output.`, runtimeDb);
       }
     } else {
       // Default: single planner

--- a/tests/disagreement-policy.test.ts
+++ b/tests/disagreement-policy.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyDisagreement,
+  shouldBlockExecution,
+  shouldFlagForReview,
+  DEFAULT_DISAGREEMENT_POLICY,
+  MODERATE_DISAGREEMENT_POLICY,
+  MINOR_DISAGREEMENT_POLICY,
+  type DisagreementPolicy,
+} from "@jarvis/runtime";
+
+describe("classifyDisagreement", () => {
+  it("no disagreement returns 'minor'", () => {
+    const result = classifyDisagreement(
+      { disagreement: false, reason: "plans_agree" },
+      DEFAULT_DISAGREEMENT_POLICY,
+    );
+    expect(result).toBe("minor");
+  });
+
+  it("single-dimension disagreement (actions only) uses policy's on_disagreement setting", () => {
+    const policy: DisagreementPolicy = {
+      action_threshold: 0.3,
+      step_ratio_threshold: 1.5,
+      on_disagreement: "moderate",
+      approval_timeout_ms: 0,
+    };
+    const result = classifyDisagreement(
+      { disagreement: true, reason: "plans_use_different_actions" },
+      policy,
+    );
+    expect(result).toBe("moderate");
+  });
+
+  it("single-dimension disagreement (steps only) uses policy's on_disagreement setting", () => {
+    const policy: DisagreementPolicy = {
+      action_threshold: 0.3,
+      step_ratio_threshold: 1.5,
+      on_disagreement: "moderate",
+      approval_timeout_ms: 0,
+    };
+    const result = classifyDisagreement(
+      { disagreement: true, reason: "plans_differ_in_scope" },
+      policy,
+    );
+    expect(result).toBe("moderate");
+  });
+
+  it("substantial disagreement (both heuristics) always returns 'severe' regardless of policy", () => {
+    const result = classifyDisagreement(
+      { disagreement: true, reason: "plans_differ_substantially_in_structure_and_actions" },
+      MINOR_DISAGREEMENT_POLICY,
+    );
+    expect(result).toBe("severe");
+  });
+
+  it("with DEFAULT_DISAGREEMENT_POLICY: single-dimension returns 'severe'", () => {
+    const result = classifyDisagreement(
+      { disagreement: true, reason: "plans_use_different_actions" },
+      DEFAULT_DISAGREEMENT_POLICY,
+    );
+    expect(result).toBe("severe");
+  });
+
+  it("with MODERATE_DISAGREEMENT_POLICY: single-dimension returns 'moderate'", () => {
+    const result = classifyDisagreement(
+      { disagreement: true, reason: "plans_differ_in_scope" },
+      MODERATE_DISAGREEMENT_POLICY,
+    );
+    expect(result).toBe("moderate");
+  });
+
+  it("with MINOR_DISAGREEMENT_POLICY: single-dimension returns 'minor'", () => {
+    const result = classifyDisagreement(
+      { disagreement: true, reason: "plans_use_different_actions" },
+      MINOR_DISAGREEMENT_POLICY,
+    );
+    expect(result).toBe("minor");
+  });
+});
+
+describe("shouldBlockExecution", () => {
+  it("'severe' blocks execution", () => {
+    expect(shouldBlockExecution("severe")).toBe(true);
+  });
+
+  it("'moderate' does not block", () => {
+    expect(shouldBlockExecution("moderate")).toBe(false);
+  });
+
+  it("'minor' does not block", () => {
+    expect(shouldBlockExecution("minor")).toBe(false);
+  });
+});
+
+describe("shouldFlagForReview", () => {
+  it("'severe' flags for review", () => {
+    expect(shouldFlagForReview("severe")).toBe(true);
+  });
+
+  it("'moderate' flags for review", () => {
+    expect(shouldFlagForReview("moderate")).toBe(true);
+  });
+
+  it("'minor' does not flag", () => {
+    expect(shouldFlagForReview("minor")).toBe(false);
+  });
+});
+
+describe("policy defaults", () => {
+  it("DEFAULT_DISAGREEMENT_POLICY has on_disagreement: 'severe'", () => {
+    expect(DEFAULT_DISAGREEMENT_POLICY.on_disagreement).toBe("severe");
+  });
+
+  it("MODERATE_DISAGREEMENT_POLICY has on_disagreement: 'moderate'", () => {
+    expect(MODERATE_DISAGREEMENT_POLICY.on_disagreement).toBe("moderate");
+  });
+
+  it("MINOR_DISAGREEMENT_POLICY has on_disagreement: 'minor'", () => {
+    expect(MINOR_DISAGREEMENT_POLICY.on_disagreement).toBe("minor");
+  });
+
+  it("all policies have positive action_threshold and step_ratio_threshold", () => {
+    for (const policy of [
+      DEFAULT_DISAGREEMENT_POLICY,
+      MODERATE_DISAGREEMENT_POLICY,
+      MINOR_DISAGREEMENT_POLICY,
+    ]) {
+      expect(policy.action_threshold).toBeGreaterThan(0);
+      expect(policy.step_ratio_threshold).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Problem Statement
Multi-viewpoint planners detect disagreement but treat all disagreements the same way (block and escalate). Minor disagreements shouldn't block execution; only severe disagreements should escalate to the operator.

## Architectural Changes
- New `DisagreementPolicy` type: action_threshold, step_ratio_threshold, on_disagreement (minor/moderate/severe), approval_timeout_ms
- Three presets: DEFAULT (severe blocks), MODERATE (flags for review), MINOR (log only)
- `classifyDisagreement()` maps detection results to severity: substantial (both heuristics) = always severe; single-dimension = policy-configured
- Orchestrator emits `disagreement_classified` event with severity, planner metadata, blocking/flagging decisions
- Moderate severity: proceeds but sends Telegram review notification
- No database migration

## Acceptance Evidence
- 1326 tests pass (59 files), build clean, contracts valid
- 17 new tests for severity classification, blocking, flagging, and policy defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)