### PR TITLE
[codex] Fix review findings across runtime, dashboard, and workers

### DIFF
--- a/packages/jarvis-dashboard/src/api/backup.ts
+++ b/packages/jarvis-dashboard/src/api/backup.ts
@@ -9,120 +9,241 @@ import type { AuthenticatedRequest } from './middleware/auth.js'
 const JARVIS_DIR = join(os.homedir(), '.jarvis')
 const BACKUPS_DIR = join(JARVIS_DIR, 'backups')
 
+const CONFIG_FILES = ['config.json'] as const
+const SQLITE_DATABASE_FILES = ['crm.db', 'knowledge.db', 'runtime.db'] as const
+const BACKUP_FILES = [...CONFIG_FILES, ...SQLITE_DATABASE_FILES] as const
+const LEGACY_WAL_SIDECARS = ['runtime.db-wal', 'runtime.db-shm', 'crm.db-wal', 'crm.db-shm', 'knowledge.db-wal', 'knowledge.db-shm'] as const
+const ALLOWED_RESTORE = new Set<string>([...BACKUP_FILES, ...LEGACY_WAL_SIDECARS])
+const SQLITE_SIDECARS = ['-wal', '-shm'] as const
 
-// Files to include in backup. Include WAL/SHM sidecars for SQLite consistency.
-const BACKUP_FILES = ['config.json', 'crm.db', 'knowledge.db', 'runtime.db']
-const WAL_SIDECARS = ['runtime.db-wal', 'runtime.db-shm', 'crm.db-wal', 'crm.db-shm', 'knowledge.db-wal', 'knowledge.db-shm']
+type BackupManifest = {
+  timestamp: string
+  files: Array<{ name: string; size: number }>
+  total_size: number
+}
+
+type BackupStatusResponse = {
+  last_backup: string | null
+  last_backup_at: string | null
+  path?: string | null
+  last_backup_path: string | null
+  files?: Array<{ name: string; size: number }>
+  size?: number
+  size_mb?: number | null
+}
+
+function formatTimestamp(now: Date): string {
+  return now.toISOString()
+    .replace(/[T]/g, '-')
+    .replace(/[:]/g, '')
+    .replace(/\.\d+Z$/, '')
+}
+
+function sqliteStringLiteral(value: string): string {
+  return value.replace(/\\/g, '/').replace(/'/g, "''")
+}
+
+function removeIfExists(path: string): void {
+  try {
+    if (fs.existsSync(path)) fs.unlinkSync(path)
+  } catch { /* best effort */ }
+}
+
+function clearSqliteSidecars(basePath: string): void {
+  for (const suffix of SQLITE_SIDECARS) {
+    removeIfExists(basePath + suffix)
+  }
+}
+
+export function snapshotSqliteDatabase(sourcePath: string, targetPath: string): void {
+  removeIfExists(targetPath)
+  const db = new DatabaseSync(sourcePath, { readOnly: true })
+  try {
+    db.exec('PRAGMA busy_timeout = 5000;')
+    db.exec(`VACUUM INTO '${sqliteStringLiteral(targetPath)}'`)
+  } finally {
+    try { db.close() } catch {}
+  }
+}
+
+export function createBackupSnapshot(
+  jarvisDir = JARVIS_DIR,
+  backupsDir = BACKUPS_DIR,
+  now = new Date(),
+): { backupDir: string; files: Array<{ name: string; size: number }>; totalSize: number; manifest: BackupManifest } {
+  const backupDir = join(backupsDir, `backup-${formatTimestamp(now)}`)
+  fs.mkdirSync(backupDir, { recursive: true })
+
+  const files: Array<{ name: string; size: number }> = []
+
+  for (const name of CONFIG_FILES) {
+    const src = join(jarvisDir, name)
+    if (!fs.existsSync(src)) continue
+    const dest = join(backupDir, name)
+    fs.copyFileSync(src, dest)
+    files.push({ name, size: fs.statSync(dest).size })
+  }
+
+  for (const name of SQLITE_DATABASE_FILES) {
+    const src = join(jarvisDir, name)
+    if (!fs.existsSync(src)) continue
+    const dest = join(backupDir, name)
+    snapshotSqliteDatabase(src, dest)
+    files.push({ name, size: fs.statSync(dest).size })
+  }
+
+  const totalSize = files.reduce((sum, file) => sum + file.size, 0)
+  const manifest: BackupManifest = {
+    timestamp: now.toISOString(),
+    files,
+    total_size: totalSize,
+  }
+
+  fs.writeFileSync(join(backupDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
+  return { backupDir, files, totalSize, manifest }
+}
+
+export function getBackupStatus(backupsDir = BACKUPS_DIR): BackupStatusResponse {
+  if (!fs.existsSync(backupsDir)) {
+    return {
+      last_backup: null,
+      last_backup_at: null,
+      last_backup_path: null,
+      size_mb: null,
+    }
+  }
+
+  const entries = fs.readdirSync(backupsDir)
+    .filter(entry => entry.startsWith('backup-'))
+    .sort()
+
+  if (entries.length === 0) {
+    return {
+      last_backup: null,
+      last_backup_at: null,
+      last_backup_path: null,
+      size_mb: null,
+    }
+  }
+
+  const latest = entries[entries.length - 1]
+  const backupPath = join(backupsDir, latest)
+  const manifestPath = join(backupPath, 'manifest.json')
+
+  if (!fs.existsSync(manifestPath)) {
+    return {
+      last_backup: latest,
+      last_backup_at: latest,
+      path: backupPath,
+      last_backup_path: backupPath,
+      files: [],
+      size: 0,
+      size_mb: 0,
+    }
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as BackupManifest
+  return {
+    last_backup: manifest.timestamp,
+    last_backup_at: manifest.timestamp,
+    path: backupPath,
+    last_backup_path: backupPath,
+    files: manifest.files,
+    size: manifest.total_size,
+    size_mb: Number((manifest.total_size / (1024 * 1024)).toFixed(2)),
+  }
+}
+
+export function restoreBackupDirectory(
+  backupPath: string,
+  jarvisDir = JARVIS_DIR,
+): { restored: string[] } {
+  const manifestPath = join(backupPath, 'manifest.json')
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error('manifest.json not found in backup path')
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+    files: Array<{ name: string; size: number }>
+  }
+
+  const safeFiles = manifest.files.filter((file) => {
+    const name = file.name
+    return ALLOWED_RESTORE.has(name) && !name.includes('/') && !name.includes('\\') && !name.includes('..')
+  })
+
+  const missing: string[] = []
+  for (const file of safeFiles) {
+    if (!fs.existsSync(join(backupPath, file.name))) {
+      missing.push(file.name)
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing files in backup: ${missing.join(', ')}`)
+  }
+
+  for (const dbName of SQLITE_DATABASE_FILES) {
+    const hasDatabaseSnapshot = safeFiles.some(file => file.name === dbName)
+    const hasLegacySidecar = safeFiles.some(file => file.name === `${dbName}-wal` || file.name === `${dbName}-shm`)
+    if (hasDatabaseSnapshot || hasLegacySidecar) {
+      clearSqliteSidecars(join(jarvisDir, dbName))
+    }
+  }
+
+  const restored: string[] = []
+  for (const file of safeFiles) {
+    fs.copyFileSync(join(backupPath, file.name), join(jarvisDir, file.name))
+    restored.push(file.name)
+  }
+
+  return { restored }
+}
 
 export const backupRouter = Router()
 
-// POST / — trigger a new backup
 backupRouter.post('/', (req, res) => {
   try {
-    const now = new Date()
-    const ts = now.toISOString()
-      .replace(/[T]/g, '-')
-      .replace(/[:]/g, '')
-      .replace(/\.\d+Z$/, '')
-    const backupDir = join(BACKUPS_DIR, `backup-${ts}`)
-
-    fs.mkdirSync(backupDir, { recursive: true })
-
-    const files: Array<{ name: string; size: number }> = []
-    // Copy main files
-    for (const name of BACKUP_FILES) {
-      const src = join(JARVIS_DIR, name)
-      if (fs.existsSync(src)) {
-        fs.copyFileSync(src, join(backupDir, name))
-        files.push({ name, size: fs.statSync(join(backupDir, name)).size })
-      }
-    }
-    // Copy WAL/SHM sidecars (optional — only exist when DB is in WAL mode)
-    for (const name of WAL_SIDECARS) {
-      const src = join(JARVIS_DIR, name)
-      if (fs.existsSync(src)) {
-        fs.copyFileSync(src, join(backupDir, name))
-        files.push({ name, size: fs.statSync(join(backupDir, name)).size })
-      }
-    }
+    const { backupDir, files, totalSize } = createBackupSnapshot()
 
     if (files.length === 0) {
       res.status(400).json({ ok: false, error: 'No files found to back up' })
       return
     }
 
-    const totalSize = files.reduce((sum, f) => sum + f.size, 0)
-    const manifest = {
-      timestamp: now.toISOString(),
-      files,
-      total_size: totalSize
-    }
-
-    fs.writeFileSync(join(backupDir, 'manifest.json'), JSON.stringify(manifest, null, 2))
-
     const actor = getActor(req as AuthenticatedRequest)
     writeAuditLog(actor.type, actor.id, 'backup.created', 'backup', backupDir, {
-      files: files.map(f => f.name),
-      total_size: totalSize
+      files: files.map(file => file.name),
+      total_size: totalSize,
     })
 
     res.json({
       ok: true,
       path: backupDir,
       files,
-      total_size: totalSize
+      total_size: totalSize,
     })
   } catch (err) {
     res.status(500).json({
       ok: false,
-      error: `Backup failed: ${err instanceof Error ? err.message : String(err)}`
+      error: `Backup failed: ${err instanceof Error ? err.message : String(err)}`,
     })
   }
 })
 
-// GET /status — return last backup info
 backupRouter.get('/status', (_req, res) => {
   try {
-    if (!fs.existsSync(BACKUPS_DIR)) {
-      res.json({ last_backup: null })
-      return
-    }
-
-    const entries = fs.readdirSync(BACKUPS_DIR)
-      .filter(e => e.startsWith('backup-'))
-      .sort()
-
-    if (entries.length === 0) {
-      res.json({ last_backup: null })
-      return
-    }
-
-    const latest = entries[entries.length - 1]
-    const manifestPath = join(BACKUPS_DIR, latest, 'manifest.json')
-
-    if (!fs.existsSync(manifestPath)) {
-      res.json({ last_backup: latest, files: [], size: 0 })
-      return
-    }
-
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
-      timestamp: string
-      files: Array<{ name: string; size: number }>
-      total_size: number
-    }
-
-    res.json({
-      last_backup: manifest.timestamp,
-      path: join(BACKUPS_DIR, latest),
-      files: manifest.files,
-      size: manifest.total_size
-    })
+    res.json(getBackupStatus())
   } catch {
-    res.json({ last_backup: null })
+    res.json({
+      last_backup: null,
+      last_backup_at: null,
+      last_backup_path: null,
+      size_mb: null,
+    })
   }
 })
 
-// POST /restore — restore from a backup
 backupRouter.post('/restore', (req, res) => {
   const { backup_path } = req.body as { backup_path?: string }
 
@@ -131,177 +252,64 @@ backupRouter.post('/restore', (req, res) => {
     return
   }
 
-  // Normalize the path: replace ~ with homedir
   const resolvedPath = backup_path.replace(/^~/, os.homedir())
 
   try {
-    const manifestPath = join(resolvedPath, 'manifest.json')
-    if (!fs.existsSync(manifestPath)) {
-      res.status(404).json({ ok: false, error: 'manifest.json not found in backup path' })
-      return
-    }
-
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
-      files: Array<{ name: string; size: number }>
-    }
-
-    // Allowlist of files that can be restored (prevents path traversal)
-    const ALLOWED_RESTORE = new Set([...BACKUP_FILES, ...WAL_SIDECARS])
-
-    // Validate: only restore allowed filenames (no path separators, no ..)
-    const safeFiles = manifest.files.filter(f => {
-      const name = f.name
-      return ALLOWED_RESTORE.has(name) && !name.includes('/') && !name.includes('\\') && !name.includes('..')
-    })
-
-    // Validate all safe files exist in the backup
-    const missing: string[] = []
-    for (const file of safeFiles) {
-      if (!fs.existsSync(join(resolvedPath, file.name))) {
-        missing.push(file.name)
-      }
-    }
-
-    if (missing.length > 0) {
-      res.status(400).json({
-        ok: false,
-        error: `Missing files in backup: ${missing.join(', ')}`
-      })
-      return
-    }
-
-    // Check if daemon is running — warn if so
     const runtimeDbPath = join(JARVIS_DIR, 'runtime.db')
     if (fs.existsSync(runtimeDbPath)) {
       let checkDb: DatabaseSync | null = null
       try {
         checkDb = new DatabaseSync(runtimeDbPath)
-        checkDb.exec("PRAGMA journal_mode = WAL;")
-        checkDb.exec("PRAGMA busy_timeout = 5000;")
+        checkDb.exec('PRAGMA journal_mode = WAL;')
+        checkDb.exec('PRAGMA busy_timeout = 5000;')
         const heartbeat = checkDb.prepare(
-          'SELECT last_seen_at, pid FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1'
+          'SELECT last_seen_at, pid FROM daemon_heartbeats ORDER BY last_seen_at DESC LIMIT 1',
         ).get() as { last_seen_at: string; pid: number } | undefined
         if (heartbeat) {
           const staleness = Date.now() - new Date(heartbeat.last_seen_at).getTime()
-          if (staleness < 30_000) {
-            // Daemon appears to be running
-            if (req.body.force !== true) {
-              res.status(409).json({
-                ok: false,
-                error: 'Daemon is running. Stop it before restoring, or pass force: true to override.',
-                daemon_pid: heartbeat.pid,
-              })
-              return
-            }
+          if (staleness < 30_000 && req.body.force !== true) {
+            res.status(409).json({
+              ok: false,
+              error: 'Daemon is running. Stop it before restoring, or pass force: true to override.',
+              daemon_pid: heartbeat.pid,
+            })
+            return
           }
         }
       } catch {
-        // Cannot read runtime.db — fail closed unless force
         if (req.body.force !== true) {
           res.status(409).json({
             ok: false,
-            error: 'Cannot verify daemon status (runtime.db unreadable). Pass force: true to override.',
+            error: 'Could not verify daemon state. Stop the daemon first, or pass force: true to override.',
           })
           return
         }
       } finally {
-        try { checkDb?.close() } catch { /* best-effort */ }
+        try { checkDb?.close() } catch {}
       }
     }
 
-    // Ensure target directory exists (fresh install or deleted dir)
-    fs.mkdirSync(JARVIS_DIR, { recursive: true })
-
-    // Pre-restore snapshot: save current files for rollback
-    const rollbackDir = join(BACKUPS_DIR, `rollback-${Date.now()}`)
-    fs.mkdirSync(rollbackDir, { recursive: true })
-    for (const file of safeFiles) {
-      const currentPath = join(JARVIS_DIR, file.name)
-      if (fs.existsSync(currentPath)) {
-        fs.copyFileSync(currentPath, join(rollbackDir, file.name))
-      }
-    }
-
-    // Copy each safe file back to ~/.jarvis/
-    const restored: string[] = []
-    for (const file of safeFiles) {
-      const src = join(resolvedPath, file.name)
-      const dest = join(JARVIS_DIR, file.name)
-      fs.copyFileSync(src, dest)
-      restored.push(file.name)
-    }
-
-    // Post-restore health validation
-    const healthChecks: Array<{ name: string; ok: boolean; message: string }> = []
-    for (const dbName of ['runtime.db', 'crm.db', 'knowledge.db']) {
-      const dbPath = join(JARVIS_DIR, dbName)
-      if (!fs.existsSync(dbPath)) {
-        healthChecks.push({ name: dbName, ok: false, message: 'File missing after restore' })
-        continue
-      }
-      let healthDb: DatabaseSync | undefined
-      try {
-        healthDb = new DatabaseSync(dbPath)
-        const integrity = healthDb.prepare('PRAGMA integrity_check').get() as { integrity_check: string }
-        healthChecks.push({
-          name: dbName,
-          ok: integrity.integrity_check === 'ok',
-          message: integrity.integrity_check === 'ok' ? 'Integrity OK' : `Integrity failed: ${integrity.integrity_check}`,
-        })
-      } catch (e) {
-        healthChecks.push({ name: dbName, ok: false, message: e instanceof Error ? e.message : 'Cannot open' })
-      } finally {
-        try { healthDb?.close() } catch { /* best-effort */ }
-      }
-    }
-
-    const allHealthy = healthChecks.every(c => c.ok)
-
-    if (!allHealthy) {
-      // Attempt rollback from pre-restore snapshot
-      let rollbackOk = true
-      for (const file of safeFiles) {
-        const rollbackSrc = join(rollbackDir, file.name)
-        if (fs.existsSync(rollbackSrc)) {
-          try {
-            fs.copyFileSync(rollbackSrc, join(JARVIS_DIR, file.name))
-          } catch {
-            rollbackOk = false
-          }
-        }
-      }
-
-      const actor = getActor(req as AuthenticatedRequest)
-      writeAuditLog(actor.type, actor.id, 'backup.restore_rollback', 'backup', resolvedPath, {
-        reason: 'post_restore_health_failed',
-        rollback_ok: rollbackOk,
-      })
-
-      const rollbackStatus = rollbackOk
-        ? 'successful'
-        : 'partial — manual intervention may be needed. Check /api/safemode or /api/repair.'
-
-      res.status(500).json({
-        ok: false,
-        error: 'Restore failed health validation — rolled back to previous state',
-        health_checks: healthChecks,
-        rollback: rollbackStatus,
-        rollback_dir: rollbackDir,
-      })
-      return
-    }
-
-    // Cleanup rollback snapshot on success
-    try { fs.rmSync(rollbackDir, { recursive: true, force: true }) } catch { /* best effort */ }
+    const result = restoreBackupDirectory(resolvedPath)
 
     const actor = getActor(req as AuthenticatedRequest)
-    writeAuditLog(actor.type, actor.id, 'backup.restored', 'backup', resolvedPath, { restored, healthy: allHealthy })
+    writeAuditLog(actor.type, actor.id, 'backup.restored', 'backup', resolvedPath, {
+      files: result.restored,
+    })
 
-    res.json({ ok: true, restored, health_checks: healthChecks, healthy: allHealthy })
+    res.json({ ok: true, restored: result.restored })
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message === 'manifest.json not found in backup path') {
+      res.status(404).json({ ok: false, error: message })
+      return
+    }
+    if (message.startsWith('Missing files in backup:')) {
+      res.status(400).json({ ok: false, error: message })
+      return
+    }
     res.status(500).json({
       ok: false,
-      error: `Restore failed: ${err instanceof Error ? err.message : String(err)}`
+      error: `Restore failed: ${message}`,
     })
   }
 })

--- a/packages/jarvis-dashboard/src/api/middleware/auth.ts
+++ b/packages/jarvis-dashboard/src/api/middleware/auth.ts
@@ -14,6 +14,7 @@ import type { Request, Response, NextFunction } from "express";
 import { Router } from "express";
 import crypto from "node:crypto";
 import fs from "node:fs";
+import type { IncomingHttpHeaders } from "node:http";
 import os from "node:os";
 import { join } from "node:path";
 
@@ -81,6 +82,9 @@ const ROUTE_PERMISSIONS: Record<string, Record<string, UserRole>> = {
   // Agent triggers and webhooks require operator
   "/api/webhooks": { POST: "operator" },
 
+  // Starter packs can change the system safety posture and must remain admin-only.
+  "/api/packs": { GET: "viewer", POST: "admin" },
+
   // CRM mutations require operator
   "/api/crm": { GET: "viewer", POST: "operator", PATCH: "operator", DELETE: "admin" },
 
@@ -111,10 +115,10 @@ const ROUTE_PERMISSIONS: Record<string, Record<string, UserRole>> = {
   "/api/runs": { GET: "viewer" },
   "/api/entities": { GET: "viewer" },
   "/api/analytics": { GET: "viewer" },
-  // Chat POST is viewer-level so it works in tokenless dev mode.
-  // All dangerous tools (shell, email send, file write) have been removed
-  // from chat — it's read-only queries + agent triggers via the runtime kernel.
-  "/api/chat": { GET: "viewer", POST: "viewer" },
+  // Chat GET is safe to expose to viewers, but POST can reach sensitive
+  // read surfaces (host files, Gmail, browser fetches) and must require an
+  // authenticated operator even in dev mode.
+  "/api/chat": { GET: "viewer", POST: "operator" },
 };
 
 const ROLE_HIERARCHY: Record<UserRole, number> = {
@@ -131,7 +135,7 @@ function hasPermission(userRole: UserRole, requiredRole: UserRole): boolean {
  * Resolve the minimum role required for a given route and method.
  * Falls back to "viewer" for GET, "operator" for mutations.
  */
-function getRequiredRole(path: string, method: string): UserRole {
+export function getRequiredRole(path: string, method: string): UserRole {
   // Find matching route prefix
   for (const [prefix, perms] of Object.entries(ROUTE_PERMISSIONS)) {
     if (path.startsWith(prefix)) {
@@ -210,6 +214,37 @@ function isBlocked(ip: string): boolean {
   return false;
 }
 
+function loadWebhookSecret(): string | undefined {
+  const configPath = join(os.homedir(), ".jarvis", "config.json");
+  if (!fs.existsSync(configPath)) {
+    return undefined;
+  }
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    return typeof raw.webhook_secret === "string" && raw.webhook_secret.trim()
+      ? raw.webhook_secret
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function shouldBypassWebhookBearerAuth(
+  path: string,
+  method: string,
+  headers: IncomingHttpHeaders,
+  hasWebhookSecret: boolean,
+): boolean {
+  if (!hasWebhookSecret) {
+    return false;
+  }
+  if (method.toUpperCase() !== "POST" || !path.startsWith("/api/webhooks")) {
+    return false;
+  }
+  return typeof headers["x-hub-signature-256"] === "string" ||
+    typeof headers["x-jarvis-signature"] === "string";
+}
+
 // ─── Auth Middleware ─────────────────────────────────────────────────────
 
 /**
@@ -229,6 +264,11 @@ export function createAuthMiddleware() {
 
     // Non-API routes (SPA, static assets) don't need auth
     if (!req.path.startsWith("/api/")) {
+      next();
+      return;
+    }
+
+    if (shouldBypassWebhookBearerAuth(req.path, req.method, req.headers, Boolean(loadWebhookSecret()))) {
       next();
       return;
     }

--- a/packages/jarvis-dashboard/src/api/portal.ts
+++ b/packages/jarvis-dashboard/src/api/portal.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import fs from 'node:fs'
 import os from 'node:os'
-import { join } from 'node:path'
+import { basename, join, win32 } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 
 export const portalRouter = Router()
@@ -33,6 +33,89 @@ type PortalMilestone = {
   notes: string
 }
 
+type PortalDocumentRow = Record<string, unknown> & {
+  id?: unknown
+  title?: unknown
+  type?: unknown
+  source_path?: unknown
+  created_at?: unknown
+  content_size?: unknown
+  tags?: unknown
+  collection?: unknown
+}
+
+function normalizePortalValue(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function parsePortalTags(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string')
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+function safePortalBasename(sourcePath: string): string {
+  return sourcePath.includes('\\') ? win32.basename(sourcePath) : basename(sourcePath)
+}
+
+export function sanitizePortalFilePath(sourcePath: unknown, title: string, id: string): string {
+  if (typeof sourcePath === 'string' && sourcePath.trim()) {
+    return safePortalBasename(sourcePath.trim())
+  }
+  const trimmedTitle = title.trim()
+  return trimmedTitle || `${id}.document`
+}
+
+export function portalDocumentMatchesClient(row: PortalDocumentRow, client: PortalClient): boolean {
+  const clientId = normalizePortalValue(client.client_id)
+  const company = normalizePortalValue(client.company)
+  const exactMatches = new Set<string>([
+    clientId,
+    company,
+    `client:${clientId}`,
+    `client_id:${clientId}`,
+    `company:${company}`,
+  ])
+
+  const collection = typeof row.collection === 'string' ? normalizePortalValue(row.collection) : ''
+  if (collection && exactMatches.has(collection)) {
+    return true
+  }
+
+  return parsePortalTags(row.tags)
+    .map(normalizePortalValue)
+    .some(tag => exactMatches.has(tag))
+}
+
+function getDocumentsTableColumns(db: DatabaseSync): Set<string> {
+  const columns = db.prepare('PRAGMA table_info(documents)').all() as Array<{ name?: unknown }>
+  return new Set(
+    columns
+      .map(column => (typeof column.name === 'string' ? column.name : ''))
+      .filter(Boolean)
+  )
+}
+
+function selectDocumentColumn(columns: Set<string>, ...candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (columns.has(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
 // ── Auth middleware ───────────────────────────────────────────────────────────
 
 function portalAuth(
@@ -40,7 +123,8 @@ function portalAuth(
   res: import('express').Response,
   next: import('express').NextFunction,
 ): void {
-  const token = req.headers.authorization?.replace('Bearer ', '') ?? (req.query.token as string | undefined)
+  const authHeader = req.headers.authorization
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : undefined
 
   const tokensFile = join(os.homedir(), '.jarvis', 'portal-tokens.json')
   if (!fs.existsSync(tokensFile)) {
@@ -144,26 +228,53 @@ portalRouter.get('/documents', (req, res) => {
 
   try {
     const db = new DatabaseSync(join(os.homedir(), '.jarvis', 'knowledge.db'))
+    const columns = getDocumentsTableColumns(db)
+    const idColumn = selectDocumentColumn(columns, 'doc_id', 'id')
+    const createdAtColumn = selectDocumentColumn(columns, 'indexed_at', 'created_at', 'updated_at')
 
-    // Search documents tagged with client company or ID
+    if (!idColumn || !columns.has('title') || !createdAtColumn) {
+      db.close()
+      res.json({ documents: [], total: 0 })
+      return
+    }
+
+    const typeColumn = selectDocumentColumn(columns, 'doc_type')
+    const sourcePathColumn = selectDocumentColumn(columns, 'source_path')
+    const collectionColumn = selectDocumentColumn(columns, 'collection')
+    const tagsColumn = selectDocumentColumn(columns, 'tags')
+    const contentSizeExpression = columns.has('content') ? 'length(content)' : '0'
+
     const docs = db.prepare(
-      `SELECT id, title, doc_type as type, source_path as file_path, indexed_at as created_at, chunk_count
+      `SELECT ${idColumn} AS id,
+              title,
+              ${typeColumn ? `${typeColumn} AS type` : `'document' AS type`},
+              ${sourcePathColumn ? `${sourcePathColumn} AS source_path` : 'NULL AS source_path'},
+              ${createdAtColumn} AS created_at,
+              ${collectionColumn ? `${collectionColumn} AS collection` : 'NULL AS collection'},
+              ${tagsColumn ? `${tagsColumn} AS tags` : 'NULL AS tags'},
+              ${contentSizeExpression} AS content_size
        FROM documents
-       WHERE title LIKE ? OR source_path LIKE ?
-       ORDER BY indexed_at DESC
-       LIMIT 50`
-    ).all(`%${client.company}%`, `%${client.company}%`) as Array<Record<string, unknown>>
+       ORDER BY ${createdAtColumn} DESC
+       LIMIT 200`
+    ).all() as PortalDocumentRow[]
 
     db.close()
 
-    const documents: PortalDocument[] = docs.map(d => ({
-      id: d.id as string,
-      title: d.title as string,
-      type: d.type as string,
-      file_path: d.file_path as string,
-      created_at: d.created_at as string,
-      size_bytes: ((d.chunk_count as number) ?? 1) * 1024, // approximate
-    }))
+    const documents: PortalDocument[] = docs
+      .filter(doc => portalDocumentMatchesClient(doc, client))
+      .slice(0, 50)
+      .map(doc => {
+        const id = String(doc.id ?? '')
+        const title = String(doc.title ?? 'Document')
+        return {
+          id,
+          title,
+          type: typeof doc.type === 'string' && doc.type.trim() ? doc.type : 'document',
+          file_path: sanitizePortalFilePath(doc.source_path, title, id),
+          created_at: typeof doc.created_at === 'string' ? doc.created_at : new Date().toISOString(),
+          size_bytes: typeof doc.content_size === 'number' ? doc.content_size : 0,
+        }
+      })
 
     res.json({
       documents,

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -40,9 +40,11 @@ const indexHtml = join(distPath, 'index.html')
 // ─── Appliance Mode Checks ───────────────────────────────────────────────
 {
   let applianceMode = false
+  let configForAppliance: Record<string, unknown> | null = null
   try {
     const cfg = loadConfig()
     applianceMode = cfg.appliance_mode
+    configForAppliance = cfg as Record<string, unknown>
   } catch { /* config may not exist yet */ }
 
   if (applianceMode) {
@@ -50,11 +52,7 @@ const indexHtml = join(distPath, 'index.html')
 
     // Verify API tokens exist — check both env var AND config file
     const hasEnvToken = !!process.env.JARVIS_API_TOKEN
-    let hasConfigToken = false
-    try {
-      const cfgRaw = cfg as Record<string, unknown>
-      hasConfigToken = !!(cfgRaw.api_token || cfgRaw.api_tokens)
-    } catch { /* already loaded above */ }
+    const hasConfigToken = !!(configForAppliance?.api_token || configForAppliance?.api_tokens)
     if (!hasEnvToken && !hasConfigToken) {
       console.error('  FATAL: appliance_mode is enabled but no API token is configured.')
       console.error('  Set JARVIS_API_TOKEN env var or add api_token to ~/.jarvis/config.json.')
@@ -69,8 +67,15 @@ const indexHtml = join(distPath, 'index.html')
   }
 }
 
-// Request size limit
-app.use(express.json({ limit: '1mb' }))
+// Request size limit. Preserve the raw payload for signed webhook verification.
+app.use(express.json({
+  limit: '1mb',
+  verify: (req, _res, buf) => {
+    if (req.url?.startsWith('/api/webhooks')) {
+      ;(req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buf)
+    }
+  },
+}))
 app.use((req, _res, next) => {
   console.log(`[${req.method}] ${req.path}`)
   next()

--- a/packages/jarvis-dashboard/src/api/settings.ts
+++ b/packages/jarvis-dashboard/src/api/settings.ts
@@ -165,7 +165,7 @@ settingsRouter.post('/repair', (req, res) => {
   if (check === 'config' || check === 'all') {
     try {
       const config = readConfig()
-      const hasLms = typeof config.lmstudio_url === 'string'
+      const hasLms = typeof config.lmstudio_url === 'string' || typeof config.lm_studio_url === 'string'
       const hasMode = typeof config.adapter_mode === 'string'
       checks.push({ name: 'config', ok: hasLms && hasMode, message: hasLms && hasMode ? 'Config valid' : 'Missing lmstudio_url or adapter_mode' })
     } catch {
@@ -196,7 +196,7 @@ settingsRouter.post('/repair', (req, res) => {
   if (check === 'lmstudio' || check === 'all') {
     // Sync check — just verify config has a URL
     const config = readConfig()
-    const url = config.lmstudio_url as string | undefined
+    const url = (config.lmstudio_url as string | undefined) ?? (config.lm_studio_url as string | undefined)
     checks.push({ name: 'lmstudio', ok: !!url, message: url ? `LM Studio configured at ${url}` : 'No lmstudio_url in config' })
   }
 

--- a/packages/jarvis-dashboard/src/api/webhooks.ts
+++ b/packages/jarvis-dashboard/src/api/webhooks.ts
@@ -9,6 +9,10 @@ import { createCommand } from '@jarvis/runtime'
 
 const JARVIS_DIR = join(os.homedir(), '.jarvis')
 
+type RawBodyRequest = import('express').Request & {
+  rawBody?: Buffer
+}
+
 const GITHUB_EVENT_TO_AGENT: Record<string, string> = {
   push: 'evidence-auditor',
   pull_request: 'contract-reviewer',
@@ -31,6 +35,30 @@ function getDb(): DatabaseSync {
   db.exec("PRAGMA journal_mode = WAL;")
   db.exec("PRAGMA busy_timeout = 5000;")
   return db
+}
+
+function getSignedPayload(req: RawBodyRequest): Buffer {
+  if (req.rawBody) {
+    return req.rawBody
+  }
+  return Buffer.from(JSON.stringify(req.body ?? {}), 'utf8')
+}
+
+export function computeWebhookSignature(secret: string, payload: Buffer | string): string {
+  const hmac = crypto.createHmac('sha256', secret)
+  hmac.update(payload)
+  return 'sha256=' + hmac.digest('hex')
+}
+
+export function signaturesMatch(signature: string, expected: string): boolean {
+  const sigBuf = Buffer.from(signature)
+  const expBuf = Buffer.from(expected)
+  const maxLen = Math.max(sigBuf.length, expBuf.length)
+  const paddedSig = Buffer.alloc(maxLen)
+  const paddedExp = Buffer.alloc(maxLen)
+  sigBuf.copy(paddedSig)
+  expBuf.copy(paddedExp)
+  return sigBuf.length === expBuf.length && crypto.timingSafeEqual(paddedSig, paddedExp)
 }
 
 /**
@@ -70,21 +98,8 @@ webhookRouter.post('/github', (req, res) => {
   const secret = loadWebhookSecret()
 
   if (secret && signature) {
-    const hmac = crypto.createHmac('sha256', secret)
-    hmac.update(JSON.stringify(req.body))
-    const expected = 'sha256=' + hmac.digest('hex')
-
-    const sigBuf = Buffer.from(signature)
-    const expBuf = Buffer.from(expected)
-    // Pad both buffers to the same length to avoid leaking length information
-    const maxLen = Math.max(sigBuf.length, expBuf.length)
-    const paddedSig = Buffer.alloc(maxLen)
-    const paddedExp = Buffer.alloc(maxLen)
-    sigBuf.copy(paddedSig)
-    expBuf.copy(paddedExp)
-
-    if (sigBuf.length !== expBuf.length ||
-        !crypto.timingSafeEqual(paddedSig, paddedExp)) {
+    const expected = computeWebhookSignature(secret, getSignedPayload(req as RawBodyRequest))
+    if (!signaturesMatch(signature, expected)) {
       res.status(401).json({ error: 'Invalid signature' })
       return
     }
@@ -133,19 +148,8 @@ function validateHmac(req: import('express').Request, secret: string | undefined
   const signature = req.headers['x-jarvis-signature'] as string | undefined
   if (!signature) return false
 
-  const hmac = crypto.createHmac('sha256', secret)
-  hmac.update(JSON.stringify(req.body))
-  const expected = 'sha256=' + hmac.digest('hex')
-
-  const sigBuf = Buffer.from(signature)
-  const expBuf = Buffer.from(expected)
-  const maxLen = Math.max(sigBuf.length, expBuf.length)
-  const paddedSig = Buffer.alloc(maxLen)
-  const paddedExp = Buffer.alloc(maxLen)
-  sigBuf.copy(paddedSig)
-  expBuf.copy(paddedExp)
-
-  return sigBuf.length === expBuf.length && crypto.timingSafeEqual(paddedSig, paddedExp)
+  const expected = computeWebhookSignature(secret, getSignedPayload(req as RawBodyRequest))
+  return signaturesMatch(signature, expected)
 }
 
 // POST /api/webhooks/generic — generic JSON webhook

--- a/packages/jarvis-dashboard/src/ui/pages/Settings.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Settings.tsx
@@ -24,15 +24,33 @@ interface Model {
 }
 
 interface BackupStatus {
-  last_backup_at: string | null
-  last_backup_path: string | null
-  size_mb: number | null
+  last_backup?: string | null
+  last_backup_at?: string | null
+  path?: string | null
+  last_backup_path?: string | null
+  size?: number | null
+  size_mb?: number | null
 }
 
 interface RestartPolicy {
   max_retries: number
   restart_delay_ms: number
   description: string
+}
+
+interface IntegrationField {
+  key: string
+  label: string
+  help: string
+  sensitive?: boolean
+}
+
+interface IntegrationDefinition {
+  key: string
+  label: string
+  icon: string
+  description: string
+  fields: readonly IntegrationField[]
 }
 
 /* ── Constants ───────────────────────────────────────────── */
@@ -45,7 +63,7 @@ type SettingsTab = typeof TABS[number]
 
 const LOG_LEVELS = ['debug', 'info', 'warn', 'error']
 
-const INTEGRATIONS = [
+const INTEGRATIONS: readonly IntegrationDefinition[] = [
   {
     key: 'gmail', label: 'Gmail', icon: 'M',
     description: 'Email search, read, draft, and send via Gmail API.',
@@ -89,7 +107,7 @@ const INTEGRATIONS = [
       { key: 'redirect_uri', label: 'Redirect URI', help: 'Usually http://localhost:4242/auth/callback' },
     ],
   },
-] as const
+]
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -298,9 +316,19 @@ export default function Settings() {
 
   /* ── Derived ─────────────────────────────────────────────── */
 
-  const integrations = config.integrations as Record<string, Record<string, unknown>> | undefined
+  const legacyIntegrations = config.integrations as Record<string, Record<string, unknown>> | undefined
+  const integrations = Object.fromEntries(
+    INTEGRATIONS.map(integration => [
+      integration.key,
+      (config[integration.key] as Record<string, unknown> | undefined) ?? legacyIntegrations?.[integration.key] ?? {},
+    ])
+  ) as Record<string, Record<string, unknown>>
   const social = config.social as Record<string, unknown> | undefined
   const modelTiers = config.model_tiers as Record<string, string> | undefined
+  const backupDate = backupStatus?.last_backup_at ?? backupStatus?.last_backup ?? null
+  const backupPath = backupStatus?.last_backup_path ?? backupStatus?.path ?? null
+  const backupSizeMb = backupStatus?.size_mb
+    ?? (typeof backupStatus?.size === 'number' ? Number((backupStatus.size / (1024 * 1024)).toFixed(2)) : null)
 
   /* ── Loading ─────────────────────────────────────────────── */
 
@@ -363,8 +391,12 @@ export default function Settings() {
               <div>
                 <FieldLabel>LM Studio URL</FieldLabel>
                 <TextInput
-                  value={(config.lm_studio_url as string) ?? 'http://localhost:1234'}
-                  onChange={v => updateConfig('lm_studio_url', v)}
+                  value={(config.lmstudio_url as string) ?? (config.lm_studio_url as string) ?? 'http://localhost:1234'}
+                  onChange={v => setConfig(prev => {
+                    const next = { ...prev, lmstudio_url: v } as Record<string, unknown> & { lm_studio_url?: unknown }
+                    delete next.lm_studio_url
+                    return next
+                  })}
                   placeholder="http://localhost:1234"
                 />
               </div>
@@ -724,7 +756,7 @@ export default function Settings() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {INTEGRATIONS.map(integration => {
               const integrationConfig = integrations?.[integration.key] ?? {}
-              const isConfigured = Object.keys(integrationConfig).length > 0
+              const isConfigured = Object.values(integrationConfig).some(value => String(value ?? '').trim().length > 0)
               const isEditing = editingIntegration === integration.key
               return (
                 <DataCard key={integration.key}>
@@ -785,12 +817,13 @@ export default function Settings() {
                             type={field.sensitive ? 'password' : 'text'}
                             value={String(integrationConfig[field.key] ?? '')}
                             onChange={e => {
-                              const current = (config.integrations ?? {}) as Record<string, Record<string, unknown>>
-                              const updated = {
-                                ...current,
-                                [integration.key]: { ...(current[integration.key] ?? {}), [field.key]: e.target.value },
-                              }
-                              setConfig(prev => ({ ...prev, integrations: updated }))
+                              setConfig(prev => ({
+                                ...prev,
+                                [integration.key]: {
+                                  ...((prev[integration.key] as Record<string, unknown> | undefined) ?? {}),
+                                  [field.key]: e.target.value,
+                                },
+                              }))
                             }}
                             placeholder={field.help}
                             className="w-full text-xs bg-slate-800 border border-slate-700 rounded-lg px-3 py-2.5 text-slate-300 placeholder-slate-600 focus:outline-none focus:border-indigo-500 font-mono transition-colors"
@@ -825,23 +858,23 @@ export default function Settings() {
                   <div className="flex items-center justify-between">
                     <span className="text-xs text-slate-500">Date</span>
                     <span className="text-sm text-slate-300">
-                      {backupStatus.last_backup_at
-                        ? new Date(backupStatus.last_backup_at).toLocaleString()
+                      {backupDate
+                        ? new Date(backupDate).toLocaleString()
                         : 'Never'}
                     </span>
                   </div>
-                  {backupStatus.last_backup_path && (
+                  {backupPath && (
                     <div className="flex items-center justify-between">
                       <span className="text-xs text-slate-500">Path</span>
                       <span className="text-xs text-slate-400 font-mono truncate max-w-[300px]">
-                        {backupStatus.last_backup_path}
+                        {backupPath}
                       </span>
                     </div>
                   )}
-                  {backupStatus.size_mb != null && (
+                  {backupSizeMb != null && (
                     <div className="flex items-center justify-between">
                       <span className="text-xs text-slate-500">Size</span>
-                      <span className="text-sm text-slate-300">{backupStatus.size_mb} MB</span>
+                      <span className="text-sm text-slate-300">{backupSizeMb} MB</span>
                     </div>
                   )}
                 </>
@@ -880,14 +913,14 @@ export default function Settings() {
           <DataCard>
             <SectionTitle>Restore from Backup</SectionTitle>
             <p className="text-xs text-slate-500 mt-1 mb-3">
-              Provide the path to a backup file to restore. This will overwrite current state.
+              Provide the path to a backup directory to restore. This will overwrite current state.
             </p>
             <div className="flex gap-3">
               <div className="flex-1">
                 <TextInput
                   value={restorePath}
                   onChange={setRestorePath}
-                  placeholder="/path/to/backup.tar.gz"
+                  placeholder="/path/to/backup-directory"
                 />
               </div>
               <button
@@ -905,7 +938,7 @@ export default function Settings() {
                       try {
                         await apiFetch('/api/backup/restore', {
                           method: 'POST',
-                          body: { path: restorePath },
+                          body: { backup_path: restorePath },
                         })
                         setRestorePath('')
                         fetchData()

--- a/packages/jarvis-dashboard/tsconfig.json
+++ b/packages/jarvis-dashboard/tsconfig.json
@@ -10,6 +10,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowImportingTsExtensions": true,
+    "composite": true,
     "noEmit": true,
     "types": ["node"]
   },

--- a/packages/jarvis-files/src/index.ts
+++ b/packages/jarvis-files/src/index.ts
@@ -43,6 +43,8 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
 /** Maximum number of entries returned during a recursive directory listing. */
 const MAX_RECURSIVE_ENTRIES = 10_000;
+const FILES_ROOT_ENV = "JARVIS_FILES_ROOT";
+const APPROVAL_TTL_MS = 10 * 60 * 1000;
 
 type FileEncoding = "utf8" | "base64";
 
@@ -125,6 +127,14 @@ type ToolResultPayload = ToolResponse & {
   structured_output?: Record<string, unknown>;
 };
 
+type PendingApproval = {
+  operation: string;
+  fingerprint: string;
+  createdAt: number;
+};
+
+const pendingApprovals = new Map<string, PendingApproval>();
+
 function asLiteralUnion<const Values extends readonly [string, ...string[]]>(
   values: Values,
 ) {
@@ -149,8 +159,36 @@ function createFilesTool(
   };
 }
 
+function cleanupExpiredApprovals(now = Date.now()): void {
+  for (const [approvalId, record] of pendingApprovals.entries()) {
+    if (now - record.createdAt > APPROVAL_TTL_MS) {
+      pendingApprovals.delete(approvalId);
+    }
+  }
+}
+
+function getConfiguredApprovedRoot(): string {
+  return resolve(process.env[FILES_ROOT_ENV]?.trim() || process.cwd());
+}
+
 function normalizeRoot(rootPath?: string): string {
-  return resolve(rootPath?.trim() || process.cwd());
+  const approvedRoot = getConfiguredApprovedRoot();
+  const requestedRoot = rootPath?.trim();
+
+  if (!requestedRoot) {
+    return approvedRoot;
+  }
+
+  const candidateRoot = isAbsolute(requestedRoot)
+    ? resolve(requestedRoot)
+    : resolve(approvedRoot, requestedRoot);
+  const relativePath = relative(approvedRoot, candidateRoot);
+
+  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) {
+    return candidateRoot;
+  }
+
+  throw new Error(`Requested root escapes configured approved root: ${rootPath}`);
 }
 
 function assertPathWithinRoot(rootPath: string, candidatePath: string): string {
@@ -176,17 +214,54 @@ function writeText(filePath: string, content: string, encoding: FileEncoding = "
   writeFileSync(filePath, content, encoding);
 }
 
-function approvalRequired(operation: string, target: string): ToolResultPayload {
+function createApprovalFingerprint(operation: string, payload: Record<string, unknown>): string {
+  return JSON.stringify({ operation, ...payload });
+}
+
+function approvalRequired(operation: string, target: string, fingerprint: string): ToolResultPayload {
+  cleanupExpiredApprovals();
+  const approvalId = randomUUID();
+  pendingApprovals.set(approvalId, {
+    operation,
+    fingerprint,
+    createdAt: Date.now()
+  });
   return createToolResponse({
     status: "awaiting_approval",
     summary: `Approval required before ${operation} ${target}.`,
-    approval_id: randomUUID(),
+    approval_id: approvalId,
     structured_output: {
       approval_required: true,
       operation,
-      target
+      target,
+      approved_root: getConfiguredApprovedRoot()
     }
   });
+}
+
+function requireApprovalMatch(
+  operation: string,
+  approvalId: string | undefined,
+  target: string,
+  fingerprint: string,
+): ToolResultPayload | null {
+  const normalizedApprovalId = approvalId?.trim();
+  if (!normalizedApprovalId) {
+    return approvalRequired(operation, target, fingerprint);
+  }
+
+  cleanupExpiredApprovals();
+  const record = pendingApprovals.get(normalizedApprovalId);
+  if (!record || record.operation !== operation || record.fingerprint !== fingerprint) {
+    return failure(
+      "INVALID_APPROVAL",
+      `Approval id is missing, expired, or does not match the pending ${operation} request.`,
+      "approvalId",
+    );
+  }
+
+  pendingApprovals.delete(normalizedApprovalId);
+  return null;
 }
 
 function success(
@@ -413,16 +488,29 @@ function searchFiles(params: FilesSearchParams): ToolResultPayload {
 }
 
 function writeFile(params: FilesWriteParams): ToolResultPayload {
-  const approval = params.approvalId?.trim();
-  if (!approval) {
-    return approvalRequired("write", params.path);
-  }
-
   const rootPath = normalizeRoot(params.rootPath);
   const filePath = assertPathWithinRoot(rootPath, params.path);
+  const normalizedPath = relative(rootPath, filePath) || ".";
   if (existsSync(filePath) && params.overwrite === false) {
     return failure("FILE_EXISTS", `File already exists: ${params.path}.`, "path");
   }
+  const approval = requireApprovalMatch(
+    "write",
+    params.approvalId,
+    normalizedPath,
+    createApprovalFingerprint("write", {
+      root_path: rootPath,
+      path: normalizedPath,
+      content: params.content,
+      encoding: params.encoding ?? "utf8",
+      create_directories: params.createDirectories !== false,
+      overwrite: params.overwrite !== false
+    }),
+  );
+  if (approval) {
+    return approval;
+  }
+
   if (params.createDirectories !== false) {
     maybeCreateDirectory(filePath);
   }
@@ -440,15 +528,26 @@ function writeFile(params: FilesWriteParams): ToolResultPayload {
 }
 
 function patchFile(params: FilesPatchParams): ToolResultPayload {
-  const approval = params.approvalId?.trim();
-  if (!approval) {
-    return approvalRequired("patch", params.path);
-  }
-
   const rootPath = normalizeRoot(params.rootPath);
   const filePath = assertPathWithinRoot(rootPath, params.path);
+  const normalizedPath = relative(rootPath, filePath) || ".";
   if (!existsSync(filePath)) {
     return failure("FILE_NOT_FOUND", `File not found: ${params.path}.`, "path");
+  }
+  const approval = requireApprovalMatch(
+    "patch",
+    params.approvalId,
+    normalizedPath,
+    createApprovalFingerprint("patch", {
+      root_path: rootPath,
+      path: normalizedPath,
+      operations: params.operations,
+      encoding: params.encoding ?? "utf8",
+      create_directories: params.createDirectories === true
+    }),
+  );
+  if (approval) {
+    return approval;
   }
   if (params.createDirectories) {
     maybeCreateDirectory(filePath);
@@ -487,14 +586,11 @@ function patchFile(params: FilesPatchParams): ToolResultPayload {
 }
 
 function copyFile(params: FilesCopyParams): ToolResultPayload {
-  const approval = params.approvalId?.trim();
-  if (!approval) {
-    return approvalRequired("copy", `${params.sourcePath} -> ${params.destinationPath}`);
-  }
-
   const rootPath = normalizeRoot(params.rootPath);
   const sourcePath = assertPathWithinRoot(rootPath, params.sourcePath);
   const destinationPath = assertPathWithinRoot(rootPath, params.destinationPath);
+  const normalizedSource = relative(rootPath, sourcePath) || ".";
+  const normalizedDestination = relative(rootPath, destinationPath) || ".";
   if (!existsSync(sourcePath)) {
     return failure("FILE_NOT_FOUND", `Source file not found: ${params.sourcePath}.`, "sourcePath");
   }
@@ -504,6 +600,21 @@ function copyFile(params: FilesCopyParams): ToolResultPayload {
       `Destination already exists: ${params.destinationPath}.`,
       "destinationPath",
     );
+  }
+  const approval = requireApprovalMatch(
+    "copy",
+    params.approvalId,
+    `${normalizedSource} -> ${normalizedDestination}`,
+    createApprovalFingerprint("copy", {
+      root_path: rootPath,
+      source_path: normalizedSource,
+      destination_path: normalizedDestination,
+      create_directories: params.createDirectories !== false,
+      overwrite: params.overwrite === true
+    }),
+  );
+  if (approval) {
+    return approval;
   }
   if (params.createDirectories !== false) {
     maybeCreateDirectory(destinationPath);
@@ -522,14 +633,11 @@ function copyFile(params: FilesCopyParams): ToolResultPayload {
 }
 
 function moveFile(params: FilesMoveParams): ToolResultPayload {
-  const approval = params.approvalId?.trim();
-  if (!approval) {
-    return approvalRequired("move", `${params.sourcePath} -> ${params.destinationPath}`);
-  }
-
   const rootPath = normalizeRoot(params.rootPath);
   const sourcePath = assertPathWithinRoot(rootPath, params.sourcePath);
   const destinationPath = assertPathWithinRoot(rootPath, params.destinationPath);
+  const normalizedSource = relative(rootPath, sourcePath) || ".";
+  const normalizedDestination = relative(rootPath, destinationPath) || ".";
   if (!existsSync(sourcePath)) {
     return failure("FILE_NOT_FOUND", `Source file not found: ${params.sourcePath}.`, "sourcePath");
   }
@@ -539,6 +647,21 @@ function moveFile(params: FilesMoveParams): ToolResultPayload {
       `Destination already exists: ${params.destinationPath}.`,
       "destinationPath",
     );
+  }
+  const approval = requireApprovalMatch(
+    "move",
+    params.approvalId,
+    `${normalizedSource} -> ${normalizedDestination}`,
+    createApprovalFingerprint("move", {
+      root_path: rootPath,
+      source_path: normalizedSource,
+      destination_path: normalizedDestination,
+      create_directories: params.createDirectories !== false,
+      overwrite: params.overwrite === true
+    }),
+  );
+  if (approval) {
+    return approval;
   }
   if (params.createDirectories !== false) {
     maybeCreateDirectory(destinationPath);

--- a/packages/jarvis-jobs/src/index.ts
+++ b/packages/jarvis-jobs/src/index.ts
@@ -266,7 +266,9 @@ function isWorkerCallback(value: Record<string, unknown>): value is WorkerCallba
     typeof value.attempt === "number" &&
     typeof value.status === "string" &&
     typeof value.summary === "string" &&
-    typeof value.worker_id === "string"
+    typeof value.worker_id === "string" &&
+    typeof value.claim_id === "string" &&
+    value.claim_id.trim().length > 0
   );
 }
 
@@ -548,6 +550,13 @@ export async function handleJobsCallback(
 
     if (message.startsWith("Unknown job ")) {
       return sendJson(res, 404, {
+        ok: false,
+        error: message
+      });
+    }
+
+    if (message.startsWith("Callback rejected for job ")) {
+      return sendJson(res, 409, {
         ok: false,
         error: message
       });

--- a/packages/jarvis-runtime/src/config.ts
+++ b/packages/jarvis-runtime/src/config.ts
@@ -140,7 +140,12 @@ export function loadConfig(): JarvisRuntimeConfig {
 
   const config: JarvisRuntimeConfig = {
     ...defaults,
-    lmstudio_url: typeof raw.lmstudio_url === "string" ? raw.lmstudio_url : defaults.lmstudio_url,
+    lmstudio_url:
+      typeof raw.lmstudio_url === "string"
+        ? raw.lmstudio_url
+        : typeof raw.lm_studio_url === "string"
+          ? raw.lm_studio_url
+          : defaults.lmstudio_url,
     default_model: typeof raw.default_model === "string" ? raw.default_model : defaults.default_model,
     adapter_mode: raw.adapter_mode === "mock" || raw.adapter_mode === "real" ? raw.adapter_mode : defaults.adapter_mode,
     poll_interval_ms: typeof raw.poll_interval_ms === "number" ? raw.poll_interval_ms : defaults.poll_interval_ms,

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { AgentDefinition, AgentTrigger, AgentRun, AgentRunStatus } from "@jarvis/agent-framework";
+import { ALL_AGENTS } from "@jarvis/agents";
 import { AgentRuntime, SqliteKnowledgeStore, LessonCapture } from "@jarvis/agent-framework";
 import { SqliteEntityGraph } from "@jarvis/agent-framework";
 import { SqliteDecisionLog } from "@jarvis/agent-framework";
@@ -12,7 +13,7 @@ import { writeTelegramQueue } from "./notify.js";
 import { RunStore } from "./run-store.js";
 import { isReadOnlyAction } from "./action-classifier.js";
 import { classifyDisagreement, shouldBlockExecution, shouldFlagForReview, DEFAULT_DISAGREEMENT_POLICY } from "./disagreement-policy.js";
-import { isActionPermitted, type PluginPermission } from "./plugin-loader.js";
+import { isActionPermitted, loadPlugins, type PluginPermission } from "./plugin-loader.js";
 import type { ChannelStore } from "./channel-store.js";
 import type { RagPipeline } from "./rag-pipeline.js";
 import type { Logger } from "./logger.js";
@@ -346,6 +347,7 @@ export async function runAgent(
 
       // ── Maturity-based approval gates ──
       const gate = resolveApprovalGate(def, step.action);
+      let envelopeApprovalState: "approved" | "not_required" = "not_required";
 
       if (gate && runtimeDb) {
         stepLog.info(`Approval required (${gate.severity}, ${gate.source})`);
@@ -370,13 +372,13 @@ export async function runAgent(
 
         const decision = await waitForApproval(runtimeDb, approvalId, 4 * 60 * 60 * 1000); // 4h timeout
 
-        // Emit approval_resolved event
-        runStore?.emitEvent(run.run_id, agentId, "approval_resolved", {
-          step_no: step.step, action: step.action,
-          details: { decision },
-        });
-
         if (decision === "rejected") {
+          run.status = "executing";
+          run.updated_at = new Date().toISOString();
+          runStore?.transition(run.run_id, agentId, "executing", "approval_resolved", {
+            step_no: step.step, action: step.action,
+            details: { decision },
+          });
           stepLog.info("Rejected — skipping");
           decisionLog.logDecision({
             agent_id: agentId, run_id: run.run_id, step: step.step,
@@ -404,9 +406,14 @@ export async function runAgent(
 
         run.status = "executing";
         run.updated_at = new Date().toISOString();
-        runStore?.transition(run.run_id, agentId, "executing", "step_started", {
+        runStore?.transition(run.run_id, agentId, "executing", "approval_resolved", {
+          step_no: step.step, action: step.action,
+          details: { decision },
+        });
+        runStore?.emitEvent(run.run_id, agentId, "step_started", {
           step_no: step.step, action: step.action,
         });
+        envelopeApprovalState = "approved";
         stepLog.info("Approved — executing");
       }
 
@@ -415,6 +422,8 @@ export async function runAgent(
         ...step.input,
         _agent_id: agentId,
         _run_id: run.run_id,
+      }, {
+        approval_state: envelopeApprovalState,
       });
 
       try {
@@ -624,28 +633,50 @@ function resolveApprovalGate(def: AgentDefinition, action: string): ResolvedGate
  * Returns null for built-in agents (no permission restrictions).
  * Returns empty array on error — fail closed (deny all actions).
  */
-function loadPluginPermissions(agentId: string, runtimeDb?: DatabaseSync): PluginPermission[] | null {
-  if (!runtimeDb) return null;
-
-  // Plugin agents typically have IDs starting with "plugin-"
+export function loadPluginPermissions(agentId: string, runtimeDb?: DatabaseSync): PluginPermission[] | null {
+  const builtinAgentIds = new Set(ALL_AGENTS.map((agent) => agent.agent_id));
   const pluginId = agentId.startsWith("plugin-") ? agentId.slice(7) : agentId;
 
-  try {
-    const row = runtimeDb.prepare(
-      "SELECT manifest_json FROM plugin_installs WHERE plugin_id = ? AND status = 'active'",
-    ).get(pluginId) as { manifest_json: string } | undefined;
-
-    // No plugin install record → not a plugin agent → no restrictions
-    if (!row?.manifest_json) return null;
-
-    const manifest = JSON.parse(row.manifest_json) as { permissions?: string[] };
-    // Plugin found but no permissions declared → deny all (fail closed)
+  const parsePermissions = (manifestJson: string): PluginPermission[] => {
+    const manifest = JSON.parse(manifestJson) as { permissions?: string[] };
     return (manifest.permissions as PluginPermission[]) ?? [];
+  };
+
+  if (runtimeDb) {
+    try {
+      const row = runtimeDb.prepare(
+        "SELECT manifest_json FROM plugin_installs WHERE plugin_id = ? AND status = 'active'",
+      ).get(pluginId) as { manifest_json: string } | undefined;
+
+      if (row?.manifest_json) {
+        return parsePermissions(row.manifest_json);
+      }
+    } catch {
+      // Fall back to the on-disk manifest below. If neither source confirms
+      // the agent is built-in, we still fail closed.
+    }
+  }
+
+  try {
+    const pluginManifest = loadPlugins().find((manifest) =>
+      manifest.agent.agent_id === agentId ||
+      manifest.id === pluginId ||
+      `plugin-${manifest.id}` === agentId,
+    );
+    if (pluginManifest) {
+      return (pluginManifest.permissions as PluginPermission[]) ?? [];
+    }
   } catch {
-    // Parse error on a known plugin → fail closed, deny all actions.
-    // Returning null would mean "unrestricted" which is unsafe for plugins.
+    if (!builtinAgentIds.has(agentId)) {
+      return [];
+    }
+  }
+
+  if (!builtinAgentIds.has(agentId)) {
     return [];
   }
+
+  return null;
 }
 
 /** Gather context from knowledge store + entity graph + RAG pipeline for the planner */

--- a/packages/jarvis-runtime/src/plugin-loader.ts
+++ b/packages/jarvis-runtime/src/plugin-loader.ts
@@ -239,7 +239,7 @@ export function deriveRequiredPermissions(capabilities: string[]): PluginPermiss
  * Fails closed: unknown/unmapped action families are denied.
  */
 export function isActionPermitted(action: string, grantedPermissions: PluginPermission[]): boolean {
-  const prefix = action.split(".")[0];
+  const prefix = action.split(".")[0] ?? action;
   const required = CAPABILITY_PERMISSION_MAP[prefix];
   if (!required) return false; // Unknown prefix — deny (fail closed)
   return grantedPermissions.includes(required);

--- a/packages/jarvis-runtime/src/run-store.ts
+++ b/packages/jarvis-runtime/src/run-store.ts
@@ -93,17 +93,6 @@ export class RunStore {
     eventType: RunEventType,
     payload?: { step_no?: number; action?: string; details?: Record<string, unknown> },
   ): void {
-    // Read current status from DB (outside transaction — read-only)
-    const currentStatus = this.getStatus(runId);
-    if (currentStatus) {
-      const allowed = VALID_TRANSITIONS[currentStatus];
-      if (allowed && !allowed.includes(newStatus)) {
-        throw new Error(
-          `Invalid run transition: ${currentStatus} -> ${newStatus} (run ${runId})`,
-        );
-      }
-    }
-
     const completedAt = (newStatus === "completed" || newStatus === "failed" || newStatus === "cancelled")
       ? new Date().toISOString()
       : null;
@@ -112,17 +101,40 @@ export class RunStore {
     // Atomic: status update + event emission
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      this.db.prepare(`
+      const row = this.db.prepare(
+        "SELECT status FROM runs WHERE run_id = ?",
+      ).get(runId) as { status: RunStatus } | undefined;
+
+      if (!row) {
+        throw new Error(`Unknown run ${runId}`);
+      }
+
+      const currentStatus = row.status;
+      const allowed = VALID_TRANSITIONS[currentStatus];
+      if (allowed && !allowed.includes(newStatus)) {
+        throw new Error(
+          `Invalid run transition: ${currentStatus} -> ${newStatus} (run ${runId})`,
+        );
+      }
+
+      const updateResult = this.db.prepare(`
         UPDATE runs SET status = ?, completed_at = COALESCE(?, completed_at),
           error = COALESCE(?, error), current_step = COALESCE(?, current_step)
-        WHERE run_id = ?
+        WHERE run_id = ? AND status = ?
       `).run(
         newStatus,
         completedAt,
         error ? String(error) : null,
         payload?.step_no ?? null,
         runId,
+        currentStatus,
       );
+
+      if ((updateResult as { changes?: number }).changes !== 1) {
+        throw new Error(
+          `Concurrent run transition rejected: ${currentStatus} -> ${newStatus} (run ${runId})`,
+        );
+      }
 
       this.db.prepare(`
         INSERT INTO run_events (event_id, run_id, agent_id, event_type, step_no, action, payload_json, created_at)

--- a/packages/jarvis-runtime/src/worker-registry.ts
+++ b/packages/jarvis-runtime/src/worker-registry.ts
@@ -266,7 +266,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
 
   return {
     async executeJob(envelope: JobEnvelope): Promise<JobResult> {
-      const prefix = envelope.type.split(".")[0];
+      const prefix = envelope.type.split(".")[0] ?? envelope.type;
       const worker = workers.get(prefix);
       const failedResult = (code: string, message: string): JobResult => ({
         contract_version: "jarvis.v1",
@@ -286,7 +286,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
       // ── Approval guard ──
       // Defense-in-depth: reject jobs that require approval but haven't been approved.
       // The orchestrator is the primary approval enforcer, but this catches edge cases.
-      const policy = getExecutionPolicy(prefix!);
+      const policy = getExecutionPolicy(prefix);
       if (policy?.requires_approval_guard) {
         const { JOB_APPROVAL_REQUIREMENT } = await import("@jarvis/shared");
         const requirement = JOB_APPROVAL_REQUIREMENT[envelope.type];
@@ -312,7 +312,7 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
         const durationMs = Date.now() - startTime;
 
         // Record health
-        healthMonitor?.recordExecution(prefix!, durationMs, result.status === "completed");
+        healthMonitor?.recordExecution(prefix, durationMs, result.status === "completed");
 
         logger.debug(`Result: ${result.status}`, { job_id: envelope.job_id, duration_ms: durationMs, summary: result.summary.slice(0, 100) });
         return result;
@@ -322,13 +322,13 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
         const isTimeout = errMsg.includes("EXECUTION_TIMEOUT");
 
         if (isTimeout) {
-          healthMonitor?.recordTimeout(prefix!);
+          healthMonitor?.recordTimeout(prefix);
           logger.warn(`Execution timeout: ${envelope.type} after ${timeoutMs}ms`, { job_id: envelope.job_id });
           return failedResult("EXECUTION_TIMEOUT", `${envelope.type} timed out after ${Math.round(timeoutMs / 1000)}s`);
         }
 
         // Error boundary: catch worker crashes without killing the daemon
-        healthMonitor?.recordExecution(prefix!, durationMs, false);
+        healthMonitor?.recordExecution(prefix, durationMs, false);
         logger.error(`Worker crash: ${envelope.type}: ${errMsg}`, { job_id: envelope.job_id });
         return failedResult("WORKER_CRASH", errMsg);
       }
@@ -344,23 +344,38 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   };
 }
 
+type BuildEnvelopeOverrides = Partial<
+  Pick<
+    JobEnvelope,
+    "session_key" | "requested_by" | "priority" | "approval_state" |
+    "timeout_seconds" | "attempt" | "artifacts_in"
+  >
+> & {
+  metadata?: Partial<JobEnvelope["metadata"]>;
+};
+
 /** Build a minimal valid JobEnvelope for a given job type */
-export function buildEnvelope(type: string, input: Record<string, unknown>): JobEnvelope {
+export function buildEnvelope(
+  type: string,
+  input: Record<string, unknown>,
+  overrides: BuildEnvelopeOverrides = {},
+): JobEnvelope {
   return {
     contract_version: "jarvis.v1",
     job_id: randomUUID(),
     type: type as JarvisJobType,
-    session_key: `daemon-${Date.now()}`,
-    requested_by: { source: "agent", agent_id: "daemon" },
-    priority: "normal",
-    approval_state: "not_required",
-    timeout_seconds: JOB_TIMEOUT_SECONDS[type as JarvisJobType] ?? 120,
-    attempt: 1,
+    session_key: overrides.session_key ?? `daemon-${Date.now()}`,
+    requested_by: overrides.requested_by ?? { channel: "agent", user_id: "daemon" },
+    priority: overrides.priority ?? "normal",
+    approval_state: overrides.approval_state ?? "not_required",
+    timeout_seconds: overrides.timeout_seconds ?? (JOB_TIMEOUT_SECONDS[type as JarvisJobType] ?? 120),
+    attempt: overrides.attempt ?? 1,
     input,
-    artifacts_in: [],
+    artifacts_in: overrides.artifacts_in ?? [],
     metadata: {
       agent_id: "daemon",
       thread_key: null,
+      ...overrides.metadata,
     },
   };
 }

--- a/packages/jarvis-runtime/tsconfig.json
+++ b/packages/jarvis-runtime/tsconfig.json
@@ -16,6 +16,16 @@
     { "path": "../jarvis-crm-worker" },
     { "path": "../jarvis-web-worker" },
     { "path": "../jarvis-calendar-worker" },
+    { "path": "../jarvis-desktop-host-worker" },
+    { "path": "../jarvis-browser-worker" },
+    { "path": "../jarvis-social-worker" },
+    { "path": "../jarvis-system-worker" },
+    { "path": "../jarvis-office-worker" },
+    { "path": "../jarvis-interpreter-worker" },
+    { "path": "../jarvis-voice-worker" },
+    { "path": "../jarvis-security-worker" },
+    { "path": "../jarvis-time-worker" },
+    { "path": "../jarvis-drive-worker" },
     { "path": "../jarvis-scheduler" }
   ]
 }

--- a/packages/jarvis-security-worker/src/firewall.ts
+++ b/packages/jarvis-security-worker/src/firewall.ts
@@ -4,6 +4,55 @@ export type CommandRunner = {
   exec(cmd: string): Promise<{ stdout: string; stderr: string }>;
 };
 
+const SAFE_RULE_NAME = /^[A-Za-z0-9 _().:\\/-]{1,120}$/;
+const UNSAFE_PROGRAM_CHARS = /["'`&|<>^%!$\r\n]/;
+
+function validateDirection(direction: string | undefined): "inbound" | "outbound" {
+  if (direction === undefined || direction === "inbound" || direction === "outbound") {
+    return direction ?? "inbound";
+  }
+  throw new Error(`Unsupported firewall direction: ${direction}`);
+}
+
+function validateProtocol(protocol: string | undefined): "tcp" | "udp" {
+  if (protocol === undefined || protocol === "tcp" || protocol === "udp") {
+    return protocol ?? "tcp";
+  }
+  throw new Error(`Unsupported firewall protocol: ${protocol}`);
+}
+
+function validatePort(port: number | undefined): number | undefined {
+  if (port === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Unsupported firewall port: ${port}`);
+  }
+  return port;
+}
+
+function validateRuleName(ruleName: string): string {
+  const trimmed = ruleName.trim();
+  if (!SAFE_RULE_NAME.test(trimmed)) {
+    throw new Error("Firewall rule name contains unsupported characters.");
+  }
+  return trimmed;
+}
+
+function validateProgramPath(program: string | undefined): string | undefined {
+  if (program === undefined) {
+    return undefined;
+  }
+  const trimmed = program.trim();
+  if (!trimmed) {
+    throw new Error("Firewall program path must not be empty.");
+  }
+  if (UNSAFE_PROGRAM_CHARS.test(trimmed)) {
+    throw new Error("Firewall program path contains unsupported characters.");
+  }
+  return trimmed;
+}
+
 /**
  * Adds a Windows Firewall rule via netsh.
  */
@@ -11,20 +60,22 @@ export async function addFirewallRule(
   runner: CommandRunner,
   input: SecurityFirewallRuleInput,
 ): Promise<{ success: boolean; message: string }> {
-  const ruleName = input.rule_name ?? `Jarvis-Security-${Date.now()}`;
-  const dir = input.direction ?? "inbound";
-  const proto = input.protocol ?? "tcp";
-
-  let cmd = `netsh advfirewall firewall add rule name="${ruleName}" dir=${dir} action=block protocol=${proto}`;
-  if (input.port !== undefined) {
-    cmd += ` localport=${input.port}`;
-  }
-  if (input.program) {
-    cmd += ` program="${input.program}"`;
-  }
-  cmd += " enable=yes";
-
   try {
+    const ruleName = validateRuleName(input.rule_name ?? `Jarvis-Security-${Date.now()}`);
+    const dir = validateDirection(input.direction);
+    const proto = validateProtocol(input.protocol);
+    const port = validatePort(input.port);
+    const program = validateProgramPath(input.program);
+
+    let cmd = `netsh advfirewall firewall add rule name="${ruleName}" dir=${dir} action=block protocol=${proto}`;
+    if (port !== undefined) {
+      cmd += ` localport=${port}`;
+    }
+    if (program) {
+      cmd += ` program="${program}"`;
+    }
+    cmd += " enable=yes";
+
     const { stdout, stderr } = await runner.exec(cmd);
     const success = stdout.toLowerCase().includes("ok") || !stderr.trim();
     return {
@@ -46,13 +97,14 @@ export async function removeFirewallRule(
   runner: CommandRunner,
   ruleName: string,
 ): Promise<{ success: boolean; message: string }> {
-  const cmd = `netsh advfirewall firewall delete rule name="${ruleName}"`;
   try {
+    const safeRuleName = validateRuleName(ruleName);
+    const cmd = `netsh advfirewall firewall delete rule name="${safeRuleName}"`;
     const { stdout, stderr } = await runner.exec(cmd);
     const success = stdout.toLowerCase().includes("deleted") || stdout.toLowerCase().includes("ok") || !stderr.trim();
     return {
       success,
-      message: success ? `Firewall rule '${ruleName}' removed.` : (stderr.trim() || "Unknown error")
+      message: success ? `Firewall rule '${safeRuleName}' removed.` : (stderr.trim() || "Unknown error")
     };
   } catch (error) {
     return {

--- a/packages/jarvis-shared/src/state.ts
+++ b/packages/jarvis-shared/src/state.ts
@@ -215,7 +215,7 @@ function isJobClaimable(record: JobRecord, routes: string[], runGroup?: string):
       ? record.envelope.metadata.run_group
       : undefined;
 
-  if (requiredRunGroup && runGroup && requiredRunGroup !== runGroup) {
+  if (requiredRunGroup && requiredRunGroup !== runGroup) {
     return false;
   }
 
@@ -729,6 +729,26 @@ class JarvisState {
 
     if (TERMINAL_STATES.has(job.result.status)) {
       return job.result;
+    }
+
+    if (!job.claim) {
+      throw new Error(`Callback rejected for job ${callback.job_id}: job is not actively claimed.`);
+    }
+
+    if (job.claim.claim_id !== callback.claim_id) {
+      throw new Error(`Callback rejected for job ${callback.job_id}: claim_id does not match the active claim.`);
+    }
+
+    if (job.claim.claimed_by !== callback.worker_id) {
+      throw new Error(`Callback rejected for job ${callback.job_id}: worker_id does not match the active claim.`);
+    }
+
+    if (job.envelope.attempt !== callback.attempt) {
+      throw new Error(`Callback rejected for job ${callback.job_id}: attempt does not match the active claim.`);
+    }
+
+    if (job.envelope.type !== callback.job_type) {
+      throw new Error(`Callback rejected for job ${callback.job_id}: job_type does not match the active claim.`);
     }
 
     job.claim = null;

--- a/packages/jarvis-telegram/src/approvals.ts
+++ b/packages/jarvis-telegram/src/approvals.ts
@@ -16,6 +16,30 @@ export type ApprovalEntry = {
   notified?: boolean
 }
 
+function asApprovalStatus(value: unknown): ApprovalEntry['status'] {
+  return value === 'approved' || value === 'rejected' ? value : 'pending'
+}
+
+function asApprovalSeverity(value: unknown): ApprovalEntry['severity'] {
+  return value === 'info' || value === 'critical' ? value : 'warning'
+}
+
+function mapApprovalRow(row: Record<string, unknown>): ApprovalEntry {
+  return {
+    id: String(row.id ?? ''),
+    agent: String(row.agent ?? ''),
+    action: String(row.action ?? ''),
+    payload: String(row.payload ?? ''),
+    created_at: String(row.created_at ?? ''),
+    status: asApprovalStatus(row.status),
+    run_id: String(row.run_id ?? ''),
+    severity: asApprovalSeverity(row.severity),
+    resolved_at: typeof row.resolved_at === 'string' ? row.resolved_at : undefined,
+    resolved_by: typeof row.resolved_by === 'string' ? row.resolved_by : undefined,
+    resolution_note: typeof row.resolution_note === 'string' ? row.resolution_note : undefined,
+  }
+}
+
 /**
  * Load approvals from the runtime database.
  */
@@ -24,7 +48,8 @@ export function loadApprovals(db: DatabaseSync, status?: 'pending' | 'approved' 
     const sql = status
       ? "SELECT approval_id as id, agent_id as agent, action, payload_json as payload, requested_at as created_at, status, run_id, severity, resolved_at, resolved_by, resolution_note FROM approvals WHERE status = ? ORDER BY requested_at DESC"
       : "SELECT approval_id as id, agent_id as agent, action, payload_json as payload, requested_at as created_at, status, run_id, severity, resolved_at, resolved_by, resolution_note FROM approvals ORDER BY requested_at DESC"
-    return (status ? db.prepare(sql).all(status) : db.prepare(sql).all()) as ApprovalEntry[]
+    const rows = (status ? db.prepare(sql).all(status) : db.prepare(sql).all()) as Array<Record<string, unknown>>
+    return rows.map(mapApprovalRow)
   } catch {
     return []
   }
@@ -36,7 +61,7 @@ export function loadApprovals(db: DatabaseSync, status?: 'pending' | 'approved' 
  */
 export function getUnnotifiedPending(db: DatabaseSync): ApprovalEntry[] {
   try {
-    return db.prepare(`
+    const rows = db.prepare(`
       SELECT a.approval_id as id, a.agent_id as agent, a.action, a.payload_json as payload,
              a.requested_at as created_at, a.status, a.run_id, a.severity
       FROM approvals a
@@ -45,9 +70,10 @@ export function getUnnotifiedPending(db: DatabaseSync): ApprovalEntry[] {
           SELECT 1 FROM notifications n
           WHERE n.kind = 'approval_prompt'
             AND json_extract(n.payload_json, '$.approval_id') = a.approval_id
-        )
-      ORDER BY a.requested_at ASC
-    `).all() as ApprovalEntry[]
+         )
+       ORDER BY a.requested_at ASC
+    `).all() as Array<Record<string, unknown>>
+    return rows.map(mapApprovalRow)
   } catch {
     return []
   }

--- a/packages/jarvis-telegram/tsconfig.json
+++ b/packages/jarvis-telegram/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
+    "composite": true,
+    "noEmit": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "types": ["node"]

--- a/scripts/ops/backup-runtime.mjs
+++ b/scripts/ops/backup-runtime.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import os from "node:os";
 import { promises as fs } from "node:fs";
 import crypto from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
 import {
   DEFAULT_PROFILE,
   buildBackupManifest,
@@ -28,6 +29,28 @@ async function copyIfExists(source, target) {
       return false;
     }
     throw error;
+  }
+}
+
+function escapeSqlitePath(filePath) {
+  return filePath.replace(/\\/g, "/").replace(/'/g, "''");
+}
+
+async function snapshotSqliteDatabase(sourcePath, targetPath) {
+  try {
+    await fs.unlink(targetPath);
+  } catch (error) {
+    if (!(error && typeof error === "object" && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+
+  const db = new DatabaseSync(sourcePath, { readOnly: true });
+  try {
+    db.exec("PRAGMA busy_timeout = 5000;");
+    db.exec(`VACUUM INTO '${escapeSqlitePath(targetPath)}'`);
+  } finally {
+    try { db.close(); } catch {}
   }
 }
 
@@ -66,15 +89,8 @@ async function main() {
     try {
       await fs.access(dbPath);
       await ensureDir(jarvisTarget);
-      await fs.copyFile(dbPath, path.join(jarvisTarget, dbName));
+      await snapshotSqliteDatabase(dbPath, path.join(jarvisTarget, dbName));
       copiedDatabases.push(dbName);
-      // Also copy WAL/SHM files if they exist
-      for (const suffix of ["-wal", "-shm"]) {
-        try {
-          await fs.access(dbPath + suffix);
-          await fs.copyFile(dbPath + suffix, path.join(jarvisTarget, dbName + suffix));
-        } catch { /* no WAL/SHM file, fine */ }
-      }
     } catch { /* db doesn't exist, skip */ }
   }
   // Copy config.json if it exists

--- a/scripts/ops/recover-runtime.mjs
+++ b/scripts/ops/recover-runtime.mjs
@@ -16,6 +16,23 @@ import {
   writeJson
 } from "./common.mjs";
 
+async function removeIfExists(filePath) {
+  try {
+    await fs.unlink(filePath);
+  } catch (error) {
+    if (!(error && typeof error === "object" && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+}
+
+async function clearSqliteSidecars(basePath) {
+  await Promise.all([
+    removeIfExists(`${basePath}-wal`),
+    removeIfExists(`${basePath}-shm`)
+  ]);
+}
+
 async function restoreBundle(bundleDir, profile, restoreWorkspace) {
   const manifestPath = path.join(bundleDir, "manifest.json");
   const manifest = await readJsonIfExists(manifestPath);
@@ -67,15 +84,21 @@ async function restoreBundle(bundleDir, profile, restoreWorkspace) {
           checksumResults[dbName] = "OK";
         }
 
-        await fs.copyFile(srcPath, path.join(jarvisDir, dbName));
+        const targetPath = path.join(jarvisDir, dbName);
+        if (dbName.endsWith(".db")) {
+          await clearSqliteSidecars(targetPath);
+        }
+
+        await fs.copyFile(srcPath, targetPath);
         restoredDatabases.push(dbName);
 
-        // Restore WAL/SHM if present
-        for (const suffix of ["-wal", "-shm"]) {
-          try {
-            await fs.access(srcPath + suffix);
-            await fs.copyFile(srcPath + suffix, path.join(jarvisDir, dbName + suffix));
-          } catch { /* no WAL/SHM */ }
+        if (dbName.endsWith(".db")) {
+          for (const suffix of ["-wal", "-shm"]) {
+            try {
+              await fs.access(srcPath + suffix);
+              await fs.copyFile(srcPath + suffix, path.join(jarvisDir, dbName + suffix));
+            } catch { /* no WAL/SHM */ }
+          }
         }
       } catch { /* file not in backup */ }
     }

--- a/tests/backup-api.test.ts
+++ b/tests/backup-api.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import {
+  CRM_MIGRATIONS,
+  KNOWLEDGE_MIGRATIONS,
+  runMigrations,
+} from "@jarvis/runtime";
+import {
+  createBackupSnapshot,
+  getBackupStatus,
+  restoreBackupDirectory,
+} from "../packages/jarvis-dashboard/src/api/backup.ts";
+
+function createTempDir(): string {
+  return fs.mkdtempSync(join(os.tmpdir(), "jarvis-backup-api-"));
+}
+
+function setupDatabase(dbPath: string, migrations?: Parameters<typeof runMigrations>[1]): void {
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec("PRAGMA busy_timeout = 5000;");
+    runMigrations(db, migrations);
+  } finally {
+    db.close();
+  }
+}
+
+function setupFakeJarvisDir(jarvisDir: string): void {
+  fs.mkdirSync(jarvisDir, { recursive: true });
+  fs.writeFileSync(join(jarvisDir, "config.json"), JSON.stringify({ lmstudio_url: "http://localhost:1234" }));
+  setupDatabase(join(jarvisDir, "runtime.db"));
+  setupDatabase(join(jarvisDir, "crm.db"), CRM_MIGRATIONS);
+  setupDatabase(join(jarvisDir, "knowledge.db"), KNOWLEDGE_MIGRATIONS);
+}
+
+describe("backup API helpers", () => {
+  let tempDir: string;
+  let jarvisDir: string;
+  let backupsDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    jarvisDir = join(tempDir, ".jarvis");
+    backupsDir = join(jarvisDir, "backups");
+    setupFakeJarvisDir(jarvisDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates sqlite snapshots and reports normalized backup status", () => {
+    const { backupDir, files } = createBackupSnapshot(jarvisDir, backupsDir, new Date("2026-04-08T10:00:00.000Z"));
+
+    expect(files.map((file) => file.name)).toEqual(
+      expect.arrayContaining(["config.json", "runtime.db", "crm.db", "knowledge.db"]),
+    );
+    expect(fs.existsSync(join(backupDir, "runtime.db-wal"))).toBe(false);
+    expect(fs.existsSync(join(backupDir, "runtime.db-shm"))).toBe(false);
+
+    const status = getBackupStatus(backupsDir);
+    expect(status).toMatchObject({
+      last_backup: "2026-04-08T10:00:00.000Z",
+      last_backup_at: "2026-04-08T10:00:00.000Z",
+      last_backup_path: backupDir,
+    });
+    expect(status.size_mb).not.toBeNull();
+  });
+
+  it("clears stale WAL sidecars when restoring snapshot backups", () => {
+    const { backupDir } = createBackupSnapshot(jarvisDir, backupsDir, new Date("2026-04-08T11:00:00.000Z"));
+
+    fs.writeFileSync(join(jarvisDir, "runtime.db-wal"), "stale wal");
+    fs.writeFileSync(join(jarvisDir, "runtime.db-shm"), "stale shm");
+    fs.writeFileSync(join(jarvisDir, "runtime.db"), Buffer.from("corrupt runtime db"));
+
+    const restored = restoreBackupDirectory(backupDir, jarvisDir);
+    expect(restored.restored).toContain("runtime.db");
+    expect(fs.existsSync(join(jarvisDir, "runtime.db-wal"))).toBe(false);
+    expect(fs.existsSync(join(jarvisDir, "runtime.db-shm"))).toBe(false);
+
+    const restoredDb = new DatabaseSync(join(jarvisDir, "runtime.db"));
+    try {
+      const integrity = restoredDb.prepare("PRAGMA integrity_check").get() as { integrity_check: string };
+      expect(integrity.integrity_check).toBe("ok");
+    } finally {
+      restoredDb.close();
+    }
+  });
+});

--- a/tests/desktop-host-worker.test.ts
+++ b/tests/desktop-host-worker.test.ts
@@ -4,7 +4,6 @@ import {
   CONTRACT_VERSION,
   getJarvisState,
   resetJarvisState,
-  submitDeviceOpenApp,
   type JobEnvelope
 } from "@jarvis/shared";
 import {
@@ -104,23 +103,41 @@ describe("Desktop host worker", () => {
       adapter: new MockDesktopHostAdapter()
     });
 
-    const submitResponse = submitDeviceOpenApp(
-      {
+    const approval = getJarvisState().requestApproval({
+      title: "Approve device.open_app",
+      description: "Needed for desktop-host callback round-trip test.",
+      severity: "warning",
+      scopes: ["device.open_app"],
+    });
+    getJarvisState().resolveApproval(approval.approval_id, "approved");
+
+    const submitResponse = getJarvisState().submitJob({
+      ctx: {
         agentId: "main",
         sessionKey: "agent:main:telegram:dm:123",
         messageChannel: "telegram",
         requesterSenderId: "123456789"
       } as any,
-      {
-        appId: "notepad",
+      type: "device.open_app",
+      approvalId: approval.approval_id,
+      input: {
+        app: { app_id: "notepad" },
         arguments: [],
-        waitForWindow: true
+        wait_for_window: true,
       },
-    );
+    });
 
     const envelope = extractEnvelope(submitResponse.job_id!);
+    const claim = getJarvisState().claimJob({
+      worker_id: worker.workerId,
+      routes: ["device"],
+    });
+    expect(claim?.claim_id).toBeTruthy();
     const result = await worker.execute(envelope);
-    const callback = worker.toCallback(result);
+    const callback = {
+      ...worker.toCallback(result),
+      claim_id: claim!.claim_id!,
+    };
     const finalResult = getJarvisState().handleWorkerCallback(callback);
     const jobResponse = getJarvisState().getJob(envelope.job_id);
 

--- a/tests/files-plugin.test.ts
+++ b/tests/files-plugin.test.ts
@@ -9,6 +9,20 @@ import {
   filesToolNames
 } from "../packages/jarvis-files/src/index";
 
+async function withFilesRoot<T>(rootPath: string, run: () => Promise<T>): Promise<T> {
+  const previous = process.env.JARVIS_FILES_ROOT;
+  process.env.JARVIS_FILES_ROOT = rootPath;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.JARVIS_FILES_ROOT;
+    } else {
+      process.env.JARVIS_FILES_ROOT = previous;
+    }
+  }
+}
+
 function makeTempWorkspace() {
   return mkdtempSync(join(tmpdir(), "jarvis-files-"));
 }
@@ -49,30 +63,32 @@ describe("Jarvis files plugin", () => {
     const rootPath = makeTempWorkspace();
     writeFileSync(join(rootPath, "notes.txt"), "alpha\nbeta\ngamma\n", "utf8");
 
-    const tool = createFilesTools().find((entry) => entry.name === "files_read");
-    expect(tool).toBeDefined();
+    await withFilesRoot(rootPath, async () => {
+      const tool = createFilesTools().find((entry) => entry.name === "files_read");
+      expect(tool).toBeDefined();
 
-    const toolResult = await tool!.execute("tool-call-1", {
-      rootPath,
-      path: "notes.txt"
-    });
+      const toolResult = await tool!.execute("tool-call-1", {
+        rootPath,
+        path: "notes.txt"
+      });
 
-    const command = createFilesCommand();
-    const commandReply = command.handler(
-      makeCommandContext(
-        JSON.stringify({
-          operation: "read",
-          rootPath,
-          path: "notes.txt"
-        })
-      )
-    );
+      const command = createFilesCommand();
+      const commandReply = command.handler(
+        makeCommandContext(
+          JSON.stringify({
+            operation: "read",
+            rootPath,
+            path: "notes.txt"
+          })
+        )
+      );
 
-    expect(commandReply.isError).toBeFalsy();
-    expect(commandReply.text).toBe(toolResult.details.summary);
-    expect(toolResult.details.structured_output).toMatchObject({
-      path: "notes.txt",
-      content: "alpha\nbeta\ngamma\n"
+      expect(commandReply.isError).toBeFalsy();
+      expect(commandReply.text).toBe(toolResult.details.summary);
+      expect(toolResult.details.structured_output).toMatchObject({
+        path: "notes.txt",
+        content: "alpha\nbeta\ngamma\n"
+      });
     });
   });
 
@@ -80,28 +96,51 @@ describe("Jarvis files plugin", () => {
     const rootPath = makeTempWorkspace();
     mkdirSync(rootPath, { recursive: true });
 
-    const writeTool = createFilesTools().find((entry) => entry.name === "files_write");
-    expect(writeTool).toBeDefined();
+    await withFilesRoot(rootPath, async () => {
+      const writeTool = createFilesTools().find((entry) => entry.name === "files_write");
+      expect(writeTool).toBeDefined();
 
-    const gated = await writeTool!.execute("tool-call-approval", {
-      rootPath,
-      path: "drafts/plan.txt",
-      content: "first draft"
+      const gated = await writeTool!.execute("tool-call-approval", {
+        rootPath,
+        path: "drafts/plan.txt",
+        content: "first draft"
+      });
+
+      expect(gated.details.status).toBe("awaiting_approval");
+      expect(existsSync(join(rootPath, "drafts", "plan.txt"))).toBe(false);
+
+      const approved = await writeTool!.execute("tool-call-approved", {
+        rootPath,
+        path: "drafts/plan.txt",
+        content: "first draft",
+        createDirectories: true,
+        approvalId: gated.details.approval_id
+      });
+
+      expect(approved.details.status).toBe("completed");
+      expect(readFileSync(join(rootPath, "drafts", "plan.txt"), "utf8")).toBe("first draft");
     });
+  });
 
-    expect(gated.details.status).toBe("awaiting_approval");
-    expect(existsSync(join(rootPath, "drafts", "plan.txt"))).toBe(false);
+  it("rejects arbitrary approval ids for destructive writes", async () => {
+    const rootPath = makeTempWorkspace();
 
-    const approved = await writeTool!.execute("tool-call-approved", {
-      rootPath,
-      path: "drafts/plan.txt",
-      content: "first draft",
-      createDirectories: true,
-      approvalId: "approval-123"
+    await withFilesRoot(rootPath, async () => {
+      const writeTool = createFilesTools().find((entry) => entry.name === "files_write");
+      expect(writeTool).toBeDefined();
+
+      const attempted = await writeTool!.execute("tool-call-invalid-approval", {
+        rootPath,
+        path: "drafts/plan.txt",
+        content: "first draft",
+        createDirectories: true,
+        approvalId: "approval-123"
+      });
+
+      expect(attempted.details.status).toBe("failed");
+      expect(attempted.details.error?.code).toBe("INVALID_APPROVAL");
+      expect(existsSync(join(rootPath, "drafts", "plan.txt"))).toBe(false);
     });
-
-    expect(approved.details.status).toBe("completed");
-    expect(readFileSync(join(rootPath, "drafts", "plan.txt"), "utf8")).toBe("first draft");
   });
 
   it("supports patching and previewing the updated content", async () => {
@@ -109,30 +148,38 @@ describe("Jarvis files plugin", () => {
     const target = join(rootPath, "memo.txt");
     writeFileSync(target, "hello world\nhello jarvis\n", "utf8");
 
-    const patchTool = createFilesTools().find((entry) => entry.name === "files_patch");
-    const previewTool = createFilesTools().find((entry) => entry.name === "files_preview");
-    expect(patchTool).toBeDefined();
-    expect(previewTool).toBeDefined();
+    await withFilesRoot(rootPath, async () => {
+      const patchTool = createFilesTools().find((entry) => entry.name === "files_patch");
+      const previewTool = createFilesTools().find((entry) => entry.name === "files_preview");
+      expect(patchTool).toBeDefined();
+      expect(previewTool).toBeDefined();
 
-    const patched = await patchTool!.execute("tool-call-patch", {
-      rootPath,
-      path: "memo.txt",
-      operations: [{ find: "hello", replace: "hi", all: true }],
-      approvalId: "approval-456"
-    });
+      const gated = await patchTool!.execute("tool-call-patch-gated", {
+        rootPath,
+        path: "memo.txt",
+        operations: [{ find: "hello", replace: "hi", all: true }],
+      });
 
-    expect(patched.details.status).toBe("completed");
-    expect(readFileSync(target, "utf8")).toBe("hi world\nhi jarvis\n");
+      const patched = await patchTool!.execute("tool-call-patch", {
+        rootPath,
+        path: "memo.txt",
+        operations: [{ find: "hello", replace: "hi", all: true }],
+        approvalId: gated.details.approval_id
+      });
 
-    const preview = await previewTool!.execute("tool-call-preview", {
-      rootPath,
-      path: "memo.txt",
-      maxLines: 1
-    });
+      expect(patched.details.status).toBe("completed");
+      expect(readFileSync(target, "utf8")).toBe("hi world\nhi jarvis\n");
 
-    expect(preview.details.structured_output).toMatchObject({
-      path: "memo.txt",
-      preview: "hi world"
+      const preview = await previewTool!.execute("tool-call-preview", {
+        rootPath,
+        path: "memo.txt",
+        maxLines: 1
+      });
+
+      expect(preview.details.structured_output).toMatchObject({
+        path: "memo.txt",
+        preview: "hi world"
+      });
     });
   });
 });

--- a/tests/firewall-command-safety.test.ts
+++ b/tests/firewall-command-safety.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { addFirewallRule, removeFirewallRule } from "../packages/jarvis-security-worker/src/firewall.ts";
+
+describe("Firewall command safety", () => {
+  it("rejects dangerous rule names before shell execution", async () => {
+    const runner = { exec: vi.fn() };
+
+    const result = await addFirewallRule(runner, {
+      action: "add",
+      rule_name: "safe\" & calc.exe",
+      port: 4444,
+    } as const);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("unsupported characters");
+    expect(runner.exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects dangerous program paths before shell execution", async () => {
+    const runner = { exec: vi.fn() };
+
+    const result = await addFirewallRule(runner, {
+      action: "add",
+      rule_name: "Jarvis-Block-Test",
+      program: "C:\\temp\\app.exe & calc.exe",
+    } as const);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("unsupported characters");
+    expect(runner.exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects dangerous rule names for deletes too", async () => {
+    const runner = { exec: vi.fn() };
+
+    const result = await removeFirewallRule(runner, "remove-me | powershell");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("unsupported characters");
+    expect(runner.exec).not.toHaveBeenCalled();
+  });
+});

--- a/tests/job-claim-isolation.test.ts
+++ b/tests/job-claim-isolation.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getJarvisState, resetJarvisState } from "@jarvis/shared";
+
+describe("Job claim isolation", () => {
+  beforeEach(() => {
+    resetJarvisState();
+  });
+
+  it("does not hand a pinned run_group job to a worker that omits run_group", () => {
+    getJarvisState().submitJob({
+      type: "office.preview",
+      input: {
+        source_artifact: { artifact_id: "a1" },
+        format: "pdf",
+        output_name: "preview.pdf",
+      },
+      runGroup: "main",
+    });
+
+    const claim = getJarvisState().claimJob({
+      worker_id: "office-worker-1",
+      routes: ["office"],
+    });
+
+    expect(claim).toBeNull();
+  });
+
+  it("still allows the matching run_group to claim the job", () => {
+    const queued = getJarvisState().submitJob({
+      type: "office.preview",
+      input: {
+        source_artifact: { artifact_id: "a1" },
+        format: "pdf",
+        output_name: "preview.pdf",
+      },
+      runGroup: "main",
+    });
+
+    const claim = getJarvisState().claimJob({
+      worker_id: "office-worker-1",
+      routes: ["office"],
+      run_group: "main",
+    });
+
+    expect(claim?.job_id).toBe(queued.job_id);
+  });
+});

--- a/tests/jobs-callback.test.ts
+++ b/tests/jobs-callback.test.ts
@@ -43,6 +43,11 @@ describe("Jarvis jobs callback route", () => {
       },
       artifactsIn: [{ artifact_id: "a1" }]
     });
+    const claim = getJarvisState().claimJob({
+      worker_id: "office-worker-1",
+      routes: ["office"],
+    });
+    expect(claim?.claim_id).toBeTruthy();
 
     const callbackPayload = {
       contract_version: "jarvis.v1" as const,
@@ -52,6 +57,7 @@ describe("Jarvis jobs callback route", () => {
       status: "completed" as const,
       summary: "Rendered preview.pdf",
       worker_id: "office-worker-1",
+      claim_id: claim!.claim_id!,
       artifacts: [
         {
           artifact_id: "preview-1",
@@ -89,5 +95,45 @@ describe("Jarvis jobs callback route", () => {
     const job = getJarvisState().getJob(queued.job_id!);
     expect(job.artifacts).toEqual(callbackPayload.artifacts);
     expect(job.summary).toBe("Rendered preview.pdf");
+  });
+
+  it("rejects callbacks whose claim_id does not match the active claim", async () => {
+    const queued = getJarvisState().submitJob({
+      type: "office.preview",
+      input: {
+        source_artifact: { artifact_id: "a1" },
+        format: "pdf",
+        output_name: "preview.pdf"
+      },
+      artifactsIn: [{ artifact_id: "a1" }]
+    });
+    const claim = getJarvisState().claimJob({
+      worker_id: "office-worker-1",
+      routes: ["office"],
+    });
+    expect(claim?.claim_id).toBeTruthy();
+
+    const request = Readable.from([JSON.stringify({
+      contract_version: "jarvis.v1",
+      job_id: queued.job_id,
+      job_type: "office.preview",
+      attempt: 1,
+      status: "completed",
+      summary: "Rendered preview.pdf",
+      worker_id: "office-worker-1",
+      claim_id: "wrong-claim-id"
+    })]) as any;
+    const response = createMockResponse();
+
+    await handleJobsCallback(request, response.response as any);
+
+    expect(response.response.statusCode).toBe(409);
+    expect(JSON.parse(response.readBody())).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("claim_id does not match"),
+    });
+
+    const job = getJarvisState().getJob(queued.job_id!);
+    expect(job.status).toBe("in_progress");
   });
 });

--- a/tests/plugin-permissions-fallback.test.ts
+++ b/tests/plugin-permissions-fallback.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { runMigrations } from "@jarvis/runtime";
+
+function createTempHome(): string {
+  return fs.mkdtempSync(join(os.tmpdir(), "jarvis-plugin-home-"));
+}
+
+describe("plugin permission fallback", () => {
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  let tempHome: string;
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    tempHome = createTempHome();
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+
+    db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec("PRAGMA busy_timeout = 5000;");
+    runMigrations(db);
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch {}
+    vi.resetModules();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("loads plugin permissions from the on-disk manifest when the DB row is missing", async () => {
+    const pluginDir = join(tempHome, ".jarvis", "plugins", "test-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(join(pluginDir, "manifest.json"), JSON.stringify({
+      id: "test-plugin",
+      name: "Test Plugin",
+      version: "1.0.0",
+      description: "A test plugin",
+      installed_at: "2026-04-08T12:00:00.000Z",
+      permissions: ["execute_web", "read_crm"],
+      agent: {
+        agent_id: "plugin-test-plugin",
+        label: "Plugin Test Agent",
+        version: "1.0.0",
+        description: "Exercises plugin permissions fallback",
+        triggers: [{ kind: "manual" }],
+        capabilities: ["web", "crm"],
+        approval_gates: [],
+        knowledge_collections: [],
+        task_profile: { objective: "answer" },
+        max_steps_per_run: 5,
+        system_prompt: "You are a test plugin.",
+        output_channels: [],
+      },
+    }, null, 2));
+
+    vi.resetModules();
+    const { loadPluginPermissions } = await import("../packages/jarvis-runtime/src/orchestrator.ts");
+
+    expect(loadPluginPermissions("plugin-test-plugin", db)).toEqual(["execute_web", "read_crm"]);
+  });
+});

--- a/tests/portal-api.test.ts
+++ b/tests/portal-api.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  portalDocumentMatchesClient,
+  sanitizePortalFilePath,
+} from "../packages/jarvis-dashboard/src/api/portal.ts";
+
+const client = {
+  client_id: "acme-001",
+  company: "Acme",
+  contact_name: "Alex",
+  email: "alex@acme.test",
+} as const;
+
+describe("Portal API helpers", () => {
+  it("matches documents only on exact client tags or collection keys", () => {
+    expect(portalDocumentMatchesClient({
+      tags: JSON.stringify(["client:acme-001", "company:acme"]),
+      collection: "deliverables",
+    }, client)).toBe(true);
+
+    expect(portalDocumentMatchesClient({
+      tags: JSON.stringify(["company:acme-holdings"]),
+      collection: "deliverables",
+    }, client)).toBe(false);
+  });
+
+  it("redacts raw host paths down to a basename", () => {
+    expect(sanitizePortalFilePath("/srv/private/contracts/acme-sow.pdf", "Acme SOW", "doc-1")).toBe("acme-sow.pdf");
+    expect(sanitizePortalFilePath("C:\\Jarvis\\private\\contracts\\acme-sow.pdf", "Acme SOW", "doc-1")).toBe("acme-sow.pdf");
+  });
+});

--- a/tests/smoke/security-posture.test.ts
+++ b/tests/smoke/security-posture.test.ts
@@ -26,6 +26,10 @@ import {
   type FilesystemPolicy,
 } from "@jarvis/runtime";
 import { validateJobInput } from "@jarvis/shared";
+import {
+  getRequiredRole,
+  shouldBypassWebhookBearerAuth,
+} from "../../packages/jarvis-dashboard/src/api/middleware/auth.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -126,6 +130,33 @@ describe("Auth middleware: token enforcement", () => {
     // Dev mode without tokens: viewer-only (read-only)
     const grantedRole = tokens.length === 0 && mode !== "production" ? "viewer" : null;
     expect(grantedRole).toBe("viewer");
+  });
+
+  it("chat mutations require operator role, not viewer", () => {
+    expect(getRequiredRole("/api/chat", "POST")).toBe("operator");
+    expect(getRequiredRole("/api/chat/telegram", "POST")).toBe("operator");
+    expect(getRequiredRole("/api/chat/models", "GET")).toBe("viewer");
+  });
+
+  it("starter pack mutations require admin role", () => {
+    expect(getRequiredRole("/api/packs/development/apply", "POST")).toBe("admin");
+    expect(getRequiredRole("/api/packs", "GET")).toBe("viewer");
+  });
+
+  it("signed webhook posts bypass bearer auth only when a webhook secret exists", () => {
+    expect(shouldBypassWebhookBearerAuth(
+      "/api/webhooks/github",
+      "POST",
+      { "x-hub-signature-256": "sha256=abc" },
+      true,
+    )).toBe(true);
+
+    expect(shouldBypassWebhookBearerAuth(
+      "/api/webhooks/github",
+      "POST",
+      { "x-hub-signature-256": "sha256=abc" },
+      false,
+    )).toBe(false);
   });
 });
 

--- a/tests/smoke/webhook-hmac.test.ts
+++ b/tests/smoke/webhook-hmac.test.ts
@@ -9,117 +9,98 @@
  */
 
 import { describe, it, expect } from "vitest";
-import crypto from "node:crypto";
-
-/**
- * Compute HMAC-SHA256 signature in the same format as the webhook endpoint.
- * Mirrors the logic in webhooks.ts for both GitHub (X-Hub-Signature-256)
- * and Jarvis generic webhooks (X-Jarvis-Signature).
- */
-function computeSignature(payload: string, secret: string): string {
-  return "sha256=" + crypto.createHmac("sha256", secret).update(payload).digest("hex");
-}
-
-/**
- * Validate an HMAC signature using timing-safe comparison.
- * Mirrors the validateHmac logic from webhooks.ts, including the buffer
- * padding for length-safe timingSafeEqual.
- */
-function validateSignature(payload: string, signature: string, secret: string): boolean {
-  const expected = computeSignature(payload, secret);
-
-  const sigBuf = Buffer.from(signature);
-  const expBuf = Buffer.from(expected);
-
-  // Pad both buffers to the same length (same as webhooks.ts)
-  const maxLen = Math.max(sigBuf.length, expBuf.length);
-  const paddedSig = Buffer.alloc(maxLen);
-  const paddedExp = Buffer.alloc(maxLen);
-  sigBuf.copy(paddedSig);
-  expBuf.copy(paddedExp);
-
-  return sigBuf.length === expBuf.length && crypto.timingSafeEqual(paddedSig, paddedExp);
-}
+import {
+  computeWebhookSignature,
+  signaturesMatch,
+} from "../../packages/jarvis-dashboard/src/api/webhooks.ts";
 
 describe("Webhook: HMAC signature validation", () => {
   const secret = "test-webhook-secret";
 
   it("valid signature passes verification", () => {
     const payload = JSON.stringify({ event: "push", ref: "refs/heads/main" });
-    const sig = computeSignature(payload, secret);
+    const sig = computeWebhookSignature(secret, payload);
 
-    expect(validateSignature(payload, sig, secret)).toBe(true);
+    expect(signaturesMatch(sig, computeWebhookSignature(secret, payload))).toBe(true);
   });
 
   it("invalid signature fails verification (wrong secret)", () => {
     const payload = JSON.stringify({ event: "push" });
-    const sig = computeSignature(payload, "wrong-secret");
+    const sig = computeWebhookSignature("wrong-secret", payload);
 
-    expect(validateSignature(payload, sig, secret)).toBe(false);
+    expect(signaturesMatch(sig, computeWebhookSignature(secret, payload))).toBe(false);
   });
 
   it("tampered payload fails verification", () => {
     const payload = JSON.stringify({ event: "push" });
-    const sig = computeSignature(payload, secret);
+    const sig = computeWebhookSignature(secret, payload);
 
     const tampered = JSON.stringify({ event: "delete" });
-    expect(validateSignature(tampered, sig, secret)).toBe(false);
+    expect(signaturesMatch(sig, computeWebhookSignature(secret, tampered))).toBe(false);
   });
 
   it("signature format is sha256=<hex>", () => {
     const payload = JSON.stringify({ test: true });
-    const sig = computeSignature(payload, secret);
+    const sig = computeWebhookSignature(secret, payload);
 
     expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/);
   });
 
   it("empty payload produces valid HMAC", () => {
     const payload = "";
-    const sig = computeSignature(payload, secret);
+    const sig = computeWebhookSignature(secret, payload);
 
-    expect(validateSignature(payload, sig, secret)).toBe(true);
+    expect(signaturesMatch(sig, computeWebhookSignature(secret, payload))).toBe(true);
     expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/);
   });
 
   it("different payloads produce different signatures", () => {
-    const sig1 = computeSignature(JSON.stringify({ a: 1 }), secret);
-    const sig2 = computeSignature(JSON.stringify({ a: 2 }), secret);
+    const sig1 = computeWebhookSignature(secret, JSON.stringify({ a: 1 }));
+    const sig2 = computeWebhookSignature(secret, JSON.stringify({ a: 2 }));
 
     expect(sig1).not.toBe(sig2);
   });
 
   it("different secrets produce different signatures for same payload", () => {
     const payload = JSON.stringify({ event: "push" });
-    const sig1 = computeSignature(payload, "secret-one");
-    const sig2 = computeSignature(payload, "secret-two");
+    const sig1 = computeWebhookSignature("secret-one", payload);
+    const sig2 = computeWebhookSignature("secret-two", payload);
 
     expect(sig1).not.toBe(sig2);
   });
 
   it("malformed signature (wrong prefix) fails verification", () => {
     const payload = JSON.stringify({ event: "push" });
-    const sig = computeSignature(payload, secret);
+    const sig = computeWebhookSignature(secret, payload);
     // Strip the sha256= prefix
     const malformed = sig.replace("sha256=", "md5=");
 
-    expect(validateSignature(payload, malformed, secret)).toBe(false);
+    expect(signaturesMatch(malformed, computeWebhookSignature(secret, payload))).toBe(false);
   });
 
   it("truncated signature fails verification", () => {
     const payload = JSON.stringify({ event: "push" });
-    const sig = computeSignature(payload, secret);
+    const sig = computeWebhookSignature(secret, payload);
     const truncated = sig.slice(0, 20);
 
     // Length mismatch should cause failure
-    expect(validateSignature(payload, truncated, secret)).toBe(false);
+    expect(signaturesMatch(truncated, computeWebhookSignature(secret, payload))).toBe(false);
   });
 
   it("signature is deterministic for same input", () => {
     const payload = JSON.stringify({ event: "push", repo: "jarvis" });
 
-    const sig1 = computeSignature(payload, secret);
-    const sig2 = computeSignature(payload, secret);
+    const sig1 = computeWebhookSignature(secret, payload);
+    const sig2 = computeWebhookSignature(secret, payload);
 
     expect(sig1).toBe(sig2);
+  });
+
+  it("different raw encodings of the same JSON object do not share a signature", () => {
+    const minified = '{"event":"push","ref":"refs/heads/main"}';
+    const pretty = '{\n  "event": "push",\n  "ref": "refs/heads/main"\n}';
+
+    const sig = computeWebhookSignature(secret, pretty);
+    expect(signaturesMatch(sig, computeWebhookSignature(secret, minified))).toBe(false);
   });
 });

--- a/tests/state-persistence.test.ts
+++ b/tests/state-persistence.test.ts
@@ -51,6 +51,11 @@ describe.sequential("Jarvis durable state persistence", () => {
 
       expect(queued.status).toBe("accepted");
       expect(queued.job_id).toBeTruthy();
+      const claim = getJarvisState().claimJob({
+        worker_id: "office-worker-1",
+        routes: ["office"],
+      });
+      expect(claim?.claim_id).toBeTruthy();
 
       const callback = {
         contract_version: "jarvis.v1" as const,
@@ -60,6 +65,7 @@ describe.sequential("Jarvis durable state persistence", () => {
         status: "completed" as const,
         summary: "Rendered preview.pdf",
         worker_id: "office-worker-1",
+        claim_id: claim!.claim_id!,
         artifacts: [
           {
             artifact_id: "preview-1",

--- a/tests/worker-registry-integration.test.ts
+++ b/tests/worker-registry-integration.test.ts
@@ -354,8 +354,8 @@ describe("buildEnvelope", () => {
     const env = buildEnvelope("browser.navigate", { url: "https://example.com" });
     expect(env.metadata.agent_id).toBe("daemon");
     expect(env.metadata.thread_key).toBeNull();
-    expect(env.requested_by.source).toBe("agent");
-    expect(env.requested_by.agent_id).toBe("daemon");
+    expect(env.requested_by.channel).toBe("agent");
+    expect(env.requested_by.user_id).toBe("daemon");
   });
 
   it("sets contract_version, priority, approval_state, and attempt", () => {
@@ -368,6 +368,17 @@ describe("buildEnvelope", () => {
     expect(env.approval_state).toBe("not_required");
     expect(env.attempt).toBe(1);
     expect(env.artifacts_in).toEqual([]);
+  });
+
+  it("allows approval_state overrides for pre-approved actions", () => {
+    const env = buildEnvelope("email.send", {
+      to: ["test@example.com"],
+      subject: "Hello",
+      body_text: "world",
+    }, {
+      approval_state: "approved",
+    });
+    expect(env.approval_state).toBe("approved");
   });
 
   it("falls back to 120s timeout for unknown job types", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -120,6 +120,15 @@
     },
     {
       "path": "./packages/jarvis-drive-worker"
+    },
+    {
+      "path": "./packages/jarvis-runtime"
+    },
+    {
+      "path": "./packages/jarvis-dashboard"
+    },
+    {
+      "path": "./packages/jarvis-telegram"
     }
   ]
 }


### PR DESCRIPTION
## What changed
This PR combines the earlier security/reliability fixes with the newer full-codebase review fixes in a single branch.

It hardens approval and callback handling in the runtime, makes backups and restore safer for the live SQLite state, fixes dashboard/settings mismatches, closes the file-broker sandbox gap, blocks firewall command injection, repairs webhook authentication and raw-body HMAC verification, tightens run-group isolation, improves portal document matching/path exposure, and brings the root TypeScript build graph in line with active packages.

## Why it changed
The repo review surfaced a mix of concrete security bugs, broken or misleading dashboard flows, and validation blind spots:
- approved jobs were not carrying approval state through to workers
- worker callbacks and run transitions had race/identity gaps
- plugin permissions could silently fail open
- live DB backups could be inconsistent
- the file broker accepted caller-chosen roots and arbitrary approval ids
- firewall commands interpolated untrusted input into shell execution
- webhook deliveries were blocked before signature verification and HMAC used reparsed JSON instead of raw bytes
- portal matching could over-broaden results and leak host paths
- the root TS project graph could pass while active packages still failed their own compile

## Impact
Operators and reviewers should now get behavior that matches the intended safety model, while CI/build validation covers more of the active codebase.

## Validation
- `npx tsc -p packages/jarvis-telegram/tsconfig.json`
- `npx tsc -b packages/jarvis-dashboard/tsconfig.json`
- `npx vitest run tests/files-plugin.test.ts tests/firewall-command-safety.test.ts tests/job-claim-isolation.test.ts tests/portal-api.test.ts tests/smoke/security-posture.test.ts tests/smoke/webhook-hmac.test.ts`
- `npx tsc -b`
- `npm run build`
- `npm test`
