### PR TITLE
150-item hardening: config schema, tool registry, plugin checksums, retention, tests, docs

### DIFF
--- a/.claude/skills/bd-pipeline.md
+++ b/.claude/skills/bd-pipeline.md
@@ -77,3 +77,10 @@ Note: In practice, construct the `summary` variable from the actual output of pr
 ## Approval Gates
 - **Sending any email: ASK THE USER FIRST.** Present the draft and wait for explicit "yes" before using gmail_send.
 - **Moving CRM stage: Flag for review** before executing.
+
+### Source Attribution
+When presenting results, always note which data sources were consulted:
+- CRM data: note the query and result count
+- Knowledge base: note which collections were searched
+- Web sources: include URLs of consulted pages
+- Email: note the search query used

--- a/.claude/skills/contract-reviewer.md
+++ b/.claude/skills/contract-reviewer.md
@@ -92,3 +92,10 @@ Note: In practice, construct the `summary` variable from the actual output of pr
 - **NEVER auto-approve.** Always present analysis for human review.
 - This is business analysis, not legal advice. State this clearly.
 - Flag any clause that could expose TIC to unlimited financial risk.
+
+### Source Attribution
+When presenting results, always note which data sources were consulted:
+- CRM data: note the query and result count
+- Knowledge base: note which collections were searched
+- Web sources: include URLs of consulted pages
+- Email: note the search query used

--- a/.claude/skills/evidence-auditor.md
+++ b/.claude/skills/evidence-auditor.md
@@ -85,3 +85,10 @@ Note: In practice, construct the `summary` variable from the actual output of pr
 
 ## No Approval Gates
 This agent is read-only analysis. No emails, no modifications.
+
+### Source Attribution
+When presenting results, always note which data sources were consulted:
+- CRM data: note the query and result count
+- Knowledge base: note which collections were searched
+- Web sources: include URLs of consulted pages
+- Email: note the search query used

--- a/.claude/skills/proposal-engine.md
+++ b/.claude/skills/proposal-engine.md
@@ -81,3 +81,10 @@ Note: In practice, construct the `summary` variable from the actual output of pr
 ## Approval Gates
 - **Sending email: ASK USER FIRST**
 - **Generating final document: Flag for review** before producing
+
+### Source Attribution
+When presenting results, always note which data sources were consulted:
+- CRM data: note the query and result count
+- Knowledge base: note which collections were searched
+- Web sources: include URLs of consulted pages
+- Email: note the search query used

--- a/.claude/skills/staffing-monitor.md
+++ b/.claude/skills/staffing-monitor.md
@@ -68,3 +68,10 @@ Note: In practice, construct the `summary` variable from the actual output of pr
 ## Approval Gates
 - **Drafting staffing emails: ASK USER before sending**
 - Staffing reassignment: recommend only, never execute
+
+### Source Attribution
+When presenting results, always note which data sources were consulted:
+- CRM data: note the query and result count
+- Knowledge base: note which collections were searched
+- Web sources: include URLs of consulted pages
+- Email: note the search query used

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Build Dashboard
         run: npm run dashboard:build
 
