### PR TITLE
Fix CI: missing vitest aliases + rate limiter proxy trust

### DIFF
--- a/packages/jarvis-dashboard/src/api/middleware/auth.ts
+++ b/packages/jarvis-dashboard/src/api/middleware/auth.ts
@@ -173,9 +173,16 @@ setInterval(() => {
   }
 }, PRUNE_INTERVAL_MS).unref();
 
+/**
+ * Get client IP for rate limiting. Only trusts X-Forwarded-For when
+ * JARVIS_TRUST_PROXY is set (i.e. behind a known reverse proxy).
+ * Otherwise uses the socket address directly to prevent spoofing.
+ */
 function getClientIp(req: Request): string {
-  const forwarded = req.headers["x-forwarded-for"];
-  if (typeof forwarded === "string") return forwarded.split(",")[0].trim();
+  if (process.env.JARVIS_TRUST_PROXY === "true") {
+    const forwarded = req.headers["x-forwarded-for"];
+    if (typeof forwarded === "string") return forwarded.split(",")[0]!.trim();
+  }
   return req.socket.remoteAddress ?? "unknown";
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,6 +44,8 @@ export default defineConfig({
       "@jarvis/office-worker": `${rootDir}packages/jarvis-office-worker/src/index.ts`,
       "@jarvis/browser-worker": `${rootDir}packages/jarvis-browser-worker/src/index.ts`,
       "@jarvis/social-worker": `${rootDir}packages/jarvis-social-worker/src/index.ts`,
+      "@jarvis/time-worker": `${rootDir}packages/jarvis-time-worker/src/index.ts`,
+      "@jarvis/drive-worker": `${rootDir}packages/jarvis-drive-worker/src/index.ts`,
       "@jarvis/runtime": `${rootDir}packages/jarvis-runtime/src/index.ts`
     }
   },


### PR DESCRIPTION
## Summary

Fixes CI failures from PRs #70/#71 and addresses the remaining PR #70 review comment.

- **CI fix**: Added missing `@jarvis/time-worker` and `@jarvis/drive-worker` aliases to `vitest.config.ts`. These workers were added in PR #70 but their vitest aliases were missed, causing `Failed to resolve entry for package` errors on CI (26 test files failing).
- **Review fix**: Rate limiter no longer trusts `X-Forwarded-For` by default. Only trusted when `JARVIS_TRUST_PROXY=true` is set. Prevents brute-force evasion via header spoofing on direct connections.
- PR #70 comment 1 (appliance token detection) was already fixed in PR #71.

## Test plan

- [x] `npm run check` passes (143 contracts, 62 test files, 1411 tests)
- [x] Vitest can resolve @jarvis/time-worker and @jarvis/drive-worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)