### PR TITLE
Close permission leak, fix appliance token detection, durablize chat history

### DIFF
--- a/docs/ADR-CHAT-SURFACES.md
+++ b/docs/ADR-CHAT-SURFACES.md
@@ -1,0 +1,48 @@
+# ADR: Chat and Godmode Surface Architecture
+
+**Status**: Decided (April 2026)
+**Context**: Jarvis has two interactive chat surfaces beyond the runtime kernel: `/api/chat/telegram` and `/api/godmode`. This document records what they are, what they are not, and why they exist as separate surfaces.
+
+## Decision
+
+### /api/chat/telegram — Read-Only Copilot Surface
+
+**What it is**: A read-only copilot surface with its own LLM function-calling loop. It can search the web, read files (within project root), query CRM and knowledge DBs, search and read Gmail, and check agent status.
+
+**What it is NOT**: An execution surface. It cannot:
+- Trigger agents (removed: trigger_agent requires operator role via /slash commands)
+- Send or reply to emails (removed: must go through approval-backed job pipeline)
+- Write files or run commands (removed: direct privileged execution eliminated)
+- Modify CRM, knowledge, or any persistent state
+
+**Why it has its own LLM loop**: The Telegram relay needs native function calling (tool_calls) for interactive multi-turn Q&A with live data. The runtime kernel's orchestrator is designed for structured agent plans, not interactive chat. These are different interaction models.
+
+**Why this is acceptable**: Every tool in the function-calling loop is read-only and comes from tool-infra.ts. The surface cannot mutate state. Agent triggering requires explicit /slash commands through the Telegram command handler, which routes through createCommand() in the kernel.
+
+**What would make this better**: Replacing the separate LLM loop with a "read-only query agent" registered in the kernel, so all inference flows through one path. This is a future convergence target, not a current priority.
+
+### /api/godmode — Read-Only Research Surface
+
+**What it is**: An interactive research and artifact generation surface with its own LLM streaming loop. It classifies user intent (chat, research, artifact, code, cowork), selects surface-specific system prompts, and uses read-only tools from tool-infra.ts.
+
+**What it is NOT**: An execution surface. Same constraints as /api/chat/telegram — no mutations, no agent triggering, no file writing, no email sending.
+
+**Why it has its own LLM loop**: Godmode serves a different UX model than the kernel — multi-surface SSE streaming with artifact extraction, intent classification, and research synthesis. The kernel orchestrator is not designed for this interaction pattern.
+
+**Why this is acceptable**: Same as /api/chat/telegram — all tools are read-only, no mutations possible, documented clearly in the file header.
+
+**What would make this better**: Same convergence path — a "research agent" in the kernel with streaming support. Future work.
+
+## Consequences
+
+- Two chat surfaces exist alongside the runtime kernel. Both are read-only.
+- The kernel is the sole authority for mutations, approvals, and agent execution.
+- Chat surfaces are thin ingress adapters for interactive queries, not competing execution engines.
+- This is an explicit architectural compromise, not an oversight.
+
+## Review Trigger
+
+Revisit this decision when:
+- The kernel gains a streaming query interface suitable for interactive chat
+- A security audit identifies read-only tool access as insufficient isolation
+- The maintenance cost of two separate LLM loops exceeds the UX benefit

--- a/packages/jarvis-dashboard/src/api/chat.ts
+++ b/packages/jarvis-dashboard/src/api/chat.ts
@@ -377,15 +377,13 @@ const AGENT_TOOLS = [
       parameters: { type: 'object', properties: { query: { type: 'string', description: 'Search topic' }, collection: { type: 'string', description: 'Optional: lessons, playbooks, iso26262, contracts, proposals' } }, required: ['query'] }
     }
   },
+  // trigger_agent REMOVED from the chat surface. It inserts into agent_commands
+  // (a mutation) but chat POST is viewer-level for tokenless dev mode. Agent
+  // triggering must go through explicit Telegram /slash commands or the
+  // dashboard agents API (which requires operator role).
   {
     type: 'function' as const, function: {
-      name: 'trigger_agent', description: 'Trigger a Jarvis agent to run. Agents: bd-pipeline, proposal-engine, evidence-auditor, contract-reviewer, staffing-monitor, content-engine, portfolio-monitor, garden-calendar, email-campaign, social-engagement, security-monitor, drive-watcher, invoice-generator, meeting-transcriber',
-      parameters: { type: 'object', properties: { agent_id: { type: 'string', description: 'Agent ID to trigger' } }, required: ['agent_id'] }
-    }
-  },
-  {
-    type: 'function' as const, function: {
-      name: 'agent_status', description: 'Get status of all Jarvis agents (last run, pending approvals)',
+      name: 'agent_status', description: 'Get status of all Jarvis agents (last run, pending approvals). Read-only.',
       parameters: { type: 'object', properties: {} }
     }
   },