+      - name: Verify copilot surface safety
+        run: |
+          # Ensure no mutation tools are exposed in chat surfaces
+          ! grep -n "name: 'run_command'" packages/jarvis-dashboard/src/api/chat.ts
+          ! grep -n "name: 'write_file'" packages/jarvis-dashboard/src/api/chat.ts
+          ! grep -n "name: 'gmail_send'" packages/jarvis-dashboard/src/api/chat.ts
+          echo "Copilot surface safety check passed"
+
       - name: Audit dependencies
         run: npm audit --audit-level=high
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -105,32 +105,32 @@ The dashboard also provides two read-only copilot surfaces (`/api/chat/telegram`
 
 ### Core (production workflows)
 
-| Agent | What it does | Schedule | Maturity |
-|---|---|---|---|
-| **bd-pipeline** | Scan for BD signals, enrich leads, draft outreach, update CRM | Weekdays 8:00 AM | Trusted |
-| **proposal-engine** | Analyze RFQ/SOW, build quote structure, draft proposal | Manual | High-stakes |
-| **evidence-auditor** | Scan project for ISO 26262 work products, produce gap matrix | Mondays 9:00 AM | Trusted |
-| **contract-reviewer** | Analyze NDA/MSA clauses, produce sign/negotiate/escalate recommendation | Manual | High-stakes |
-| **staffing-monitor** | Calculate team utilization, forecast gaps, match skills to pipeline | Mondays 9:00 AM | Operational |
+| Agent | What it does | Schedule | Tier | Maturity |
+|---|---|---|---|---|
+| **bd-pipeline** | Scan for BD signals, enrich leads, draft outreach, update CRM | Weekdays 8:00 AM | Core | Trusted |
+| **proposal-engine** | Analyze RFQ/SOW, build quote structure, draft proposal | Manual | Core | High-stakes |
+| **evidence-auditor** | Scan project for ISO 26262 work products, produce gap matrix | Mondays 9:00 AM | Core | Trusted |
+| **contract-reviewer** | Analyze NDA/MSA clauses, produce sign/negotiate/escalate recommendation | Manual | Core | High-stakes |
+| **staffing-monitor** | Calculate team utilization, forecast gaps, match skills to pipeline | Mondays 9:00 AM | Core | Operational |
 
 ### Extended
 
-| Agent | What it does | Schedule | Maturity |
-|---|---|---|---|
-| **content-engine** | Draft LinkedIn post for today's content pillar | Mon/Wed/Thu 7:00 AM | Operational |
-| **email-campaign** | Manage drip campaigns, follow-up sequences | Manual | Trusted |
-| **invoice-generator** | Generate and track invoices for client engagements | Manual | Trusted |
-| **meeting-transcriber** | Transcribe and summarize meeting recordings | Manual | Operational |
+| Agent | What it does | Schedule | Tier | Maturity |
+|---|---|---|---|---|
+| **content-engine** | Draft LinkedIn post for today's content pillar | Mon/Wed/Thu 7:00 AM | Extended | Operational |
+| **email-campaign** | Manage drip campaigns, follow-up sequences | Manual | Extended | Trusted |
+| **invoice-generator** | Generate and track invoices for client engagements | Manual | Extended | Trusted |
+| **meeting-transcriber** | Transcribe and summarize meeting recordings | Manual | Extended | Operational |
 
 ### Personal / Experimental
 
-| Agent | What it does | Schedule | Tier |
-|---|---|---|---|
-| **portfolio-monitor** | Check crypto prices, calculate drift, recommend rebalance | Daily 8 AM + 8 PM | Personal |
-| **garden-calendar** | Generate weekly garden brief based on date + weather | Mondays 7:00 AM | Personal |
-| **social-engagement** | Monitor and respond to social media interactions | Weekdays 8:30 AM + 6 PM | Experimental |
-| **security-monitor** | Track security advisories, vulnerability alerts | Daily 3:00 AM | Experimental |
-| **drive-watcher** | Watch shared drives for new/changed documents | Every 5 minutes | Experimental |
+| Agent | What it does | Schedule | Tier | Maturity |
+|---|---|---|---|---|
+| **portfolio-monitor** | Check crypto prices, calculate drift, recommend rebalance | Daily 8 AM + 8 PM | Personal | Operational |
+| **garden-calendar** | Generate weekly garden brief based on date + weather | Mondays 7:00 AM | Personal | Operational |
+| **social-engagement** | Monitor and respond to social media interactions | Weekdays 8:30 AM + 6 PM | Experimental | Experimental |
+| **security-monitor** | Track security advisories, vulnerability alerts | Daily 3:00 AM | Experimental | Experimental |
+| **drive-watcher** | Watch shared drives for new/changed documents | Every 5 minutes | Experimental | Experimental |
 
 **Maturity levels:**
 - **High-stakes**: Every mutating action requires human approval
@@ -383,6 +383,10 @@ For more help: `npm run jarvis -- doctor`
 | [KNOWN-TRUST-GAPS.md](docs/KNOWN-TRUST-GAPS.md) | Honest list of what's not yet enforced |
 | [ADR-CHAT-SURFACES.md](docs/ADR-CHAT-SURFACES.md) | Why chat/godmode have separate LLM loops |
 | [OPERATOR-RUNBOOK.md](docs/OPERATOR-RUNBOOK.md) | Secure installation, daily ops, failure recovery |
+| [GLOSSARY.md](docs/GLOSSARY.md) | Canonical vocabulary (agent, plugin, worker, job, run, etc.) |
+| [WHAT-JARVIS-IS-NOT.md](docs/WHAT-JARVIS-IS-NOT.md) | Explicit non-goals and boundaries |
+| [LIFECYCLE-DIAGRAMS.md](docs/LIFECYCLE-DIAGRAMS.md) | Mermaid state machines for runs, approvals, jobs |
+| [ARCHITECTURE-STATUS.md](docs/ARCHITECTURE-STATUS.md) | Target design vs shipped implementation comparison |
 | [alpha-operating-guide.md](docs/alpha-operating-guide.md) | Daily workflow, failure taxonomy, metrics |
 
 ### Specs

--- a/docs/ARCHITECTURE-STATUS.md
+++ b/docs/ARCHITECTURE-STATUS.md
@@ -1,0 +1,33 @@
+# Architecture Status
+
+Honest comparison of the target design versus what has actually shipped. Updated each quarter.
+
+Last updated: 2026-04-08
+
+## Status Key
+
+- **Shipped** -- target design is fully implemented
+- **Partial** -- core capability shipped with documented exceptions
+- **Gap** -- target design is not yet implemented
+
+## Comparison
+
+| Capability | Target Design | Shipped Implementation | Status |
+|---|---|---|---|
+| **Runtime kernel as sole authority** | All state mutations flow through the runtime kernel. No surface can bypass the kernel to mutate state. | Shipped. Chat and Telegram are read-only ingress. `trigger_agent` removed from chat surfaces. Copilot surfaces (`/api/chat`, `/api/godmode`) have their own LLM loops but cannot mutate state. Documented in [ADR-CHAT-SURFACES.md](ADR-CHAT-SURFACES.md). | Partial |
+| **Durable state in runtime.db** | All control-plane state (runs, approvals, jobs, heartbeats, model registry, agent memory) persists in SQLite. No in-memory-only state. | Shipped. `SqliteMemoryStore`, `RunStore`, `ChannelStore` all write to `runtime.db`. Daemon restart loses no state. | Shipped |
+| **Approval-backed mutations** | Every high-stakes action requires explicit human approval before execution. No side-door execution paths. | Shipped. 17 always-require, 33 conditional, 93 exempt. `trigger_agent` removed from chat surfaces. All mutating actions flow through the job queue with approval checks. | Shipped |
+| **Worker process isolation** | Workers run in isolated processes with independent failure domains. A crashing worker cannot corrupt the daemon or other workers. | Cooperative isolation with timeouts. Child-process workers (browser, interpreter, files, device, voice, security, social) have process boundaries. In-process workers share the Node.js event loop. Documented in [KNOWN-TRUST-GAPS.md](KNOWN-TRUST-GAPS.md). | Partial |
+| **Full channel provenance** | Every artifact delivered to a channel includes complete provenance: source run, generating job, timestamps, and full content for exact replay. | Preview provenance shipped (source run, job type, timestamps). Full content storage is optional -- large artifacts store a summary plus a link to the full output. Exact replay not guaranteed for all artifact types. | Partial |
+| **Single inference path** | All LLM inference routes through the runtime kernel's model router. One place to audit, rate-limit, and log all model calls. | Copilot surfaces (`/api/chat/telegram`, `/api/godmode`) maintain their own LLM loops for interactive queries. These are read-only and cannot trigger mutations, but their inference calls do not flow through the kernel's model router. Documented in [ADR-CHAT-SURFACES.md](ADR-CHAT-SURFACES.md). | Partial |
+| **Encrypted credentials** | Sensitive credentials (API tokens, webhook secrets, integration keys) stored encrypted at rest. Decrypted only in memory during use. | Not shipped. Credentials stored in plaintext in `~/.jarvis/config.json`. File permissions are the only protection. Encryption at rest is a planned improvement. | Gap |
+
+## Summary
+
+| Status | Count |
+|---|---|
+| Shipped | 2 |
+| Partial | 4 |
+| Gap | 1 |
+
+The two fully shipped capabilities (durable state and approval-backed mutations) are the most critical for operational safety. The four partial items have documented exceptions with ADRs or trust-gap entries explaining the rationale. The one gap (encrypted credentials) is a known risk mitigated by filesystem permissions and localhost-only binding.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,43 @@
+# Glossary
+
+Canonical vocabulary for the Jarvis system. Every document and code comment should use these terms consistently.
+
+## Core Concepts
+
+**Agent** -- A named autonomous workflow (e.g., `bd-pipeline`) with a system prompt, capabilities, approval gates, and schedule. Agents define *what* to do; plugins and workers handle *how*. Each agent belongs to a product tier and has a maturity level that governs its approval policy.
+
+**Plugin** -- An OpenClaw extension that registers tools and commands for agents (e.g., `@jarvis/email-plugin`). Plugins expose the agent-facing interface; they translate tool calls into job submissions. There are 19 Jarvis plugins registered with the gateway.
+
+**Worker** -- An async job processor that executes a specific job family (e.g., `@jarvis/email-worker`). Workers claim jobs from the queue via HTTP, execute them, send heartbeats to renew their lease, and return results via callback. Workers run either in-process or as child processes.
+
+**Tool** -- A function agents call via the plugin SDK; returns structured results (e.g., `email_search`). Tools are the agent-visible surface of a plugin. Each tool call produces a deterministic job spec submitted to the job queue.
+
+**Job** -- A queued unit of work with a type, input payload, and expected output (e.g., `email.send`). Jobs are the atomic unit of execution. There are 143 defined job types across 23 schema families.
+
+**Run** -- A single execution of an agent, tracked from planning through completion. Runs progress through a state machine (queued, planning, executing, awaiting_approval, completed, failed, cancelled) and emit events to the `run_events` table for audit.
+
+**Command** -- An operator instruction to start an agent run, stored in the `agent_commands` table. Commands flow from channels (Telegram, dashboard, CLI) into the runtime kernel, which creates a run.
+
+**Approval** -- A human-gated decision point for high-stakes actions. Approvals are created in `pending` state and transition to `approved`, `rejected`, `expired`, or `cancelled`. Of 143 job types, 17 always require approval and 33 are conditionally gated.
+
+## Outputs and Delivery
+
+**Artifact** -- An output produced by a run (report, draft, analysis, gap matrix) delivered to the operator via one or more channels. Artifacts are the tangible result of agent work.
+
+**Channel** -- A communication surface through which operators interact with Jarvis: Telegram, dashboard, email, or webhook. Each channel has its own delivery characteristics and authentication model.
+
+**Thread** -- A conversation context within a channel (e.g., a Telegram chat, a dashboard session). Threads allow multi-turn interaction and contextual follow-ups within a single channel.
+
+## Wire Format
+
+**Envelope** -- A job's wire format conforming to the `jarvis.v1` contract. Contains the job type, input payload, metadata (attempt number, correlation ID, timestamps), and schema version. Validated against `job-envelope.schema.json`.
+
+## Classification
+
+**Product Tier** -- Agent classification reflecting its operational domain: `core` (production consulting workflows), `extended` (supporting business functions), `personal` (operator personal tasks), or `experimental` (under development).
+
+**Maturity** -- Agent execution policy governing approval strictness: `high_stakes_manual_gate` (every mutation needs approval), `trusted_with_review` (runs autonomously, outputs reviewed), `operational` (standard approval gates), or `experimental` (limited trust, monitoring required).
+
+## Security
+
+**Appliance Mode** -- Strict security posture activated by setting `appliance_mode: true` in config or `JARVIS_MODE=production`. Requires API tokens, enforces webhook secrets, binds to localhost only, and blocks startup if security prerequisites are missing.

--- a/docs/LIFECYCLE-DIAGRAMS.md
+++ b/docs/LIFECYCLE-DIAGRAMS.md
@@ -1,0 +1,101 @@
+# Lifecycle Diagrams
+
+Visual state machines for core Jarvis concepts. All diagrams use [Mermaid](https://mermaid.js.org/) syntax.
+
+## Run State Machine
+
+A run is a single execution of an agent, from creation to terminal state.
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued : command received
+    queued --> planning : scheduler picks up
+    planning --> executing : plan approved / no gate
+    planning --> awaiting_approval : plan requires approval
+    awaiting_approval --> executing : operator approves
+    awaiting_approval --> cancelled : operator rejects
+    awaiting_approval --> failed : approval expires
+    executing --> completed : all jobs succeed
+    executing --> failed : unrecoverable error
+    executing --> awaiting_approval : mid-run approval needed
+    executing --> cancelled : operator cancels
+    completed --> [*]
+    failed --> [*]
+    cancelled --> [*]
+```
+
+**Terminal states**: `completed`, `failed`, `cancelled`. All run state transitions are recorded in the `run_events` table for audit.
+
+## High-Stakes Action Lifecycle
+
+End-to-end flow from operator request through artifact delivery.
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant Channel as Channel (Telegram / Dashboard)
+    participant Kernel as Runtime Kernel
+    participant Agent
+    participant Queue as Job Queue
+    participant Worker
+    participant Delivery as Channel Delivery
+
+    Operator->>Channel: /bd-pipeline (command)
+    Channel->>Kernel: command record
+    Kernel->>Agent: create run (queued)
+    Agent->>Agent: planning phase
+    Agent->>Queue: submitJob(email.send, payload)
+    Queue->>Kernel: approval required
+    Kernel->>Channel: approval request
+    Channel->>Operator: "Approve email send to X?"
+    Operator->>Channel: /approve <id>
+    Channel->>Kernel: approval granted
+    Kernel->>Queue: release job
+    Queue->>Worker: POST /jarvis/jobs/claim
+    Worker->>Worker: execute job
+    Worker->>Queue: POST /jarvis/jobs/callback (result)
+    Queue->>Agent: job completed
+    Agent->>Delivery: artifact (report, draft)
+    Delivery->>Operator: result via channel
+```
+
+## Approval Flow
+
+State machine for a single approval decision.
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending : approval created
+    pending --> approved : operator approves
+    pending --> rejected : operator rejects
+    pending --> expired : TTL exceeded
+    pending --> cancelled : run cancelled
+    approved --> [*]
+    rejected --> [*]
+    expired --> [*]
+    cancelled --> [*]
+```
+
+**Rules**:
+- Approvals in `pending` state block the associated job from executing.
+- Stale approvals do not auto-approve; they remain pending until explicitly resolved or expired.
+- 17 job types always create approvals. 33 create approvals conditionally based on agent maturity and policy.
+- Operators can resolve approvals via the dashboard API or Telegram bot (`/approve`, `/reject`).
+
+## Job Lifecycle
+
+State machine for a single job in the queue.
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued : submitJob()
+    queued --> running : worker claims via POST /claim
+    running --> running : heartbeat renews lease
+    running --> completed : worker posts success callback
+    running --> failed : worker posts failure callback
+    running --> queued : lease expires (no heartbeat)
+    completed --> [*]
+    failed --> [*]
+```
+
+**Lease model**: Workers must send heartbeats to maintain their claim. If a worker crashes without sending a failure callback, the lease expires and the job returns to `queued` for another worker to claim.

--- a/docs/LOCAL-TLS-GUIDE.md
+++ b/docs/LOCAL-TLS-GUIDE.md
@@ -1,0 +1,80 @@
+# Local TLS Guide
+
+## Why
+
+By default the Jarvis dashboard API serves plain HTTP.  When accessed only
+from `localhost` (the default `bind_host`) this is fine -- traffic never
+leaves the machine.  However, if you bind the dashboard to `0.0.0.0` or a
+LAN address so other machines can reach it, credentials and session tokens
+transit in plaintext over the network.  A TLS reverse proxy in front of the
+dashboard fixes this.
+
+## When needed
+
+- You access the dashboard from **another machine** on your LAN.
+- You expose the dashboard through a tunnel (ngrok, Tailscale Funnel, etc.).
+
+If you only access the dashboard on `http://localhost:3100` (the default),
+you do **not** need TLS.
+
+## Option A: nginx with a self-signed certificate
+
+Generate a self-signed cert (valid 365 days):
+
+```bash
+mkdir -p ~/.jarvis/tls
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout ~/.jarvis/tls/key.pem \
+  -out    ~/.jarvis/tls/cert.pem \
+  -days 365 -subj "/CN=jarvis.local"
+```
+
+Minimal nginx config (`/etc/nginx/sites-enabled/jarvis`):
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name jarvis.local;
+
+    ssl_certificate     /home/YOU/.jarvis/tls/cert.pem;
+    ssl_certificate_key /home/YOU/.jarvis/tls/key.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3100;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Set `trust_proxy: true` in `~/.jarvis/config.json` so the dashboard
+reads `X-Forwarded-*` headers correctly.
+
+## Option B: Caddy (automatic self-signed)
+
+Install Caddy, then create a `Caddyfile`:
+
+```caddyfile
+jarvis.local {
+    reverse_proxy 127.0.0.1:3100
+    tls internal
+}
+```
+
+Run:
+
+```bash
+caddy run
+```
+
+Caddy generates and trusts a local CA automatically.  Set `trust_proxy: true`
+in config.json as above.
+
+## Notes
+
+- Both options keep the dashboard itself on `127.0.0.1:3100` -- only the
+  reverse proxy listens on the LAN interface.
+- Browsers will warn about self-signed certs.  Import `cert.pem` (nginx) or
+  Caddy's root CA into your trust store to suppress warnings.
+- For production deployments, use a proper CA (Let's Encrypt via Caddy, etc.).

--- a/docs/OPERATOR-RUNBOOK.md
+++ b/docs/OPERATOR-RUNBOOK.md
@@ -65,6 +65,18 @@ If no backup exists, re-initialize with `npx tsx scripts/init-jarvis.ts` (this r
 
 **Recovery**: Worker crashes do not kill the daemon. Check logs for the failing worker. Child-process workers (browser, interpreter, files, device, voice, security, social) restart automatically. In-process workers require a daemon restart if they corrupt shared state.
 
+## Why Each Surface Exists
+
+Jarvis exposes four operator-facing surfaces. Each exists for a specific reason and has distinct capabilities.
+
+**Dashboard** (http://localhost:4242) -- Primary operator interface with full visibility. Shows agent run history, pending approvals, CRM pipeline, knowledge base, decision audit trail, and scheduled tasks. Supports all read and write operations (approve, reject, trigger runs). This is the canonical interface for daily operation.
+
+**Telegram** -- Mobile-friendly surface for approval handling and quick status checks. Operators receive approval requests as push notifications and can resolve them with `/approve <id>` or `/reject <id>` without opening a browser. Also supports status queries (`/status`, `/crm`, `/portfolio`, `/garden`, `/bd`, `/content`). Telegram is a channel, not a control plane -- it forwards commands to the runtime kernel.
+
+**Chat** (`/api/chat`) -- Read-only copilot surface for interactive data queries. Has its own LLM loop (not routed through the runtime kernel's model router) so it can answer ad-hoc questions about CRM state, run history, and knowledge base content. Cannot mutate state or trigger agent runs. The architectural decision to give it a separate LLM loop is documented in [ADR-CHAT-SURFACES.md](ADR-CHAT-SURFACES.md).
+
+**Godmode** (`/api/godmode`) -- Read-only research surface for deep investigation. Like Chat, it has its own LLM loop and cannot mutate state. Designed for complex multi-step analysis queries (e.g., cross-referencing CRM pipeline with evidence audit gaps). The separate LLM loop allows it to use different model parameters optimized for long-context reasoning. Documented in [ADR-CHAT-SURFACES.md](ADR-CHAT-SURFACES.md).
+
 ## Key Endpoints
 
 | Endpoint | Auth | Purpose |

--- a/docs/WHAT-JARVIS-IS-NOT.md
+++ b/docs/WHAT-JARVIS-IS-NOT.md
@@ -1,0 +1,31 @@
+# What Jarvis Is Not
+
+Explicit non-goals and boundaries. Understanding what Jarvis does not do is as important as understanding what it does.
+
+## Not a Multi-Tenant SaaS
+
+Jarvis is a single-operator appliance. There is one operator (Daniel), one set of credentials, one SQLite database cluster. There are no user accounts, no tenant isolation, no subscription billing. It is designed for a team of one running a consulting firm, not for resale.
+
+## Not a Cloud-First Platform
+
+Jarvis is local-first. LLM inference runs on local hardware via Ollama or LM Studio. State lives in SQLite files on disk at `~/.jarvis/`. The dashboard binds to localhost. There is no cloud deployment target, no managed infrastructure, no serverless functions. It can run on a single machine with no internet connection (aside from the APIs it integrates with).
+
+## Not a General-Purpose AI Assistant
+
+Jarvis is domain-focused for automotive safety consulting (ISO 26262, ASPICE, AUTOSAR, cybersecurity). Its 14 agents are purpose-built for business development, compliance auditing, proposal generation, and related workflows. It is not a chatbot, not a coding assistant, and not a generic task manager.
+
+## Not a Replacement for Human Judgment
+
+High-stakes decisions are approval-gated. Jarvis will not send an email, publish a post, execute a trade, or move a CRM stage without human approval. Of 143 job types, 17 always require approval and 33 are conditionally gated. The system is designed to surface recommendations, not to act unilaterally on consequential actions.
+
+## Not a Distributed System
+
+Jarvis runs on a single node. State is in SQLite, not Postgres or a distributed database. There is no clustering, no replication, no leader election. The job queue is a table in `runtime.db`, not Kafka or RabbitMQ. This is a deliberate simplicity choice -- a single-operator appliance does not need distributed systems complexity.
+
+## Not a Real-Time System
+
+Jarvis is polling-based and asynchronous. Agents run on cron schedules or on demand. The job queue is polled, not pushed. Workers claim jobs via HTTP request, not via persistent connections. Latency is measured in seconds to minutes, not milliseconds. There is no streaming, no WebSocket push to the dashboard (it polls the REST API).
+
+## Not Fully Process-Isolated
+
+Workers run cooperatively, not in hard-isolated containers. In-process workers share the Node.js event loop with the daemon. Child-process workers (browser, interpreter, files, device, voice, security, social) have process boundaries but share the filesystem. This is a documented trust gap (see [KNOWN-TRUST-GAPS.md](KNOWN-TRUST-GAPS.md)) -- a misbehaving worker can affect the daemon. Hard isolation via containers is a future target, not a shipped capability.

--- a/docs/WORKFLOW-INTAKE.md
+++ b/docs/WORKFLOW-INTAKE.md
@@ -1,0 +1,112 @@
+# Workflow Intake Forms
+
+Canonical intake forms for the five core Jarvis agent workflows.
+Fill out the relevant form before invoking the agent to ensure all required context is provided.
+
+---
+
+## 1. RFQ / Proposal Intake (proposal-engine)
+
+| Field | Required | Description |
+|---|---|---|
+| Client name | Yes | Full legal entity name |
+| Company | Yes | Parent company if different from client |
+| Contact email | Yes | Primary point of contact |
+| RFQ/SOW document path | Yes | Local file path or URL to the RFQ/SOW document |
+| Service areas | Yes | Check all that apply: ISO 26262, ASPICE, AUTOSAR, Cybersecurity (ISO 21434) |
+| ASIL level | If known | A, B, C, or D |
+| Deadline | Yes | Proposal submission deadline (YYYY-MM-DD) |
+| Budget range | If known | Estimated budget or rate expectations |
+| Competition known | No | Other vendors known to be bidding |
+| Prior relationship | No | Any previous TIC engagement with this client |
+| Special requirements | No | Tool mandates, language, on-site needs, security clearance |
+
+**Minimum viable intake:** Client name, document path, service areas, deadline.
+
+---
+
+## 2. Contract Review Intake (contract-reviewer)
+
+| Field | Required | Description |
+|---|---|---|
+| Document type | Yes | NDA, MSA, SOW amendment, subcontract, framework agreement |
+| Document path | Yes | Local file path to the contract document (PDF or DOCX) |
+| Counterparty name | Yes | Legal entity name of the other party |
+| Jurisdiction | If known | Governing law stated or expected |
+| Key concerns | No | Specific clauses to scrutinize: IP, non-compete, liability, payment terms, indemnity |
+| Urgency level | Yes | Standard (5 business days), Urgent (48h), Critical (same day) |
+| Related contracts | No | Paths to existing MSA or prior agreements with the same counterparty |
+| Internal notes | No | Context from Daniel or project lead about negotiation posture |
+
+**Minimum viable intake:** Document type, document path, counterparty name, urgency level.
+
+---
+
+## 3. Evidence Audit Intake (evidence-auditor)
+
+| Field | Required | Description |
+|---|---|---|
+| Project name | Yes | Internal project identifier |
+| ASIL level | Yes | A, B, C, or D |
+| Evidence directory path | Yes | Root directory containing work products |
+| Target standard | Yes | ISO 26262 (specify Part: 3, 4, 6, 8) or ASPICE (specify SWE processes) |
+| Scope | Yes | Full audit, delta from last audit, specific phase only |
+| Last audit date | If delta | Date of previous audit for delta comparison |
+| Deliverable format | No | Gap matrix only, full report, or gate-readiness summary |
+| Deadline | Yes | When the audit results are needed (YYYY-MM-DD) |
+| Stakeholders | No | Who receives the audit output (names or roles) |
+
+**Minimum viable intake:** Project name, ASIL level, evidence directory path, target standard, scope.
+
+---
+
+## 4. BD Pipeline Intake (bd-pipeline)
+
+| Field | Required | Description |
+|---|---|---|
+| Signal source | Yes | LinkedIn, referral, RFQ portal, conference, inbound email, job board |
+| Company name | Yes | Target company |
+| Industry segment | No | Powertrain, ADAS, chassis, body electronics, EV, general automotive |
+| Company size | No | Approximate headcount or tier classification (OEM, Tier-1, Tier-2) |
+| Contact name | If known | Name of the person to reach |
+| Contact role | If known | Job title |
+| Contact email | If known | Email address |
+| Opportunity description | Yes | What triggered this lead and what TIC could offer |
+| Estimated value range | No | Expected engagement size (EUR) |
+| Urgency | No | Time-sensitive signal (active RFQ, hiring freeze ending, etc.) |
+| CRM status | No | New lead, or existing contact with known stage |
+
+**Minimum viable intake:** Signal source, company name, opportunity description.
+
+---
+
+## 5. Staffing Review Intake (staffing-monitor)
+
+| Field | Required | Description |
+|---|---|---|
+| Review period | Yes | Current month, next quarter, or custom date range |
+| Active projects to include | No | List specific project names, or "all" (default) |
+| Pipeline items to factor in | No | BD pipeline leads likely to convert within the review period |
+| Specific skill gaps to investigate | No | AUTOSAR, ISO 26262, cybersecurity, timing, ASPICE |
+| Hiring constraints | No | Budget limits, geographic restrictions, clearance requirements |
+| Bench tolerance | No | Acceptable bench percentage before escalation (default: 15%) |
+| Output format | No | Executive summary only, full breakdown, or comparison to prior period |
+
+**Minimum viable intake:** Review period.
+
+---
+
+## Usage
+
+Invoke the corresponding agent with the intake fields as context:
+
+```
+/proposal-engine
+Client: Bertrandt AG
+Document: ~/Documents/RFQs/bertrandt-asild-bsw-2026.pdf
+Service areas: AUTOSAR, ISO 26262
+ASIL: D
+Deadline: 2026-04-25
+```
+
+Agents will prompt for any missing required fields before proceeding.

--- a/packages/jarvis-agent-framework/src/schema.ts
+++ b/packages/jarvis-agent-framework/src/schema.ts
@@ -105,4 +105,8 @@ export type AgentDefinition = {
   experimental?: boolean;
   /** Product tier: core, extended, personal, or experimental. See {@link ProductTier}. */
   product_tier?: ProductTier;
+  /** Target turnaround time in hours for this agent's runs. */
+  turnaround_target_hours?: number;
+  /** Whether operator review is required after every run. */
+  review_required?: boolean;
 };

--- a/packages/jarvis-agents/src/definitions/bd-pipeline.ts
+++ b/packages/jarvis-agents/src/definitions/bd-pipeline.ts
@@ -79,4 +79,6 @@ export const bdPipelineAgent: AgentDefinition = {
   maturity: "trusted_with_review",
   pack: "core",
   product_tier: "core",
+  turnaround_target_hours: 2,
+  review_required: false,
 };

--- a/packages/jarvis-agents/src/definitions/contract-reviewer.ts
+++ b/packages/jarvis-agents/src/definitions/contract-reviewer.ts
@@ -86,4 +86,6 @@ export const contractReviewerAgent: AgentDefinition = {
   maturity: "high_stakes_manual_gate",
   pack: "core",
   product_tier: "core",
+  turnaround_target_hours: 1,
+  review_required: true,
 };

--- a/packages/jarvis-agents/src/definitions/evidence-auditor.ts
+++ b/packages/jarvis-agents/src/definitions/evidence-auditor.ts
@@ -83,4 +83,6 @@ export const evidenceAuditorAgent: AgentDefinition = {
   maturity: "trusted_with_review",
   pack: "core",
   product_tier: "core",
+  turnaround_target_hours: 4,
+  review_required: true,
 };

--- a/packages/jarvis-agents/src/definitions/proposal-engine.ts
+++ b/packages/jarvis-agents/src/definitions/proposal-engine.ts
@@ -64,4 +64,6 @@ export const proposalEngineAgent: AgentDefinition = {
   maturity: "high_stakes_manual_gate",
   pack: "core",
   product_tier: "core",
+  turnaround_target_hours: 24,
+  review_required: true,
 };

--- a/packages/jarvis-agents/src/definitions/staffing-monitor.ts
+++ b/packages/jarvis-agents/src/definitions/staffing-monitor.ts
@@ -73,4 +73,6 @@ export const staffingMonitorAgent: AgentDefinition = {
   maturity: "operational",
   pack: "core",
   product_tier: "core",
+  turnaround_target_hours: 2,
+  review_required: false,
 };

--- a/packages/jarvis-dashboard/src/api/chat.ts
+++ b/packages/jarvis-dashboard/src/api/chat.ts
@@ -10,6 +10,10 @@ import {
   executeTool,
   extractToolCalls,
   buildContext,
+  loadGmailConfig,
+  getGmailAccessToken,
+  httpsPost,
+  httpsGet,
   type FetchUrlOptions,
 } from './tool-infra.js'
 
@@ -56,57 +60,6 @@ function chatExecuteTool(name: string, params: Record<string, unknown>): Promise
     fetch: CHAT_FETCH_OPTS,
     webSearch: { handler: googleNewsSearch },
   })
-}
-
-// ─── Gmail Helper ────────────────────────────────────────────────────────────
-
-function loadGmailConfig(): { client_id: string; client_secret: string; refresh_token: string } | null {
-  try {
-    const raw = JSON.parse(fs.readFileSync(join(os.homedir(), '.jarvis', 'config.json'), 'utf8'))
-    return raw.gmail ?? null
-  } catch { return null }
-}
-
-function httpsPost(url: string, body: string, headers: Record<string, string> = {}): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const parsed = new URL(url)
-    const req = https.request({
-      hostname: parsed.hostname, port: 443, path: parsed.pathname + parsed.search,
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': Buffer.byteLength(body), ...headers }
-    }, (res) => {
-      let data = ''
-      res.on('data', (c: Buffer) => data += c.toString())
-      res.on('end', () => resolve(data))
-      res.on('error', reject)
-    })
-    req.on('error', reject)
-    req.setTimeout(15000, () => { req.destroy(); reject(new Error('timeout')) })
-    req.write(body)
-    req.end()
-  })
-}
-
-function httpsGet(url: string, headers: Record<string, string> = {}): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const parsed = new URL(url)
-    const req = https.get({ hostname: parsed.hostname, port: 443, path: parsed.pathname + parsed.search, headers }, (res) => {
-      let data = ''
-      res.on('data', (c: Buffer) => data += c.toString())
-      res.on('end', () => resolve(data))
-      res.on('error', reject)
-    })
-    req.on('error', reject)
-    req.setTimeout(15000, () => { req.destroy(); reject(new Error('timeout')) })
-  })
-}
-
-async function getGmailAccessToken(): Promise<string | null> {
-  const cfg = loadGmailConfig()
-  if (!cfg) return null
-  const body = `client_id=${cfg.client_id}&client_secret=${cfg.client_secret}&refresh_token=${cfg.refresh_token}&grant_type=refresh_token`
-  const resp = JSON.parse(await httpsPost('https://oauth2.googleapis.com/token', body))
-  return resp.access_token ?? null
 }
 
 // ─── Tool Definitions ─────────────────────────────────────────────────────────
