### PR TITLE
Y2-Q4: Enable small-team operating mode without becoming multi-tenant

### DIFF
--- a/docs/quarters/y2-q4/migration-plan.md
+++ b/docs/quarters/y2-q4/migration-plan.md
@@ -1,0 +1,18 @@
+# Y2-Q4 Small-Team Mode — Migration Plan
+
+## Migration 0006: Team Mode
+
+ALTER TABLE operations on existing tables:
+
+```sql
+ALTER TABLE runs ADD COLUMN owner TEXT;
+ALTER TABLE runs ADD COLUMN assignee TEXT;
+ALTER TABLE approvals ADD COLUMN assignee TEXT;
+ALTER TABLE approvals ADD COLUMN delegated_by TEXT;
+ALTER TABLE approvals ADD COLUMN delegation_note TEXT;
+```
+
+New columns are nullable — existing rows are unaffected.
+
+## Rollback
+SQLite ALTER TABLE ADD COLUMN cannot be reverted. To rollback, reinitialize databases via `npx tsx scripts/init-jarvis.ts` (destroys existing data).

--- a/docs/quarters/y2-q4/release-notes.md
+++ b/docs/quarters/y2-q4/release-notes.md
@@ -1,0 +1,25 @@
+# Y2-Q4 Small-Team Mode — Release Notes
+
+## Summary
+
+Jarvis now supports small-team operation. Runs track ownership (who initiated) and assignment (who is responsible). Approvals can be delegated to specific operators with audit trail. No multi-tenant abstractions — the architecture remains single-node.
+
+## What Changed
+
+### Migration 0006: Team Mode
+- `runs` table: added `owner` and `assignee` columns
+- `approvals` table: added `assignee`, `delegated_by`, `delegation_note` columns
+- Indexes on owner, assignee for efficient filtering
+
+### RunStore
+- `setRunOwner(runId, owner)`: set who initiated a run
+- `assignRun(runId, assignee)`: assign a run for review/action
+- `getRunsByUser(userId)`: get runs owned by or assigned to a user
+
+### Approval Delegation
+- `delegateApproval(db, approvalId, assignee, delegatedBy, note?)`: delegate a pending approval to another operator
+- `listApprovalsByAssignee(db, assignee)`: get approvals assigned to a specific user
+- Delegation recorded in audit_log with actor, target, and delegation note
+
+## Rollback
+Migration 0006 uses ALTER TABLE which cannot be rolled back in SQLite. To rollback, recreate tables from scratch via init-jarvis.ts.

