### PR TITLE
Fix plugin checksum, release metadata, run ownership (#76)

### DIFF
--- a/packages/jarvis-runtime/src/agent-queue.ts
+++ b/packages/jarvis-runtime/src/agent-queue.ts
@@ -8,6 +8,7 @@ type QueueEntry = {
   trigger: AgentTrigger;
   commandId?: string; // links this queue entry to an agent_commands row
   commandPayload?: Record<string, unknown>; // parsed payload_json from agent_commands (carries retry_of, etc.)
+  owner?: string; // user who triggered the run (for team-mode ownership)
   priority: number; // higher = run first
   enqueuedAt: string;
 };
@@ -65,7 +66,7 @@ export class AgentQueue {
    * Add an agent run to the queue, sorted by priority (descending).
    * If the agent is already running or already queued, this is a no-op.
    */
-  enqueue(agentId: string, trigger: AgentTrigger, priority = 0, commandId?: string, commandPayload?: Record<string, unknown>): boolean {
+  enqueue(agentId: string, trigger: AgentTrigger, priority = 0, commandId?: string, commandPayload?: Record<string, unknown>, owner?: string): boolean {
     // Reject in drain mode
     if (this._draining) {
       this.logger.debug(`Agent ${agentId} rejected — queue is draining`);
@@ -89,6 +90,7 @@ export class AgentQueue {
       trigger,
       commandId,
       commandPayload,
+      owner,
       priority,
       enqueuedAt: new Date().toISOString(),
     });
@@ -127,8 +129,13 @@ export class AgentQueue {
 
       // Attach command_id and command_payload to trigger so orchestrator can link the run
       // and log retry relationships atomically
-      const triggerWithCommand = entry.commandId
-        ? { ...entry.trigger, command_id: entry.commandId, ...(entry.commandPayload ? { command_payload: entry.commandPayload } : {}) }
+      const triggerWithCommand = entry.commandId || entry.owner
+        ? {
+            ...entry.trigger,
+            ...(entry.commandId ? { command_id: entry.commandId } : {}),
+            ...(entry.commandPayload ? { command_payload: entry.commandPayload } : {}),
+            ...(entry.owner ? { owner: entry.owner } : {}),
+          }
         : entry.trigger;
       const runPromise = runAgent(entry.agentId, triggerWithCommand, this.deps)
         .catch((e) => {

--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -328,8 +328,8 @@ async function main() {
       // Check queued commands in runtime.db
       try {
         const commands = runtimeDb.prepare(
-          "SELECT command_id, command_type, target_agent_id, payload_json FROM agent_commands WHERE status = 'queued' ORDER BY priority DESC, created_at ASC LIMIT 10",
-        ).all() as Array<{ command_id: string; command_type: string; target_agent_id: string; payload_json: string | null }>;
+          "SELECT command_id, command_type, target_agent_id, payload_json, created_by FROM agent_commands WHERE status = 'queued' ORDER BY priority DESC, created_at ASC LIMIT 10",
+        ).all() as Array<{ command_id: string; command_type: string; target_agent_id: string; payload_json: string | null; created_by: string | null }>;
 
         for (const cmd of commands) {
           // Claim the command
@@ -350,7 +350,9 @@ async function main() {
 
             // Enqueue the agent with command_id + payload for atomic linkage.
             // If enqueue is a no-op (agent already running/queued), revert the claim.
-            const enqueued = agentQueue.enqueue(cmd.target_agent_id, { kind: "manual" }, 0, cmd.command_id, commandPayload);
+            // Pass created_by as owner so run ownership is tracked
+            const owner = cmd.created_by ?? undefined;
+            const enqueued = agentQueue.enqueue(cmd.target_agent_id, { kind: "manual" }, 0, cmd.command_id, commandPayload, owner);
             if (!enqueued) {
               runtimeDb.prepare(
                 "UPDATE agent_commands SET status = 'queued', claimed_at = NULL WHERE command_id = ?",

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -38,7 +38,7 @@ export {
   type ArtifactState, type ArtifactLifecycleEntry,
 } from "./artifact-lifecycle.js";
 export {
-  CURRENT_RELEASE, checkUpgrade, getPlatformVersion,
+  CURRENT_RELEASE, checkUpgrade, getPlatformVersion, persistRelease, loadInstalledVersion,
   type ReleaseInfo, type UpgradeCheckResult,
 } from "./release-metadata.js";
 export {

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -82,16 +82,17 @@ export async function runAgent(
   // Initialize durable run tracking if runtime DB is available
   const runStore = runtimeDb ? new RunStore(runtimeDb) : null;
 
-  // command_id and command_payload are carried directly on the trigger by AgentQueue (atomic linkage)
+  // command_id, command_payload, and owner are carried directly on the trigger by AgentQueue (atomic linkage)
   const commandId = (trigger as { command_id?: string }).command_id;
   const commandPayload = (trigger as { command_payload?: Record<string, unknown> }).command_payload;
+  const owner = (trigger as { owner?: string }).owner;
 
   // Load plugin permissions if this is a plugin agent
   const pluginPermissions = loadPluginPermissions(agentId, runtimeDb);
 
   // 1. Start run — use the same run_id for both in-memory and durable state
   const run = runtime.startRun(agentId, trigger);
-  runStore?.startRun(agentId, trigger.kind, commandId, run.goal, run.run_id);
+  runStore?.startRun(agentId, trigger.kind, commandId, run.goal, run.run_id, owner);
 
   // Log retry relationship in the audit trail so retry runs are linked to originals
   if (commandPayload?.retry_of && runStore) {

--- a/packages/jarvis-runtime/src/plugin-loader.ts
+++ b/packages/jarvis-runtime/src/plugin-loader.ts
@@ -258,6 +258,7 @@ function verifyManifestChecksum(manifestPath: string, manifest: PluginManifest):
   // Remove the checksum field itself before hashing (it was added after content was hashed)
   const withoutChecksum = JSON.parse(content);
   delete withoutChecksum.checksum_sha256;
+  delete withoutChecksum.installed_at; // Added post-hash by installPlugin()
   const hash = createHash("sha256").update(JSON.stringify(withoutChecksum, null, 2)).digest("hex");
   return hash === manifest.checksum_sha256;
 }

--- a/packages/jarvis-runtime/src/release-metadata.ts
+++ b/packages/jarvis-runtime/src/release-metadata.ts
@@ -3,6 +3,7 @@
  * and rollback guidance for the Jarvis appliance.
  */
 
+import type { DatabaseSync } from "node:sqlite";
 import { JARVIS_PLATFORM_VERSION } from "./plugin-loader.js";
 import { RUNTIME_MIGRATIONS } from "./migrations/runner.js";
 
@@ -30,24 +31,73 @@ export type UpgradeCheckResult = {
 
 export const CURRENT_RELEASE: ReleaseInfo = {
   version: JARVIS_PLATFORM_VERSION,
-  released_at: new Date().toISOString(),
+  released_at: "2026-04-08T00:00:00.000Z",
   migrations: RUNTIME_MIGRATIONS.map(m => m.id),
-  changelog_summary: "Year 1-2: Channel ingress, execution hardening, core workflows, appliance reliability, provenance, multi-viewpoint, knowledge loop, team mode",
+  changelog_summary: "Year 1-3: Channel ingress, execution hardening, core workflows, appliance reliability, provenance, multi-viewpoint, knowledge loop, team mode, platform polish",
   rollback_safe: true,
 };
+
+// ─── Persistence ────────────────────────────────────────────────────────────
+
+type PersistedRelease = {
+  version: string;
+  released_at: string;
+  installed_at: string;
+};
+
+/**
+ * Persist the current release version to the settings table.
+ * Call once at daemon startup after migrations have run.
+ */
+export function persistRelease(db: DatabaseSync): void {
+  try {
+    const payload: PersistedRelease = {
+      version: CURRENT_RELEASE.version,
+      released_at: CURRENT_RELEASE.released_at,
+      installed_at: new Date().toISOString(),
+    };
+    db.prepare(
+      "INSERT OR REPLACE INTO settings (key, value_json, updated_at) VALUES (?, ?, ?)",
+    ).run("platform_release", JSON.stringify(payload), payload.installed_at);
+  } catch {
+    // Best-effort — settings table may not exist in all DB contexts
+  }
+}
+
+/**
+ * Load the installed release version from the settings table.
+ * Returns null if no release has been persisted yet.
+ */
+export function loadInstalledVersion(db: DatabaseSync): PersistedRelease | null {
+  try {
+    const row = db.prepare(
+      "SELECT value_json FROM settings WHERE key = ?",
+    ).get("platform_release") as { value_json: string } | undefined;
+    if (!row?.value_json) return null;
+    return JSON.parse(row.value_json) as PersistedRelease;
+  } catch {
+    return null;
+  }
+}
 
 // ─── Upgrade Validation ─────────────────────────────────────────────────────
 
 /**
  * Check if an upgrade from one version to another is safe.
+ * When a database is provided, reads the installed version from persistent
+ * state rather than relying on the in-memory constant.
  */
 export function checkUpgrade(
   currentMigrations: string[],
   targetRelease: ReleaseInfo,
+  db?: DatabaseSync,
 ): UpgradeCheckResult {
   const currentSet = new Set(currentMigrations);
   const pendingMigrations = targetRelease.migrations.filter(m => !currentSet.has(m));
   const warnings: string[] = [];
+
+  const installed = db ? loadInstalledVersion(db) : null;
+  const currentVersion = installed?.version ?? JARVIS_PLATFORM_VERSION;
 
   if (pendingMigrations.length > 3) {
     warnings.push(`${pendingMigrations.length} pending migrations — consider backing up first`);
@@ -55,7 +105,7 @@ export function checkUpgrade(
 
   return {
     can_upgrade: true,
-    current_version: JARVIS_PLATFORM_VERSION,
+    current_version: currentVersion,
     target_version: targetRelease.version,
     pending_migrations: pendingMigrations,
     warnings,


### PR DESCRIPTION
## Summary

- **Plugin checksum**: strip `installed_at` before hash verification — field is added post-install by `installPlugin()` and wasn't in the original hash
- **Release metadata**: replace runtime `new Date()` with fixed build timestamp, add `persistRelease()`/`loadInstalledVersion()` for DB-backed version tracking via settings table
- **Run ownership**: wire `owner` from command `created_by` through daemon -> agent-queue -> orchestrator -> `runStore.startRun()` so team-mode ownership is populated on live runs

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 1480/1480 passing
- [ ] Verify: install a plugin with checksum, restart, confirm `loadPlugins()` doesn't reject it
- [ ] Verify: `CURRENT_RELEASE.released_at` is `"2026-04-08T00:00:00.000Z"`, not a fresh timestamp
- [ ] Verify: runs triggered via dashboard/telegram have `owner` set in the runs table

🤖 Generated with [Claude Code](https://claude.com/claude-code)