@@ -333,6 +286,7 @@ function streamToClient(res: import('express').Response, messages: Array<{ role:
 }
 
 // ─── Tool Definitions for Function Calling ───────────────────────────────────
+// Tool list must be a subset of READONLY_TOOL_NAMES from tool-infra.ts
 
 const AGENT_TOOLS = [
   {

--- a/packages/jarvis-dashboard/src/api/godmode.ts
+++ b/packages/jarvis-dashboard/src/api/godmode.ts
@@ -41,10 +41,17 @@ import {
   executeTool,
   extractToolCalls,
   buildContext,
+  isReadOnlyTool,
 } from './tool-infra.js'
 
 const LMS_URL = process.env.LMS_URL ?? 'http://localhost:1234'
 const DEFAULT_MODEL = process.env.LMS_MODEL ?? 'qwen/qwen3.5-35b-a3b'
+
+// Verify godmode tools are a subset of the shared registry
+const GODMODE_TOOLS = ["web_search", "web_fetch", "crm_search", "knowledge_search", "system_info", "file_read", "file_list"];
+for (const t of GODMODE_TOOLS) {
+  if (!isReadOnlyTool(t)) throw new Error(`Godmode tool "${t}" is not in the read-only registry`);
+}
 
 // ─── Intent Classification ───────────────────────────────────────────────────
 

--- a/packages/jarvis-dashboard/src/api/tool-infra.ts
+++ b/packages/jarvis-dashboard/src/api/tool-infra.ts
@@ -18,6 +18,50 @@ import os from 'os'
 import fs, { realpathSync } from 'fs'
 import { join, resolve, relative } from 'path'
 
+// ─── Read-Only Tool Registry ──────────────────────────────────────────────────
+
+/** Single source of truth for read-only tools available to copilot surfaces. */
+export const READONLY_TOOL_NAMES = [
+  "web_search", "web_fetch", "crm_search", "knowledge_search",
+  "system_info", "list_files", "file_read", "file_list",
+  "gmail_search", "gmail_read", "agent_status", "browse_page",
+] as const;
+
+export type ReadOnlyToolName = (typeof READONLY_TOOL_NAMES)[number];
+
+/** Check if a tool name is in the read-only registry. */
+export function isReadOnlyTool(name: string): name is ReadOnlyToolName {
+  return (READONLY_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+// ─── Tool Sensitivity Classification ──────────────────────────────────────────
+
+/** Tools that access potentially sensitive content (email, files). */
+export const SENSITIVE_READ_TOOLS = new Set(["gmail_search", "gmail_read", "file_read", "browse_page"]);
+/** Tools that only access public or system data. */
+export const SAFE_READ_TOOLS = new Set(["web_search", "web_fetch", "crm_search", "knowledge_search", "system_info", "list_files", "file_list", "agent_status"]);
+
+// ─── Prompt Sanitization ──────────────────────────────────────────────────────
+
+/** Strip content that could be interpreted as instructions by the LLM. */
+export function sanitizeForPrompt(text: string): string {
+  return text
+    // Remove script/style content
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    // Remove HTML tags
+    .replace(/<[^>]+>/g, ' ')
+    // Decode entities
+    .replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    // Remove common prompt injection patterns
+    .replace(/\[SYSTEM\][\s\S]*?\[\/SYSTEM\]/gi, '[content removed]')
+    .replace(/\[INST\][\s\S]*?\[\/INST\]/gi, '[content removed]')
+    .replace(/<\|im_start\|>[\s\S]*?<\|im_end\|>/gi, '[content removed]')
+    // Collapse whitespace
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // ─── Project Root ──────────────────────────────────────────────────────────────
 
 /** Project root for file_read/file_list tools. Configurable via env or config. */
@@ -181,7 +225,7 @@ export async function executeTool(
           }
         }
         if (results.length === 0) {
-          const textContent = html.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+          const textContent = sanitizeForPrompt(html)
           return `Search results for "${query}":\n${textContent.slice(0, 2000)}`
         }
         return `Search results for "${query}":\n\n${results.join('\n\n')}`
@@ -195,14 +239,11 @@ export async function executeTool(
       if (!url) return 'Error: url is required'
       try {
         const html = await fetch(url)
-        const text = html
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<style[\s\S]*?<\/style>/gi, '')
+        // Strip nav/footer before general sanitization
+        const stripped = html
           .replace(/<nav[\s\S]*?<\/nav>/gi, '')
           .replace(/<footer[\s\S]*?<\/footer>/gi, '')
-          .replace(/<[^>]+>/g, ' ')
-          .replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
-          .replace(/\s+/g, ' ').trim()
+        const text = sanitizeForPrompt(stripped)
         return `Content from ${url}:\n\n${text.slice(0, 4000)}`
       } catch (e) {
         return `Fetch failed: ${e instanceof Error ? e.message : String(e)}`
@@ -336,4 +377,55 @@ export async function executeTool(
     default:
       return `Unknown tool: ${name}`
   }
+}
+
+// ─── Gmail Helpers ────────────────────────────────────────────────────────────
+
+export function loadGmailConfig(): { client_id: string; client_secret: string; refresh_token: string } | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(join(os.homedir(), '.jarvis', 'config.json'), 'utf8'))
+    return raw.gmail ?? null
+  } catch { return null }
+}
+
+export function httpsPost(url: string, body: string, headers: Record<string, string> = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const req = https.request({
+      hostname: parsed.hostname, port: 443, path: parsed.pathname + parsed.search,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Content-Length': Buffer.byteLength(body), ...headers }
+    }, (res) => {
+      let data = ''
+      res.on('data', (c: Buffer) => data += c.toString())
+      res.on('end', () => resolve(data))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('timeout')) })
+    req.write(body)
+    req.end()
+  })
+}
+
+export function httpsGet(url: string, headers: Record<string, string> = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const req = https.get({ hostname: parsed.hostname, port: 443, path: parsed.pathname + parsed.search, headers }, (res) => {
+      let data = ''
+      res.on('data', (c: Buffer) => data += c.toString())
+      res.on('end', () => resolve(data))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.setTimeout(15000, () => { req.destroy(); reject(new Error('timeout')) })
+  })
+}
+
+export async function getGmailAccessToken(): Promise<string | null> {
+  const cfg = loadGmailConfig()
+  if (!cfg) return null
+  const body = `client_id=${cfg.client_id}&client_secret=${cfg.client_secret}&refresh_token=${cfg.refresh_token}&grant_type=refresh_token`
+  const resp = JSON.parse(await httpsPost('https://oauth2.googleapis.com/token', body))
+  return resp.access_token ?? null
 }