--- a/packages/jarvis-runtime/src/approval-bridge.ts
+++ b/packages/jarvis-runtime/src/approval-bridge.ts
@@ -118,6 +118,53 @@ export function resolveApproval(
 }
 
 /**
+ * Delegate a pending approval to another operator.
+ * Records who delegated and why in the approvals table + audit log.
+ */
+export function delegateApproval(
+  db: DatabaseSync,
+  approvalId: string,
+  assignee: string,
+  delegatedBy: string,
+  note?: string,
+): boolean {
+  const now = new Date().toISOString();
+  try {
+    const result = db.prepare(`
+      UPDATE approvals SET assignee = ?, delegated_by = ?, delegation_note = ?
+      WHERE approval_id = ? AND status = 'pending'
+    `).run(assignee, delegatedBy, note ?? null, approvalId);
+
+    if ((result as { changes: number }).changes === 0) return false;
+
+    db.prepare(`
+      INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      randomUUID(), "user", delegatedBy, "approval.delegated",
+      "approval", approvalId,
+      JSON.stringify({ assignee, note }), now,
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List approvals assigned to a specific user.
+ */
+export function listApprovalsByAssignee(
+  db: DatabaseSync,
+  assignee: string,
+): ApprovalEntry[] {
+  return db.prepare(
+    "SELECT approval_id as id, agent_id as agent, action, payload_json as payload, requested_at as created_at, status, run_id, severity, resolved_at, resolved_by, resolution_note FROM approvals WHERE assignee = ? AND status = 'pending' ORDER BY requested_at DESC",
+  ).all(assignee) as ApprovalEntry[];
+}
+
+/**
  * List approvals, optionally filtered by status.
  */
 export function listApprovals(

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -9,7 +9,7 @@ export { buildPlanMultiViewpoint, type MultiPlanResult } from "./planner-multi.j
 export { scorePlan, rankPlans, detectDisagreement, type PlanScore } from "./plan-evaluator.js";
 export { runAgent, type OrchestratorDeps } from "./orchestrator.js";
 export { RunStore, type RunStatus, type RunEventType } from "./run-store.js";
-export { requestApproval, waitForApproval, resolveApproval, listApprovals, type ApprovalEntry } from "./approval-bridge.js";
+export { requestApproval, waitForApproval, resolveApproval, delegateApproval, listApprovals, listApprovalsByAssignee, type ApprovalEntry } from "./approval-bridge.js";
 export { writeTelegramQueue } from "./notify.js";
 export { createFilesWorkerBridge } from "./files-bridge.js";
 export { StatusWriter, type DaemonStatusData } from "./status-writer.js";

--- a/packages/jarvis-runtime/src/migrations/0006_team_mode.ts
+++ b/packages/jarvis-runtime/src/migrations/0006_team_mode.ts
@@ -1,0 +1,26 @@
+import type { Migration } from "./runner.js";
+
+export const migration0006: Migration = {
+  id: "0006",
+  name: "team_mode",
+  sql: `
+-- ============================================================
+-- Small-team mode: ownership and delegation for runs/approvals.
+-- Enables multiple trusted operators on a single Jarvis node.
+-- ============================================================
+
+-- Add owner and assignee to runs
+ALTER TABLE runs ADD COLUMN owner TEXT;
+ALTER TABLE runs ADD COLUMN assignee TEXT;
+
+-- Add assignee and delegated_by to approvals
+ALTER TABLE approvals ADD COLUMN assignee TEXT;
+ALTER TABLE approvals ADD COLUMN delegated_by TEXT;
+ALTER TABLE approvals ADD COLUMN delegation_note TEXT;
+
+-- Team activity timeline index
+CREATE INDEX IF NOT EXISTS idx_runs_owner ON runs(owner);
+CREATE INDEX IF NOT EXISTS idx_runs_assignee ON runs(assignee);
+CREATE INDEX IF NOT EXISTS idx_approvals_assignee ON approvals(assignee);
+`,
+};

--- a/packages/jarvis-runtime/src/migrations/runner.ts
+++ b/packages/jarvis-runtime/src/migrations/runner.ts
@@ -4,6 +4,7 @@ import { migration0002 } from "./0002_production_fixes.js";
 import { migration0003 } from "./0003_channel_persistence.js";
 import { migration0004 } from "./0004_channel_fixes.js";
 import { migration0005 } from "./0005_knowledge_links.js";
+import { migration0006 } from "./0006_team_mode.js";
 import { crmMigration0001 } from "./crm_0001_core.js";
 import { knowledgeMigration0001 } from "./knowledge_0001_core.js";
 
@@ -20,6 +21,7 @@ export const RUNTIME_MIGRATIONS: Migration[] = [
   migration0003,
   migration0004,
   migration0005,
+  migration0006,
 ];
 
 /** CRM DB migrations — contacts, notes, stages, campaigns. */

--- a/packages/jarvis-runtime/src/run-store.ts
+++ b/packages/jarvis-runtime/src/run-store.ts
@@ -40,7 +40,7 @@ export class RunStore {
   constructor(private db: DatabaseSync) {}
 
   /** Start a new run. Inserts into runs table and emits run_started event atomically. Returns run_id. */
-  startRun(agentId: string, triggerKind?: string, commandId?: string, goal?: string, runId?: string): string {
+  startRun(agentId: string, triggerKind?: string, commandId?: string, goal?: string, runId?: string, owner?: string): string {
     runId = runId ?? randomUUID();
     const now = new Date().toISOString();
 
@@ -138,6 +138,23 @@ export class RunStore {
     if (meta.total_steps !== undefined) {
       this.db.prepare("UPDATE runs SET total_steps = ? WHERE run_id = ?").run(meta.total_steps, runId);
     }
+  }
+
+  /** Set the owner of a run (who initiated it). */
+  setRunOwner(runId: string, owner: string): void {
+    this.db.prepare("UPDATE runs SET owner = ? WHERE run_id = ?").run(owner, runId);
+  }
+
+  /** Assign a run to a specific operator for review/action. */
+  assignRun(runId: string, assignee: string): void {
+    this.db.prepare("UPDATE runs SET assignee = ? WHERE run_id = ?").run(assignee, runId);
+  }
+
+  /** Get runs owned by or assigned to a specific user. */
+  getRunsByUser(userId: string, limit = 20): Array<Record<string, unknown>> {
+    return this.db.prepare(
+      "SELECT * FROM runs WHERE owner = ? OR assignee = ? ORDER BY started_at DESC LIMIT ?",
+    ).all(userId, userId, limit) as Array<Record<string, unknown>>;
   }
 
   /** Emit a run event without changing status (e.g., step_started within executing). */

--- a/tests/runtime-db.test.ts
+++ b/tests/runtime-db.test.ts
@@ -33,7 +33,7 @@ describe("Runtime DB and Migration Framework", () => {
     it("records applied migrations", () => {
       runMigrations(db);
       const rows = db.prepare("SELECT id, name FROM schema_migrations ORDER BY id").all() as Array<{ id: string; name: string }>;
-      expect(rows).toHaveLength(5);
+      expect(rows).toHaveLength(6);
       expect(rows[0]!.id).toBe("0001");
       expect(rows[0]!.name).toBe("runtime_core");
       expect(rows[1]!.id).toBe("0002");
@@ -44,13 +44,15 @@ describe("Runtime DB and Migration Framework", () => {
       expect(rows[3]!.name).toBe("channel_fixes");
       expect(rows[4]!.id).toBe("0005");
       expect(rows[4]!.name).toBe("knowledge_links");
+      expect(rows[5]!.id).toBe("0006");
+      expect(rows[5]!.name).toBe("team_mode");
     });
 
     it("is idempotent — repeated runs do not fail", () => {
       runMigrations(db);
       runMigrations(db);
       const rows = db.prepare("SELECT id FROM schema_migrations").all();
-      expect(rows).toHaveLength(5);
+      expect(rows).toHaveLength(6);
     });
   });
 

--- a/tests/smoke/appliance-readiness.test.ts
+++ b/tests/smoke/appliance-readiness.test.ts
@@ -259,7 +259,7 @@ describe("Migration completeness", () => {
     const migCount = (
       db.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number }
     ).n;
-    expect(migCount).toBe(5);
+    expect(migCount).toBe(6);
 
     db.close();
   });
@@ -272,7 +272,7 @@ describe("Migration completeness", () => {
       .all() as Array<{ id: string }>;
     const ids = rows.map((r) => r.id);
 
-    expect(ids).toEqual(["0001", "0002", "0003", "0004", "0005"]);
+    expect(ids).toEqual(["0001", "0002", "0003", "0004", "0005", "0006"]);
     db.close();
   });
 

--- a/tests/smoke/lifecycle.test.ts
+++ b/tests/smoke/lifecycle.test.ts
@@ -61,7 +61,7 @@ describe("Smoke: Database Lifecycle", () => {
     runMigrations(db); // second time
     runMigrations(db); // third time
     const rows = db.prepare("SELECT COUNT(*) as n FROM schema_migrations").get() as { n: number };
-    expect(rows.n).toBe(5);
+    expect(rows.n).toBe(6);
   });
 });
 


### PR DESCRIPTION
## Problem Statement
Jarvis operates as a single-operator appliance. Multiple trusted users cannot track who initiated or is responsible for runs, and approvals cannot be routed to specific operators.

## Architectural Changes
- Migration 0006: adds `owner`, `assignee` to runs; `assignee`, `delegated_by`, `delegation_note` to approvals
- RunStore: `setRunOwner()`, `assignRun()`, `getRunsByUser()` for ownership tracking
- Approval bridge: `delegateApproval()` with audit trail, `listApprovalsByAssignee()` for operator queues
- No multi-tenant abstractions — single-node model preserved

## Acceptance Evidence
- 1326 tests pass (59 files), build clean, contracts valid
- Migration applies cleanly (ALTER TABLE — nullable columns, no data migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)