@@ -429,24 +427,9 @@ async function executeAgentTool(name: string, params: Record<string, unknown>): 
         return `Cannot read ${filePath}: ${e instanceof Error ? e.message : String(e)}`
       }
     }
-    case 'trigger_agent': {
-      const agentId = params.agent_id as string
-      try {
-        const { DatabaseSync } = await import('node:sqlite')
-        const { randomUUID } = await import('node:crypto')
-        const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'runtime.db'))
-        db.exec("PRAGMA journal_mode = WAL;")
-        db.exec("PRAGMA busy_timeout = 5000;")
-        const commandId = randomUUID()
-        db.prepare(`INSERT INTO agent_commands (command_id, command_type, target_agent_id, payload_json, status, priority, created_at, created_by, idempotency_key) VALUES (?, 'run_agent', ?, ?, 'queued', 0, ?, 'telegram', ?)`).run(
-          commandId, agentId, JSON.stringify({ triggered_by: 'telegram-agent' }), new Date().toISOString(), `telegram-${agentId}-${Date.now()}`
-        )
-        db.close()
-        return `Agent ${agentId} triggered successfully. It will run shortly.`
-      } catch (e) {
-        return `Failed to trigger ${agentId}: ${e instanceof Error ? e.message : String(e)}`
-      }
-    }
+    // trigger_agent handler removed — mutation not allowed from viewer-level chat.
+    case 'trigger_agent':
+      return 'Agent triggering is not available from the chat surface. Use Telegram /slash commands (e.g. /bd, /content) or the dashboard agents API.'
     case 'agent_status': {
       try {
         const { DatabaseSync } = await import('node:sqlite')
@@ -670,8 +653,8 @@ RULES:
 6. Today: ${new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
 
 You can SEARCH and READ emails (gmail_search, gmail_read) but CANNOT send emails from this surface.
-To send emails, trigger the email-campaign agent: use trigger_agent with agent_id "email-campaign".
-For other agent tasks, use trigger_agent with the appropriate agent ID.
+To send emails or trigger agents, use Telegram /slash commands (e.g. /bd, /content).
+This surface is read-only — it cannot trigger agents or send emails directly.
 
 CRM/Knowledge:
 ${context.slice(0, 1500)}`

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -48,9 +48,14 @@ const indexHtml = join(distPath, 'index.html')
   if (applianceMode) {
     console.log('  Appliance mode: enforcing secure defaults')
 
-    // Verify API tokens exist
-    const hasToken = !!process.env.JARVIS_API_TOKEN
-    if (!hasToken) {
+    // Verify API tokens exist — check both env var AND config file
+    const hasEnvToken = !!process.env.JARVIS_API_TOKEN
+    let hasConfigToken = false
+    try {
+      const cfgRaw = cfg as Record<string, unknown>
+      hasConfigToken = !!(cfgRaw.api_token || cfgRaw.api_tokens)
+    } catch { /* already loaded above */ }
+    if (!hasEnvToken && !hasConfigToken) {
       console.error('  FATAL: appliance_mode is enabled but no API token is configured.')
       console.error('  Set JARVIS_API_TOKEN env var or add api_token to ~/.jarvis/config.json.')
       process.exit(1)

--- a/packages/jarvis-telegram/src/chat-handler.ts
+++ b/packages/jarvis-telegram/src/chat-handler.ts
@@ -2,21 +2,15 @@ import http from 'node:http'
 import fs from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
+import type { ChannelStore } from '@jarvis/runtime'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 type ChatMessage = { role: string; content: string }
 
-// ─── Conversation History (per-session, thin layer) ─────────────────────────
-
-const conversationHistory: ChatMessage[] = []
-const MAX_HISTORY = 20
-
-function addToHistory(role: string, content: string) {
-  conversationHistory.push({ role, content })
-  while (conversationHistory.length > MAX_HISTORY) {
-    conversationHistory.shift()
-  }
+export type ChatContext = {
+  channelStore?: ChannelStore
+  threadId?: string
 }
 
 // ─── Jarvis API Relay ───────────────────────────────────────────────────────
@@ -44,6 +38,26 @@ function loadApiToken(): string | null {
     }
   } catch { /* no config */ }
   return null
+}
+
+/**
+ * Load recent conversation history from the channel store (thread-scoped,
+ * durable). Falls back gracefully to empty history if the store is unavailable.
+ */
+function loadThreadHistory(ctx?: ChatContext, limit = 20): ChatMessage[] {
+  if (!ctx?.channelStore || !ctx?.threadId) return []
+
+  try {
+    const messages = ctx.channelStore.getThreadMessages(ctx.threadId, limit)
+    return messages
+      .filter(m => m.content_preview && m.direction)
+      .map(m => ({
+        role: m.direction === 'inbound' ? 'user' : 'assistant',
+        content: m.content_preview!,
+      }))
+  } catch {
+    return []
+  }
 }
 
 function callJarvisApi(message: string, history: ChatMessage[]): Promise<string> {
@@ -103,17 +117,15 @@ function callJarvisApi(message: string, history: ChatMessage[]): Promise<string>
 /**
  * Handle free-text messages from Telegram.
  *
- * This is a relay layer — it sends the message plus recent conversation
- * history to the dashboard API and returns the response. No action-tag
- * parsing, no agent triggering from model output. All agent triggers
- * must come via explicit /slash commands.
+ * Conversation history is loaded from the channel store (thread-scoped,
+ * durable across restarts). No process-global in-memory state.
+ * No action-tag parsing, no agent triggering from model output.
+ * All agent triggers must come via explicit /slash commands.
  */
-export async function handleFreeText(userMessage: string): Promise<{ text: string }> {
-  addToHistory('user', userMessage)
+export async function handleFreeText(userMessage: string, ctx?: ChatContext): Promise<{ text: string }> {
+  // Load prior turns from the durable channel store, not process memory
+  const history = loadThreadHistory(ctx)
 
-  // Pass prior turns so the LLM has multi-turn context
-  const response = await callJarvisApi(userMessage, conversationHistory.slice(0, -1))
-
-  addToHistory('assistant', response)
+  const response = await callJarvisApi(userMessage, history)
   return { text: response }
 }

--- a/packages/jarvis-telegram/src/commands.ts
+++ b/packages/jarvis-telegram/src/commands.ts
@@ -2,7 +2,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { createCommand, ChannelStore } from '@jarvis/runtime'
 import { CRM_DB, openRuntimeDb } from './config.js'
 import { loadApprovals, resolveApproval } from './approvals.js'
-import { handleFreeText } from './chat-handler.js'
+import { handleFreeText, type ChatContext } from './chat-handler.js'
 
 const AGENTS = [
   'bd-pipeline', 'proposal-engine', 'evidence-auditor', 'contract-reviewer',
@@ -40,9 +40,13 @@ export async function handleCommand(text: string, ctx?: CommandContext): Promise
     }
   }
 
-  // Free-text — relay through Jarvis API (pure pass-through, no action parsing).
+  // Free-text — relay through Jarvis API with thread-scoped durable history.
   // All agent triggers must come via explicit /slash commands, not from LLM output.
-  const { text: reply } = await handleFreeText(text)
+  const chatCtx: ChatContext = {
+    channelStore: ctx?.channelStore,
+    threadId: ctx?.threadId,
+  }
+  const { text: reply } = await handleFreeText(text, chatCtx)
   return reply
 }
 


### PR DESCRIPTION
## Summary

Fixes the 5 remaining architectural issues identified in the final review pass.

- **Permission leak closed**: `trigger_agent` removed from viewer-level `/api/chat` surface — it was a mutation (inserts into `agent_commands`) reachable without operator tokens. Agent triggering now requires explicit Telegram `/slash` commands or the dashboard agents API.
- **Appliance token detection fixed**: Startup now checks both `JARVIS_API_TOKEN` env var AND `~/.jarvis/config.json` tokens. Previously only checked env, causing false startup failures.
- **Chat history durablized**: Telegram conversation history loaded from `ChannelStore` (thread-scoped, durable in runtime.db) instead of a process-global in-memory array. Survives restarts, scoped per thread.
- **ADR documented**: `docs/ADR-CHAT-SURFACES.md` records the explicit architectural decision that `/api/chat/telegram` and `/api/godmode` are read-only copilot surfaces, not competing execution engines. Documents why, what would make it better, and when to revisit.

## Test plan

- [x] `npm run check` passes (143 contracts, 62 test files, 1411 tests)
- [ ] Manual: verify chat no longer offers trigger_agent tool
- [ ] Manual: verify appliance mode accepts config-file tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)