--- a/packages/jarvis-runtime/src/channel-store.ts
+++ b/packages/jarvis-runtime/src/channel-store.ts
@@ -325,6 +325,23 @@ export class ChannelStore {
     return entries;
   }
 
+  // ─── Retention ──────────────────────────────────────────────────────────
+
+  /**
+   * NULL out content_full for messages older than maxAgeDays. Keeps the
+   * message row and content_preview for thread-continuity queries.
+   * Returns the number of messages archived (0 if column doesn't exist yet).
+   */
+  archiveOldContent(maxAgeDays = 30): number {
+    const cutoff = new Date(Date.now() - maxAgeDays * 86400000).toISOString();
+    try {
+      const result = this.db.prepare(
+        "UPDATE channel_messages SET content_full = NULL WHERE created_at < ? AND content_full IS NOT NULL"
+      ).run(cutoff);
+      return (result as { changes: number }).changes;
+    } catch { return 0; }
+  }
+
   // ─── Thread status (#43) ──────────────────────────────────────────────
 
   /** Update the status of a thread (active, resolved, archived). */

--- a/packages/jarvis-runtime/src/config.ts
+++ b/packages/jarvis-runtime/src/config.ts
@@ -45,6 +45,11 @@ const ConfigSchema = Type.Object({
   webhook_secret: Type.Optional(Type.String()),
   anthropic_api_key: Type.Optional(Type.String()),
   appliance_mode: Type.Boolean(),
+  api_token: Type.Optional(Type.String()),
+  api_tokens: Type.Optional(Type.Record(Type.String(), Type.String())),
+  mode: Type.Optional(Type.Union([Type.Literal("dev"), Type.Literal("production")])),
+  bind_host: Type.Optional(Type.String()),
+  trust_proxy: Type.Optional(Type.Boolean()),
 });
 
 export type JarvisRuntimeConfig = Static<typeof ConfigSchema>;
@@ -116,6 +121,9 @@ export function loadConfig(): JarvisRuntimeConfig {
     max_concurrent: 2,
     log_level: "info",
     appliance_mode: false,
+    mode: undefined,
+    bind_host: undefined,
+    trust_proxy: undefined,
   };
 
   const configPath = join(JARVIS_DIR, "config.json");
@@ -149,6 +157,11 @@ export function loadConfig(): JarvisRuntimeConfig {
     webhook_secret: typeof raw.webhook_secret === "string" ? raw.webhook_secret : undefined,
     anthropic_api_key: typeof raw.anthropic_api_key === "string" ? raw.anthropic_api_key : undefined,
     appliance_mode: typeof raw.appliance_mode === "boolean" ? raw.appliance_mode : defaults.appliance_mode,
+    api_token: typeof raw.api_token === "string" ? raw.api_token : undefined,
+    api_tokens: isStringRecord(raw.api_tokens) ? raw.api_tokens : undefined,
+    mode: raw.mode === "dev" || raw.mode === "production" ? raw.mode : defaults.mode,
+    bind_host: typeof raw.bind_host === "string" ? raw.bind_host : defaults.bind_host,
+    trust_proxy: typeof raw.trust_proxy === "boolean" ? raw.trust_proxy : defaults.trust_proxy,
   };
 
   // Environment overrides
@@ -169,6 +182,12 @@ export function loadConfig(): JarvisRuntimeConfig {
   }
   if (process.env.JARVIS_APPLIANCE_MODE === "true") {
     config.appliance_mode = true;
+  }
+  if (process.env.JARVIS_MODE === "dev" || process.env.JARVIS_MODE === "production") {
+    config.mode = process.env.JARVIS_MODE;
+  }
+  if (process.env.JARVIS_BIND_HOST) {
+    config.bind_host = process.env.JARVIS_BIND_HOST;
   }
 
   // Validate
@@ -236,4 +255,9 @@ export function getCredentialsForWorker(
 
 function isLogLevel(v: unknown): v is JarvisRuntimeConfig["log_level"] {
   return v === "debug" || v === "info" || v === "warn" || v === "error";
+}
+
+function isStringRecord(v: unknown): v is Record<string, string> {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  return Object.values(v).every(val => typeof val === "string");
 }

--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -400,6 +400,25 @@ async function main() {
       }
     }, 5 * 60 * 1000);
     activeIntervals.push(modelRediscoveryInterval);
+
+    // ─── Daily maintenance: compact old events, archive old content, vacuum ──
+    const maintenanceInterval = setInterval(() => {
+      try {
+        const runStore = new RunStore(runtimeDb);
+        const eventsCompacted = runStore.compactOldEvents(90);
+        if (eventsCompacted > 0) logger.info(`Maintenance: compacted ${eventsCompacted} old run events`);
+
+        const cs = new ChannelStore(runtimeDb);
+        const contentArchived = cs.archiveOldContent(30);
+        if (contentArchived > 0) logger.info(`Maintenance: archived ${contentArchived} old message contents`);
+
+        // Vacuum to reclaim space
+        runtimeDb.exec("PRAGMA incremental_vacuum(100)");
+      } catch (e) {
+        logger.warn(`Maintenance error: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }, 24 * 60 * 60 * 1000); // Every 24 hours
+    activeIntervals.push(maintenanceInterval);
   }
 
   // ─── Conditional interval startup ──────────────────────────────────────────

--- a/packages/jarvis-runtime/src/doctor.ts
+++ b/packages/jarvis-runtime/src/doctor.ts
@@ -22,6 +22,7 @@ import {
   validateConfig,
 } from "./config.js";
 import { JARVIS_PLATFORM_VERSION } from "./plugin-loader.js";
+import { RUNTIME_MIGRATIONS, CRM_MIGRATIONS, KNOWLEDGE_MIGRATIONS } from "./migrations/runner.js";
 
 type CheckResult = {
   name: string;
@@ -134,9 +135,9 @@ function checkDaemon() {
 
 function checkMigrations() {
   for (const [name, dbPath, expected] of [
-    ["Runtime", RUNTIME_DB_PATH, "0008"],
-    ["CRM", CRM_DB_PATH, "crm_0001"],
-    ["Knowledge", KNOWLEDGE_DB_PATH, "knowledge_0001"],
+    ["Runtime", RUNTIME_DB_PATH, RUNTIME_MIGRATIONS[RUNTIME_MIGRATIONS.length - 1].id],
+    ["CRM", CRM_DB_PATH, CRM_MIGRATIONS[CRM_MIGRATIONS.length - 1].id],
+    ["Knowledge", KNOWLEDGE_DB_PATH, KNOWLEDGE_MIGRATIONS[KNOWLEDGE_MIGRATIONS.length - 1].id],
   ] as const) {
     if (!fs.existsSync(dbPath)) continue;
     try {
@@ -421,6 +422,89 @@ function checkDiskSpace() {
   }
 }
 
+// ─── Config Permissions ───────────────────────────────────────────────────
+
+function checkConfigPermissions() {
+  if (process.platform === "win32") {
+    // File mode checks are not meaningful on Windows
+    return;
+  }
+
+  const configPath = join(JARVIS_DIR, "config.json");
+  if (!fs.existsSync(configPath)) return;
+
+  try {
+    const stat = fs.statSync(configPath);
+    // Check if world-readable (others have read permission: mode & 0o004)
+    if (stat.mode & 0o004) {
+      warn("Config Permissions", `${configPath} is world-readable`,
+        "Run: chmod 600 ~/.jarvis/config.json",
+        "chmod 600 " + configPath);
+    } else {
+      pass("Config Permissions", "config.json is not world-readable");
+    }
+  } catch {
+    warn("Config Permissions", "Could not check file permissions");
+  }
+}
+
+// ─── Dead Letter Jobs ─────────────────────────────────────────────────────
+
+function checkDeadLetterJobs() {
+  if (!fs.existsSync(RUNTIME_DB_PATH)) return;
+
+  try {
+    const db = new DatabaseSync(RUNTIME_DB_PATH);
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA busy_timeout = 5000;");
+
+    const row = db.prepare(
+      `SELECT COUNT(*) as cnt FROM agent_commands
+       WHERE status = 'queued'
+       AND created_at < datetime('now', '-1 hour')`,
+    ).get() as { cnt: number } | undefined;
+    db.close();
+
+    const count = row?.cnt ?? 0;
+    if (count === 0) {
+      pass("Dead Letter Jobs", "No stale queued jobs");
+    } else {
+      warn("Dead Letter Jobs", `${count} job(s) stuck in 'queued' for > 1 hour`,
+        "Inspect with: SELECT * FROM agent_commands WHERE status='queued' AND created_at < datetime('now','-1 hour')");
+    }
+  } catch {
+    warn("Dead Letter Jobs", "Could not check for stale jobs");
+  }
+}
+
+// ─── DB Growth ────────────────────────────────────────────────────────────
+
+function checkDbGrowth() {
+  const dbFiles = [
+    ["Runtime", RUNTIME_DB_PATH],
+    ["CRM", CRM_DB_PATH],
+    ["Knowledge", KNOWLEDGE_DB_PATH],
+  ] as const;
+
+  const MAX_SIZE_BYTES = 500 * 1024 * 1024; // 500 MB
+
+  for (const [name, dbPath] of dbFiles) {
+    if (!fs.existsSync(dbPath)) continue;
+    try {
+      const stat = fs.statSync(dbPath);
+      const sizeMB = stat.size / (1024 * 1024);
+      if (stat.size > MAX_SIZE_BYTES) {
+        warn(`${name} DB Size`, `${sizeMB.toFixed(1)} MB — exceeds 500 MB threshold`,
+          `Consider running VACUUM on ${dbPath} or archiving old data`);
+      } else {
+        pass(`${name} DB Size`, `${sizeMB.toFixed(1)} MB`);
+      }
+    } catch {
+      warn(`${name} DB Size`, "Could not check database file size");
+    }
+  }
+}
+
 // ─── Run ───────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -439,6 +523,9 @@ async function main() {
   checkWalMode();
   checkDaemon();
   checkSecurityPosture();
+  checkConfigPermissions();
+  checkDeadLetterJobs();
+  checkDbGrowth();
   await checkModelRuntime();
   await checkChrome();
   checkDashboard();

--- a/packages/jarvis-runtime/src/filesystem-policy.ts
+++ b/packages/jarvis-runtime/src/filesystem-policy.ts
@@ -207,6 +207,25 @@ export function loadFilesystemPolicy(config: {
   return base;
 }
 
+// ─── Readable File-Type Allowlist ──────────────────────────────────────────
+
+/**
+ * File extensions that copilot surfaces are allowed to read.
+ * Prevents accidental exposure of binary, credential, or database files.
+ */
+export const READABLE_FILE_EXTENSIONS = new Set([
+  ".ts", ".js", ".tsx", ".jsx", ".json", ".md", ".txt", ".yaml", ".yml",
+  ".toml", ".csv", ".xml", ".html", ".css", ".sql", ".sh", ".bat", ".ps1",
+  ".py", ".go", ".rs", ".java", ".c", ".cpp", ".h", ".hpp",
+  ".env.example", ".gitignore", ".editorconfig",
+]);
+
+/** Check whether a file path has a readable (text-based) extension. */
+export function isReadableFileType(filePath: string): boolean {
+  const ext = filePath.slice(filePath.lastIndexOf(".")).toLowerCase();
+  return READABLE_FILE_EXTENSIONS.has(ext);
+}
+
 /** Normalize path separators for consistent comparison. */
 function normalizePath(p: string): string {
   return normalize(p);

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -22,6 +22,22 @@ import type { StatusWriter } from "./status-writer.js";
  *  since that's typically the main deliverable and should still execute in preview. */
 const OUTBOUND_ACTIONS = new Set(['email.send', 'social.post', 'crm.move_stage']);
 
+// ─── Failure classification (#70) ──────────────────────────────────────────
+// Classify step failures so the daemon can decide retry strategy and operators
+// can filter by failure class in the dashboard.
+// ────────────────────────────────────────────────────────────────────────────
+
+type FailureClass = "transient" | "permanent" | "timeout" | "permission" | "unknown";
+
+function classifyFailure(error: unknown, jobResult?: { error?: { code?: string; retryable?: boolean } }): FailureClass {
+  if (jobResult?.error?.code === "EXECUTION_TIMEOUT") return "timeout";
+  if (jobResult?.error?.code === "FILESYSTEM_POLICY_VIOLATION") return "permission";
+  if (jobResult?.error?.retryable) return "transient";
+  if (jobResult?.error?.code === "INVALID_INPUT") return "permanent";
+  if (error instanceof Error && error.message.includes("ECONNREFUSED")) return "transient";
+  return "unknown";
+}
+
 export type OrchestratorDeps = {
   runtime: AgentRuntime;
   registry: WorkerRegistry;
@@ -425,9 +441,10 @@ export async function runAgent(
         });
 
         if (result.status === "failed") {
+          const failureClass = classifyFailure(null, result);
           runStore?.emitEvent(run.run_id, agentId, "step_failed", {
             step_no: step.step, action: step.action,
-            details: { error: result.error?.message, error_code: result.error?.code, retryable: result.error?.retryable },
+            details: { error: result.error?.message, error_code: result.error?.code, retryable: result.error?.retryable, failure_class: failureClass },
           });
 
           // Retry once if retryable
@@ -436,6 +453,7 @@ export async function runAgent(
             const retry = await registry.executeJob({ ...envelope, attempt: 2 });
             if (retry.status === "failed") {
               stepLog.warn("Retry also failed");
+              const retryFailureClass = classifyFailure(null, retry);
               runStore?.emitEvent(run.run_id, agentId, "step_failed", {
                 step_no: step.step, action: step.action,
                 details: {
@@ -443,6 +461,7 @@ export async function runAgent(
                   error_code: retry.error?.code,
                   attempt: 2,
                   retryable: false,
+                  failure_class: retryFailureClass,
                 },
               });
             } else {
@@ -465,10 +484,11 @@ export async function runAgent(
         run.updated_at = new Date().toISOString();
       } catch (e) {
         const errMsg = e instanceof Error ? e.message : String(e);
+        const caughtFailureClass = classifyFailure(e);
         stepLog.error(`Threw: ${errMsg}`);
         runStore?.emitEvent(run.run_id, agentId, "step_failed", {
           step_no: step.step, action: step.action,
-          details: { error: errMsg },
+          details: { error: errMsg, failure_class: caughtFailureClass },
         });
         decisionLog.logDecision({
           agent_id: agentId, run_id: run.run_id, step: step.step,

--- a/packages/jarvis-runtime/src/plugin-loader.ts
+++ b/packages/jarvis-runtime/src/plugin-loader.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import { Type, type Static } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 import type { AgentDefinition } from "@jarvis/agent-framework";
@@ -189,8 +191,25 @@ export function validateManifest(data: unknown): ManifestValidationResult {
   return { valid: errors.length === 0, errors };
 }
 
+/** Load platform version from root package.json instead of hardcoding. */
+function loadPlatformVersion(): string {
+  try {
+    // Walk up from this file to find root package.json
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let i = 0; i < 5; i++) {
+      const pkgPath = join(dir, "package.json");
+      if (fs.existsSync(pkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+        if (pkg.name === "jarvis-plugin-pack") return pkg.version;
+      }
+      dir = dirname(dir);
+    }
+  } catch { /* fallback below */ }
+  return "0.1.0"; // fallback
+}
+
 /** Current Jarvis platform version for compatibility gating. */
-export const JARVIS_PLATFORM_VERSION = "0.1.0";
+export const JARVIS_PLATFORM_VERSION = loadPlatformVersion();
 
 /** Simple semver comparison. Returns -1 if a < b, 0 if equal, 1 if a > b. */
 function compareSemver(a: string, b: string): number {
@@ -226,6 +245,23 @@ export function isActionPermitted(action: string, grantedPermissions: PluginPerm
   return grantedPermissions.includes(required);
 }
 
+// ── Checksum Verification ─────────────────────────────────────────────────
+
+/**
+ * Verify the SHA-256 checksum of a plugin manifest file.
+ * If the manifest doesn't include a checksum, verification is skipped (optional field).
+ * The checksum is computed over the manifest content with the checksum field removed.
+ */
+function verifyManifestChecksum(manifestPath: string, manifest: PluginManifest): boolean {
+  if (!manifest.checksum_sha256) return true; // Optional field — skip if not provided
+  const content = fs.readFileSync(manifestPath, "utf8");
+  // Remove the checksum field itself before hashing (it was added after content was hashed)
+  const withoutChecksum = JSON.parse(content);
+  delete withoutChecksum.checksum_sha256;
+  const hash = createHash("sha256").update(JSON.stringify(withoutChecksum, null, 2)).digest("hex");
+  return hash === manifest.checksum_sha256;
+}
+
 // ── Loading ────────────────────────────────────────────────────────────────
 
 /**
@@ -252,6 +288,11 @@ export function loadPlugins(logger?: { warn: (msg: string) => void }): PluginMan
       const validation = validateManifest(raw);
       if (!validation.valid) {
         logger?.warn(`Plugin ${dir}: invalid manifest — ${validation.errors.join("; ")}`);
+        continue;
+      }
+      // Verify checksum integrity before accepting the plugin
+      if (!verifyManifestChecksum(manifestPath, raw as PluginManifest)) {
+        logger?.warn(`Plugin ${dir}: checksum mismatch — manifest may have been tampered with`);
         continue;
       }
       manifests.push(raw as PluginManifest);

--- a/packages/jarvis-runtime/src/release-metadata.ts
+++ b/packages/jarvis-runtime/src/release-metadata.ts
@@ -4,6 +4,7 @@
  */
 
 import { JARVIS_PLATFORM_VERSION } from "./plugin-loader.js";
+import { RUNTIME_MIGRATIONS } from "./migrations/runner.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -30,7 +31,7 @@ export type UpgradeCheckResult = {
 export const CURRENT_RELEASE: ReleaseInfo = {
   version: JARVIS_PLATFORM_VERSION,
   released_at: new Date().toISOString(),
-  migrations: ["0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008"],
+  migrations: RUNTIME_MIGRATIONS.map(m => m.id),
   changelog_summary: "Year 1-2: Channel ingress, execution hardening, core workflows, appliance reliability, provenance, multi-viewpoint, knowledge loop, team mode",
   rollback_safe: true,
 };

--- a/packages/jarvis-runtime/src/run-store.ts
+++ b/packages/jarvis-runtime/src/run-store.ts
@@ -37,19 +37,18 @@ const VALID_TRANSITIONS: Record<RunStatus, RunStatus[]> = {
  * Current status is always read from DB, never from an in-memory cache.
  *
  * ── Retention Policy (#70) ──────────────────────────────────────────────────
- * Intended data-lifecycle rules (not yet implemented — document intent now,
- * build compaction job later):
+ * Data-lifecycle rules enforced by the daemon's daily maintenance job:
  *
- *  - run_events older than 90 days: compact into per-run summary rows, then
- *    delete the individual step-level events. The summary preserves final
- *    status, duration, step count, and error (if any).
+ *  - run_events older than 90 days: step-level events are deleted via
+ *    compactOldEvents(). Run lifecycle events (run_started, run_completed,
+ *    run_failed, run_cancelled) are preserved for auditing.
  *
- *  - channel_messages previews older than 30 days: archive preview_json to
- *    cold storage (or drop if full content is retained in full_content_json),
- *    keeping the message row for thread-continuity queries.
+ *  - channel_messages older than 30 days: content_full is NULLed via
+ *    ChannelStore.archiveOldContent(), keeping message rows for
+ *    thread-continuity queries.
  *
- * Until the compaction job ships, these tables grow unbounded. Monitor
- * runtime.db size via the dashboard health endpoint.
+ * The daemon runs maintenance every 24h with incremental vacuum to reclaim
+ * space. Monitor runtime.db size via the dashboard health endpoint.
  * ────────────────────────────────────────────────────────────────────────────
  */
 export class RunStore {
@@ -265,6 +264,19 @@ export class RunStore {
     return this.db.prepare(
       "SELECT run_id, agent_id, status, started_at, completed_at FROM runs ORDER BY started_at DESC LIMIT ?",
     ).all(limit) as any[];
+  }
+
+  /**
+   * Delete step-level events older than maxAgeDays, preserving run lifecycle
+   * events (run_started, run_completed, run_failed, run_cancelled) for auditing.
+   * Returns the number of events deleted.
+   */
+  compactOldEvents(maxAgeDays = 90): number {
+    const cutoff = new Date(Date.now() - maxAgeDays * 86400000).toISOString();
+    const result = this.db.prepare(
+      "DELETE FROM run_events WHERE created_at < ? AND event_type NOT IN ('run_started', 'run_completed', 'run_failed', 'run_cancelled')"
+    ).run(cutoff);
+    return (result as { changes: number }).changes;
   }
 
   /** Mark a run's associated command as completed, failed, or cancelled. */

--- a/packages/jarvis-runtime/src/worker-registry.ts
+++ b/packages/jarvis-runtime/src/worker-registry.ts
@@ -39,6 +39,16 @@ export type WorkerRegistry = {
 export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger, runtimeDb?: DatabaseSync, healthMonitor?: WorkerHealthMonitor): WorkerRegistry {
   const useReal = config.adapter_mode === "real";
 
+  // Audit helper: log credential access for security trail (best-effort)
+  const auditCredentialAccess = (workerId: string, credentialType: string) => {
+    if (!runtimeDb) return;
+    try {
+      runtimeDb.prepare(
+        "INSERT INTO audit_log (event_type, actor, target, details_json, created_at) VALUES (?, ?, ?, ?, ?)"
+      ).run("credential_access", "worker-registry", workerId, JSON.stringify({ credential_type: credentialType }), new Date().toISOString());
+    } catch { /* best-effort — audit table may not exist yet */ }
+  };
+
   // ─── Inference ──────────────────────────────────────────────────────────
   const inferenceAdapter = useReal ? new DefaultInferenceAdapter(runtimeDb, config.lmstudio_url) : new MockInferenceAdapter();
   const inferenceWorker = createInferenceWorker({ adapter: inferenceAdapter });
@@ -92,6 +102,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   if (useReal && config.gmail) {
     logger.info("Email: using Gmail API adapter");
     emailAdapter = new GmailAdapter(config.gmail);
+    auditCredentialAccess("email", "gmail");
   } else {
     logger.info("Email: using mock adapter");
     emailAdapter = new MockEmailAdapter();
@@ -136,6 +147,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   if (useReal && config.calendar) {
     logger.info("Calendar: using Google Calendar API adapter");
     calendarAdapter = new GoogleCalendarAdapter(config.calendar);
+    auditCredentialAccess("calendar", "calendar");
   } else {
     logger.info("Calendar: using mock adapter");
     calendarAdapter = new MockCalendarAdapter();
@@ -158,6 +170,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   if (useReal && config.chrome) {
     logger.info(`Browser: using Chrome adapter (${config.chrome.debugging_url})`);
     browserAdapter = new ChromeAdapter({ debugging_url: config.chrome.debugging_url });
+    auditCredentialAccess("browser", "chrome");
   } else {
     logger.info("Browser: using mock adapter");
     browserAdapter = new MockBrowserAdapter();
@@ -222,6 +235,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   if (useReal && config.toggl) {
     logger.info("Time: using Toggl adapter");
     timeAdapter = new TogglAdapter(config.toggl);
+    auditCredentialAccess("time", "toggl");
   } else {
     logger.info("Time: using mock adapter");
     timeAdapter = new MockTimeAdapter();
@@ -234,6 +248,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   if (useReal && config.drive) {
     logger.info("Drive: using Google Drive adapter");
     driveAdapter = new GoogleDriveAdapter(config.drive);
+    auditCredentialAccess("drive", "drive");
   } else {
     logger.info("Drive: using mock adapter");
     driveAdapter = new MockDriveAdapter();

--- a/packages/jarvis-shared/src/state.ts
+++ b/packages/jarvis-shared/src/state.ts
@@ -51,6 +51,7 @@ type SubmitJobParams = {
   notifyOnCompletion?: boolean;
   runGroup?: string;
   attempt?: number;
+  idempotencyKey?: string;
 };
 
 type DispatchParams = {
@@ -335,6 +336,19 @@ class JarvisState {
   }
 
   submitJob(params: SubmitJobParams): ToolResponse {
+    // Idempotency guard: if a key is provided, reject duplicate submissions
+    if (params.idempotencyKey) {
+      const existing = this.findJobByIdempotencyKey(params.idempotencyKey);
+      if (existing) {
+        return createToolResponse({
+          status: "accepted",
+          summary: "Job already submitted with this idempotency key.",
+          job_id: existing,
+          structured_output: { duplicate: true, idempotency_key: params.idempotencyKey },
+        });
+      }
+    }
+
     const approvalRequirement = JOB_APPROVAL_REQUIREMENT[params.type];
     const approvalGranted = this.isApprovalGranted(params.approvalId);
 
@@ -1104,6 +1118,25 @@ class JarvisState {
     return this.getApproval(approvalId)?.state === "approved";
   }
 
+  /**
+   * Find a job by its idempotency key stored in envelope metadata.
+   * Returns the job_id if found, null otherwise.
+   */
+  private findJobByIdempotencyKey(key: string): string | null {
+    const rows = this.db
+      .prepare("SELECT job_id, record_json FROM jobs")
+      .all() as Array<{ job_id: string; record_json: string }>;
+    for (const row of rows) {
+      try {
+        const record = deserializeJson<JobRecord>(row.record_json);
+        if (record.envelope.metadata.idempotency_key === key) {
+          return row.job_id;
+        }
+      } catch { /* skip malformed records */ }
+    }
+    return null;
+  }
+
   private buildEnvelope(
     params: SubmitJobParams,
     approvalGranted: boolean,
@@ -1137,6 +1170,7 @@ class JarvisState {
         capability_route: params.capabilityRoute,
         notify_on_completion: params.notifyOnCompletion ?? false,
         run_group: params.runGroup,
+        idempotency_key: params.idempotencyKey,
         queued_at: queuedAt
       }
     };

--- a/packages/jarvis-telegram/src/chat-handler.ts
+++ b/packages/jarvis-telegram/src/chat-handler.ts
@@ -44,17 +44,27 @@ function loadApiToken(): string | null {
  * Load recent conversation history from the channel store (thread-scoped,
  * durable). Falls back gracefully to empty history if the store is unavailable.
  */
-function loadThreadHistory(ctx?: ChatContext, limit = 20): ChatMessage[] {
+function loadThreadHistory(ctx?: ChatContext, limit = 20, maxChars = 4000): ChatMessage[] {
   if (!ctx?.channelStore || !ctx?.threadId) return []
 
   try {
     const messages = ctx.channelStore.getThreadMessages(ctx.threadId, limit)
-    return messages
       .filter(m => m.content_preview && m.direction)
       .map(m => ({
         role: m.direction === 'inbound' ? 'user' : 'assistant',
         content: m.content_preview!,
       }))
+
+    // Truncate from the oldest end to stay within maxChars budget
+    let totalChars = 0
+    const windowed: ChatMessage[] = []
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const len = messages[i]!.content.length
+      if (totalChars + len > maxChars) break
+      totalChars += len
+      windowed.unshift(messages[i]!)
+    }
+    return windowed
   } catch {
     return []
   }

--- a/scripts/setup-jarvis.ts
+++ b/scripts/setup-jarvis.ts
@@ -550,6 +550,74 @@ async function setupDrive(): Promise<void> {
   }
 }
 
+// ─── Security Summary ──────────────────────────────────────────────────────
+
+function printSecuritySummary(config: Record<string, unknown>): void {
+  console.log("──── Security Summary ─────────────────────────");
+  const ok = (label: string) => console.log(`  [OK] ${label}`);
+  const missing = (label: string) => console.log(`  [--] ${label}`);
+
+  if (config.api_token || config.api_tokens) ok("API authentication configured");
+  else missing("API authentication — not configured");
+
+  if (config.api_tokens) ok("Role-based tokens (admin/operator/viewer)");
+  else missing("Role-based tokens — not configured (single token or none)");
+
+  if (config.bind_host === "127.0.0.1") ok("Dashboard bound to localhost");
+  else missing("Dashboard bound to " + (config.bind_host ?? "default") + " — consider 127.0.0.1");
+
+  if (config.appliance_mode) ok("Appliance mode enabled");
+  else missing("Appliance mode — disabled");
+
+  if (config.webhook_secret) ok("Webhook secret configured");
+  else missing("Webhook secret — not configured");
+
+  console.log();
+}
+
+// ─── Appliance Preset ──────────────────────────────────────────────────────
+
+async function setupAppliancePreset(): Promise<void> {
+  console.log("\n╔═══════════════════════════════════════╗");
+  console.log("║     Jarvis Appliance Mode Setup       ║");
+  console.log("╚═══════════════════════════════════════╝\n");
+  console.log("Auto-configuring strict security defaults...\n");
+
+  const { randomBytes } = await import("node:crypto");
+  const config = loadConfig();
+
+  // Generate role-based tokens
+  const tokens: Record<string, string> = {
+    admin: randomBytes(32).toString("hex"),
+    operator: randomBytes(32).toString("hex"),
+    viewer: randomBytes(32).toString("hex"),
+  };
+  config.api_tokens = tokens;
+
+  // Localhost binding
+  config.bind_host = "127.0.0.1";
+
+  // Appliance mode
+  config.appliance_mode = true;
+
+  // Webhook secret
+  const webhookSecret = randomBytes(32).toString("hex");
+  config.webhook_secret = webhookSecret;
+
+  saveConfig(config);
+
+  console.log("Configuration saved to ~/.jarvis/config.json\n");
+  console.log("──── Generated Credentials ────────────────────");
+  for (const [role, token] of Object.entries(tokens)) {
+    console.log(`  ${role} token: ${(token as string).slice(0, 8)}...${(token as string).slice(-4)}`);
+  }
+  console.log(`  webhook secret: ${webhookSecret.slice(0, 8)}...${webhookSecret.slice(-4)}`);
+  console.log();
+
+  printSecuritySummary(config);
+  console.log("Appliance setup complete. Start with: npm start\n");
+}
+
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -567,6 +635,11 @@ async function main(): Promise<void> {
   if (arg === "lmstudio") { await setupLmStudio(); return; }
   if (arg === "toggl") { await setupToggl(); return; }
   if (arg === "drive") { await setupDrive(); return; }
+
+  if (arg === "appliance") {
+    await setupAppliancePreset();
+    return;
+  }
 
   // Full interactive setup
   console.log("\n╔═══════════════════════════════════════╗");
@@ -589,16 +662,75 @@ async function main(): Promise<void> {
     const doToken = await prompt("Generate API token now? [Y/n]: ");
     if (doToken.toLowerCase() !== "n") {
       const { randomBytes } = await import("node:crypto");
-      const token = randomBytes(32).toString("hex");
-      config.api_token = token;
-      saveConfig(config);
-      console.log(`\nAPI token generated and saved to ~/.jarvis/config.json`);
-      console.log(`Token: ${token.slice(0, 8)}...${token.slice(-4)}`);
-      console.log(`\nSet this as Authorization header: Bearer ${token}`);
-      console.log(`Or set env: JARVIS_API_TOKEN=${token}\n`);
+
+      const doRoleBased = await prompt("Generate role-based tokens (admin/operator/viewer)? [y/N]: ");
+      if (doRoleBased.toLowerCase() === "y") {
+        const tokens: Record<string, string> = {
+          admin: randomBytes(32).toString("hex"),
+          operator: randomBytes(32).toString("hex"),
+          viewer: randomBytes(32).toString("hex"),
+        };
+        config.api_tokens = tokens;
+        saveConfig(config);
+        console.log(`\nRole-based API tokens generated and saved to ~/.jarvis/config.json`);
+        for (const [role, token] of Object.entries(tokens)) {
+          console.log(`  ${role}: ${(token as string).slice(0, 8)}...${(token as string).slice(-4)}`);
+        }
+        console.log();
+      } else {
+        const token = randomBytes(32).toString("hex");
+        config.api_token = token;
+        saveConfig(config);
+        console.log(`\nAPI token generated and saved to ~/.jarvis/config.json`);
+        console.log(`Token: ${token.slice(0, 8)}...${token.slice(-4)}`);
+        console.log(`\nSet this as Authorization header: Bearer ${token}`);
+        console.log(`Or set env: JARVIS_API_TOKEN=${token}\n`);
+      }
     }
   } else {
     console.log("API token: already configured\n");
+  }
+
+  // 2b. Bind host
+  console.log("──── Network Binding ──────────────────────────");
+  const doLocalhost = await prompt("Bind dashboard to localhost only? [Y/n]: ");
+  if (doLocalhost.toLowerCase() === "n") {
+    config.bind_host = "0.0.0.0";
+    console.log("Dashboard will listen on all interfaces (0.0.0.0)\n");
+  } else {
+    config.bind_host = "127.0.0.1";
+    console.log("Dashboard will listen on localhost only (127.0.0.1)\n");
+  }
+  saveConfig(config);
+
+  // 2c. Appliance mode
+  console.log("──── Appliance Mode ───────────────────────────");
+  const doAppliance = await prompt("Enable appliance mode (strict security)? [y/N]: ");
+  if (doAppliance.toLowerCase() === "y") {
+    config.appliance_mode = true;
+    console.log("Appliance mode enabled\n");
+  } else {
+    config.appliance_mode = false;
+  }
+  saveConfig(config);
+
+  // 2d. Webhook secret
+  if (config.appliance_mode) {
+    const { randomBytes } = await import("node:crypto");
+    const secret = randomBytes(32).toString("hex");
+    config.webhook_secret = secret;
+    saveConfig(config);
+    console.log("Webhook secret auto-generated for appliance mode");
+    console.log(`Secret: ${secret.slice(0, 8)}...${secret.slice(-4)}\n`);
+  } else if (!config.webhook_secret) {
+    const doWebhook = await prompt("Generate webhook secret? [y/N]: ");
+    if (doWebhook.toLowerCase() === "y") {
+      const { randomBytes } = await import("node:crypto");
+      const secret = randomBytes(32).toString("hex");
+      config.webhook_secret = secret;
+      saveConfig(config);
+      console.log(`Webhook secret generated: ${secret.slice(0, 8)}...${secret.slice(-4)}\n`);
+    }
   }
 
   // 3. LM Studio
@@ -630,6 +762,7 @@ async function main(): Promise<void> {
   if (doDrive.toLowerCase() !== "n") await setupDrive();
 
   console.log("\n=== Setup Complete ===\n");
+  printSecuritySummary(config);
   showStatus();
 }
 

--- a/tests/smoke/surface-readonly.test.ts
+++ b/tests/smoke/surface-readonly.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Frozen contract: copilot surfaces (chat and godmode) expose ONLY read-only tools.
+ * This test prevents accidental re-addition of mutation tools.
+ *
+ * Also includes fuzz-style tests for tool-call extraction regex resilience.
+ */
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+
+// ===========================================================================
+// Copilot Surface: Frozen Read-Only Contract
+// ===========================================================================
+
+describe("Copilot Surface: Frozen Read-Only Contract", () => {
+  const MUTATION_TOOLS = [
+    "run_command", "write_file", "gmail_send", "gmail_reply",
+    "trigger_agent", "crm_update", "email_send", "execute_shell",
+    "file_write", "publish_post", "trade_execute",
+  ];
+
+  it("chat.ts AGENT_TOOLS contains no mutation tools", () => {
+    const chatSrc = fs.readFileSync(join(ROOT, "packages/jarvis-dashboard/src/api/chat.ts"), "utf8");
+    for (const tool of MUTATION_TOOLS) {
+      // Check tool isn't in the AGENT_TOOLS array (allow comments/error handlers)
+      const inToolDef = new RegExp(`name:\\s*'${tool}'`).test(chatSrc);
+      expect(inToolDef, `chat.ts should not define tool '${tool}'`).toBe(false);
+    }
+  });
+
+  it("godmode.ts contains no mutation tools in TOOL_DESCRIPTIONS", () => {
+    const godmodeSrc = fs.readFileSync(join(ROOT, "packages/jarvis-dashboard/src/api/godmode.ts"), "utf8");
+    for (const tool of MUTATION_TOOLS) {
+      const inDesc = new RegExp(`\\[TOOL:${tool}\\]`).test(godmodeSrc);
+      expect(inDesc, `godmode.ts should not expose tool '${tool}'`).toBe(false);
+    }
+  });
+
+  it("tool-infra.ts READONLY_TOOL_NAMES does not include mutation tools", () => {
+    const infraSrc = fs.readFileSync(join(ROOT, "packages/jarvis-dashboard/src/api/tool-infra.ts"), "utf8");
+    for (const tool of MUTATION_TOOLS) {
+      expect(infraSrc).not.toContain(`"${tool}"`);
+    }
+  });
+
+  it("trigger_agent returns error message when called from chat", () => {
+    const chatSrc = fs.readFileSync(join(ROOT, "packages/jarvis-dashboard/src/api/chat.ts"), "utf8");
+    expect(chatSrc).toContain("case 'trigger_agent':");
+    expect(chatSrc).toContain("not available from the chat surface");
+  });
+});
+
+// ===========================================================================
+// Tool-call extraction: fuzz cases
+// ===========================================================================
+
+describe("Tool-call extraction: fuzz cases", () => {
+  // These test the extractToolCalls regex from tool-infra.ts
+  // We replicate the regex here to test pattern resilience without
+  // importing from a package that requires a full build context.
+  const TOOL_REGEX = /\[TOOL:(\w+)\]\((\{[\s\S]*?\})\)/g;
+
+  it("handles malformed JSON gracefully", () => {
+    const text = '[TOOL:web_search]({"query": broken})';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(1); // Regex matches but JSON.parse would fail
+  });
+
+  it("handles nested braces", () => {
+    const text = '[TOOL:test]({"a":{"b":"c"}})';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects tool names with special characters", () => {
+    const text = '[TOOL:rm -rf]({"path":"/"})';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(0); // \w+ won't match spaces
+  });
+
+  it("handles empty params", () => {
+    const text = '[TOOL:system_info]({})';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(1);
+  });
+
+  it("rejects tool names with path separators", () => {
+    const text = '[TOOL:../../etc/passwd]({"read":true})';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(0); // \w+ won't match dots or slashes
+  });
+
+  it("handles multiple tool calls in one string", () => {
+    const text = 'First [TOOL:web_search]({"query":"test"}) then [TOOL:web_fetch]({"url":"https://x.com"})';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(2);
+    expect(matches[0]![1]).toBe("web_search");
+    expect(matches[1]![1]).toBe("web_fetch");
+  });
+
+  it("does not match incomplete tool syntax", () => {
+    const text = '[TOOL:web_search]';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(0); // Missing params section
+  });
+
+  it("does not match if curly braces are absent", () => {
+    const text = '[TOOL:web_search](no-braces)';
+    const matches = [...text.matchAll(new RegExp(TOOL_REGEX.source, "g"))];
+    expect(matches.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

8-batch hardening pass covering ~150 items across config/setup, tool registry, plugin verification, security, runtime governance, testing, documentation, and workflow polish.

**37 files changed, +1178/-105 lines. 63 test files, 1423 tests passing.**

### Highlights
- Config schema: api_token/api_tokens/mode/bind_host now in TypeBox schema
- Doctor derives migration IDs from runner (no hardcoding)
- Shared READONLY_TOOL_NAMES registry prevents surface drift
- Plugin SHA-256 checksum verification on load
- Retention enforcement: 90-day event compaction, 30-day content archival
- 12 new frozen-contract tests proving surfaces are read-only
- 8 new docs: glossary, lifecycle diagrams, architecture status, TLS guide, intake forms, non-goals

## Test plan
- [x] `npm run check` passes (143 contracts, 63 files, 1423 tests)
- [x] New surface-readonly tests pass (12 tests)
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)