### PR TITLE
Wave 2: Hybrid retrieval wiring + domain benchmarks

### DIFF
--- a/packages/jarvis-agent-framework/src/sqlite-knowledge.ts
+++ b/packages/jarvis-agent-framework/src/sqlite-knowledge.ts
@@ -43,6 +43,11 @@ export class SqliteKnowledgeStore {
     }
   }
 
+  /** Attach an embedding pipeline after construction (for deferred initialization). */
+  setEmbeddingPipeline(pipeline: EmbeddingPipeline): void {
+    this.embeddingPipeline = pipeline;
+  }
+
   private hasFts(): boolean {
     try {
       this.db.prepare("SELECT * FROM documents_fts LIMIT 0").all();

--- a/packages/jarvis-runtime/src/daemon.ts
+++ b/packages/jarvis-runtime/src/daemon.ts
@@ -6,6 +6,10 @@ import {
   SqliteMemoryStore,
   SqliteKnowledgeStore,
   LessonCapture,
+  VectorStore,
+  SparseStore,
+  EmbeddingPipeline,
+  HybridRetriever,
 } from "@jarvis/agent-framework";
 import { SqliteEntityGraph } from "@jarvis/agent-framework";
 import { SqliteDecisionLog } from "@jarvis/agent-framework";
@@ -13,6 +17,7 @@ import { ALL_AGENTS } from "@jarvis/agents";
 import { loadPlugins } from "./plugin-loader.js";
 import { computeNextFireAt } from "@jarvis/scheduler";
 import { loadConfig, JARVIS_DIR, KNOWLEDGE_DB_PATH } from "./config.js";
+import { RagPipeline } from "./rag-pipeline.js";
 import { openRuntimeDb } from "./runtime-db.js";
 import { createWorkerRegistry } from "./worker-registry.js";
 import { AgentQueue } from "./agent-queue.js";
@@ -122,11 +127,48 @@ async function main() {
   const memory = new SqliteMemoryStore(KNOWLEDGE_DB_PATH);
   const runtime = new AgentRuntime(memory);
   const lessonCapture = new LessonCapture(knowledgeStore);
+
+  // ─── Retrieval stores ────────────────────────────────────────────────────
+  // VectorStore and SparseStore self-create their tables on construction.
+  const vectorStore = new VectorStore(KNOWLEDGE_DB_PATH);
+  const sparseStore = new SparseStore(KNOWLEDGE_DB_PATH);
+  const embeddingBaseUrl = config.lmstudio_url ?? "http://localhost:1234";
+  const embeddingModel = "nomic-embed-text";
+  const embedFn: import("@jarvis/agent-framework").EmbedFn = async (params) => {
+    const { embedTexts } = await import("@jarvis/inference");
+    return embedTexts(params);
+  };
+  const hybridRetriever = new HybridRetriever({
+    vectorStore,
+    sparseStore,
+    embeddingBaseUrl,
+    embeddingModel,
+    embedFn,
+  });
+  logger.info("Retrieval stores initialized (vector + sparse + hybrid)");
+
   // Worker health monitor — tracks per-worker execution outcomes
   const healthMonitor = new WorkerHealthMonitor(WORKER_EXECUTION_POLICIES);
   setWorkerHealthProvider(() => healthMonitor.getHealthReport());
 
-  const registry = createWorkerRegistry(config, logger, runtimeDb, healthMonitor);
+  const registry = createWorkerRegistry(config, logger, runtimeDb, healthMonitor, {
+    hybridRetriever,
+  });
+
+  // ─── Embedding + RAG pipeline ────────────────────────────────────────────
+  // Created after registry (needs worker for embedding calls).
+  // EmbeddingPipeline is attached to the knowledge store so new documents
+  // are automatically chunked and embedded on ingestion.
+  const embeddingPipeline = new EmbeddingPipeline({
+    vectorStore,
+    sparseStore,
+    embeddingBaseUrl,
+    embeddingModel,
+    embedFn,
+  });
+  knowledgeStore.setEmbeddingPipeline(embeddingPipeline);
+  const ragPipeline = new RagPipeline(vectorStore, registry, logger, sparseStore);
+  logger.info("Embedding pipeline + RAG pipeline initialized");
 
   // DB-backed scheduler — persists across restarts
   const scheduler = new DbSchedulerStore(runtimeDb);
@@ -290,7 +332,7 @@ async function main() {
   }
 
   // Orchestrator deps
-  const deps = { runtime, registry, knowledgeStore, entityGraph, decisionLog, lessonCapture, logger, statusWriter, runtimeDb, channelStore };
+  const deps = { runtime, registry, knowledgeStore, entityGraph, decisionLog, lessonCapture, logger, statusWriter, runtimeDb, channelStore, ragPipeline };
 
   // Agent Queue
   const agentQueue = new AgentQueue(config.max_concurrent, deps, logger);

--- a/packages/jarvis-runtime/src/worker-registry.ts
+++ b/packages/jarvis-runtime/src/worker-registry.ts
@@ -36,7 +36,18 @@ export type WorkerRegistry = {
   getHealthMonitor(): WorkerHealthMonitor | undefined;
 };
 
-export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger, runtimeDb?: DatabaseSync, healthMonitor?: WorkerHealthMonitor): WorkerRegistry {
+export type WorkerRegistryOptions = {
+  embeddingPipeline?: import("@jarvis/agent-framework").EmbeddingPipeline;
+  hybridRetriever?: import("@jarvis/agent-framework").HybridRetriever;
+};
+
+export function createWorkerRegistry(
+  config: JarvisRuntimeConfig,
+  logger: Logger,
+  runtimeDb?: DatabaseSync,
+  healthMonitor?: WorkerHealthMonitor,
+  opts?: WorkerRegistryOptions,
+): WorkerRegistry {
   const useReal = config.adapter_mode === "real";
 
   // Audit helper: log credential access for security trail (best-effort)
@@ -50,7 +61,9 @@ export function createWorkerRegistry(config: JarvisRuntimeConfig, logger: Logger
   };
 
   // ─── Inference ──────────────────────────────────────────────────────────
-  const inferenceAdapter = useReal ? new DefaultInferenceAdapter(runtimeDb, config.lmstudio_url) : new MockInferenceAdapter();
+  const inferenceAdapter = useReal
+    ? new DefaultInferenceAdapter(runtimeDb, config.lmstudio_url, opts?.embeddingPipeline, opts?.hybridRetriever)
+    : new MockInferenceAdapter();
   const inferenceWorker = createInferenceWorker({ adapter: inferenceAdapter });
 
   // Chat helper for adapters that need LLM access.

--- a/tests/eval/retrieval/benchmark.ts
+++ b/tests/eval/retrieval/benchmark.ts
@@ -1,0 +1,95 @@
+/**
+ * Retrieval quality benchmark harness.
+ *
+ * Measures recall@k, precision@k, MRR, and hit-rate for the hybrid
+ * retriever across domain-specific query/relevance-doc pairs.
+ *
+ * Designed for deterministic local runs (no LLM calls needed).
+ * Uses the in-memory VectorStore and SparseStore with mock embeddings.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type BenchmarkQuery = {
+  query_id: string;
+  query: string;
+  collection?: string;
+  relevant_doc_ids: string[];
+};
+
+export type BenchmarkCorpus = {
+  domain: string;
+  documents: Array<{
+    doc_id: string;
+    collection: string;
+    text: string;
+  }>;
+  queries: BenchmarkQuery[];
+};
+
+export type BenchmarkResult = {
+  domain: string;
+  total_queries: number;
+  recall_at_5: number;
+  precision_at_5: number;
+  mrr: number;
+  hit_rate: number;
+  per_query: Array<{
+    query_id: string;
+    retrieved_ids: string[];
+    relevant_ids: string[];
+    recall: number;
+    precision: number;
+    reciprocal_rank: number;
+    hit: boolean;
+  }>;
+};
+
+// ─── Scoring ────────────────────────────────────────────────────────────────
+
+export function scoreBenchmark(
+  corpus: BenchmarkCorpus,
+  retrieveFn: (query: string, topK: number, collection?: string) => Array<{ docId: string; score: number }>,
+  topK = 5,
+): BenchmarkResult {
+  const perQuery: BenchmarkResult["per_query"] = [];
+
+  for (const q of corpus.queries) {
+    const results = retrieveFn(q.query, topK, q.collection);
+    const retrievedIds = results.map(r => r.docId);
+    const relevantSet = new Set(q.relevant_doc_ids);
+
+    const hits = retrievedIds.filter(id => relevantSet.has(id));
+    const recall = relevantSet.size === 0 ? 1.0 : hits.length / relevantSet.size;
+    const precision = retrievedIds.length === 0 ? 0 : hits.length / retrievedIds.length;
+
+    let reciprocalRank = 0;
+    for (let i = 0; i < retrievedIds.length; i++) {
+      if (relevantSet.has(retrievedIds[i])) {
+        reciprocalRank = 1 / (i + 1);
+        break;
+      }
+    }
+
+    perQuery.push({
+      query_id: q.query_id,
+      retrieved_ids: retrievedIds,
+      relevant_ids: q.relevant_doc_ids,
+      recall,
+      precision,
+      reciprocal_rank: reciprocalRank,
+      hit: hits.length > 0,
+    });
+  }
+
+  const n = perQuery.length || 1;
+  return {
+    domain: corpus.domain,
+    total_queries: corpus.queries.length,
+    recall_at_5: perQuery.reduce((s, q) => s + q.recall, 0) / n,
+    precision_at_5: perQuery.reduce((s, q) => s + q.precision, 0) / n,
+    mrr: perQuery.reduce((s, q) => s + q.reciprocal_rank, 0) / n,
+    hit_rate: perQuery.filter(q => q.hit).length / n,
+    per_query: perQuery,
+  };
+}

--- a/tests/eval/retrieval/corpora.ts
+++ b/tests/eval/retrieval/corpora.ts
@@ -1,0 +1,91 @@
+/**
+ * Domain-specific benchmark corpora for retrieval quality evaluation.
+ *
+ * Each corpus has documents seeded from Jarvis's knowledge domain
+ * and queries with expected relevant document IDs.
+ */
+
+import type { BenchmarkCorpus } from "./benchmark.js";
+
+export const CONTRACT_CORPUS: BenchmarkCorpus = {
+  domain: "contracts",
+  documents: [
+    { doc_id: "c-nda-baseline", collection: "contracts", text: "Jurisdiction: Romania or EU member state. Confidentiality: 3 years post-engagement, not indefinite. IP assignment: customer owns deliverables explicitly listed in SOW, not background IP. Liability cap: total fees paid in preceding 12 months. Indemnity: mutual and symmetric. Non-compete: 6 months, product-line specific. Payment: Net 30." },
+    { doc_id: "c-volvo-nda", collection: "contracts", text: "NDA between Thinking in Code and Volvo Cars. Swedish law jurisdiction. Confidentiality period: 5 years. IP assignment: all deliverables created for the project. Mutual indemnity. Liability capped at 12-month fees. Non-compete: specific product line, 6 months." },
+    { doc_id: "c-bosch-msa", collection: "contracts", text: "Master Service Agreement with Robert Bosch GmbH. German law jurisdiction. Payment terms: Net 45. IP: customer owns work product, TIC retains background IP license. Non-compete: automotive division only, 12 months. Termination: 60 days written notice." },
+    { doc_id: "c-us-msa", collection: "contracts", text: "MSA with US-based client under Delaware law. Unlimited indemnity clause. No liability cap specified. Perpetual confidentiality. Customer-only termination right. Payment contingent on customer satisfaction approval." },
+    { doc_id: "c-standard-sow", collection: "contracts", text: "Statement of Work for ASIL-D safety analysis. Fixed price EUR 85,000. Deliverables: HARA report, safety concept, TSR set, DIA. Timeline: 12 weeks. Acceptance criteria: formal review with customer safety team." },
+  ],
+  queries: [
+    { query_id: "cq-1", query: "What are the standard liability terms for TIC contracts?", relevant_doc_ids: ["c-nda-baseline"] },
+    { query_id: "cq-2", query: "Find contracts with non-EU jurisdiction", relevant_doc_ids: ["c-us-msa"] },
+    { query_id: "cq-3", query: "Which contracts have unlimited indemnity or no liability cap?", relevant_doc_ids: ["c-us-msa"] },
+    { query_id: "cq-4", query: "Volvo NDA confidentiality terms", relevant_doc_ids: ["c-volvo-nda"] },
+    { query_id: "cq-5", query: "ASIL-D safety analysis scope and deliverables", relevant_doc_ids: ["c-standard-sow"] },
+    { query_id: "cq-6", query: "Non-compete clause comparison across clients", relevant_doc_ids: ["c-nda-baseline", "c-volvo-nda", "c-bosch-msa", "c-us-msa"] },
+    { query_id: "cq-7", query: "Payment terms longer than Net 30", relevant_doc_ids: ["c-bosch-msa"] },
+  ],
+};
+
+export const EVIDENCE_CORPUS: BenchmarkCorpus = {
+  domain: "evidence",
+  documents: [
+    { doc_id: "e-iso-part6", collection: "iso26262", text: "ISO 26262 Part 6 required work products by ASIL level. ASIL A: software safety plan, design spec, unit tests. ASIL B adds: formal review of unit tests. ASIL C adds: MC/DC coverage, software safety analysis. ASIL D adds: independent review, 100% structural coverage, formal inspection records." },
+    { doc_id: "e-aspice-swe1", collection: "iso26262", text: "ASPICE SWE.1 Software Requirements Analysis. Purpose: establish software requirements. Base practices: elicitation, analysis, evaluation, agreement. Output: software requirements specification, traceability matrix from system requirements. Capability Level 2 requires: review records, stakeholder sign-off, change management log." },
+    { doc_id: "e-traceability", collection: "iso26262", text: "ISO 26262 traceability requirements for ASIL C and D. HSR to FSR to TSR to SSR requirement chain. SSR to SW Arch to SW Unit Design for design traceability. SSR to Test Cases to Test Results for test traceability. All links must be formally documented and reviewable." },
+    { doc_id: "e-dia-guide", collection: "playbooks", text: "Development Interface Agreement (DIA) guidelines. Required when work is split across suppliers. Must cover: responsibility matrix, deliverable formats, review gates, change notification process, tool compatibility, and traceability handoff procedures. Missing DIA is a common audit finding." },
+    { doc_id: "e-gate-review", collection: "case-studies", text: "Gate review findings from 14 supplier audits. Most common gap: SWE.1 work product completeness. Second: missing traceability from HSR to SSR. Third: no formal review records for ASIL C/D unit tests. Fourth: DIA gaps in multi-supplier projects." },
+  ],
+  queries: [
+    { query_id: "eq-1", query: "What work products are required for ASIL D?", relevant_doc_ids: ["e-iso-part6"] },
+    { query_id: "eq-2", query: "SWE.1 requirements for ASPICE Level 2", relevant_doc_ids: ["e-aspice-swe1"] },
+    { query_id: "eq-3", query: "Traceability chain from HSR to test results", relevant_doc_ids: ["e-traceability"] },
+    { query_id: "eq-4", query: "When is a DIA required and what should it cover?", relevant_doc_ids: ["e-dia-guide"] },
+    { query_id: "eq-5", query: "Most common audit findings in supplier gate reviews", relevant_doc_ids: ["e-gate-review"] },
+    { query_id: "eq-6", query: "MC/DC coverage requirements by ASIL level", relevant_doc_ids: ["e-iso-part6"] },
+  ],
+};
+
+export const PROPOSAL_CORPUS: BenchmarkCorpus = {
+  domain: "proposals",
+  documents: [
+    { doc_id: "p-rate-card", collection: "proposals", text: "Thinking in Code 2026 rate card. Senior Safety Engineer: EUR 130-180/h. Safety Architect ASIL-D: EUR 160-200/h. Cyber Security Engineer: EUR 120-160/h. AUTOSAR Architect: EUR 140-180/h. Standard engagement: T&M with 3-month minimum. Fixed price only for well-scoped work products." },
+    { doc_id: "p-volvo-proposal", collection: "proposals", text: "Proposal for Volvo ASIL-D E/E architecture safety analysis. Phase 1: 2-week diagnostic at EUR 12,000 fixed. Phase 2: 12-week delivery, 2 senior engineers, milestone-based pricing. Deliverables: HARA, FSC, TSR, DIA with 3 Tier-1s." },
+    { doc_id: "p-garrett-proposal", collection: "proposals", text: "Proposal for Garrett Motion E-Axle timing closure. Phase 1: 3-week diagnostic at EUR 15,000 fixed. Key risk: timing analysis tool compatibility. Phase 2: workstream ownership with dedicated timing specialist. 4 engineers assigned." },
+    { doc_id: "p-scope-lesson", collection: "lessons", text: "Every proposal that omitted explicit out-of-scope statements led to scope creep disputes. Include EXCLUSIONS section listing: validation of third-party components, tool qualification, production software delivery, acceptance testing unless specified." },
+    { doc_id: "p-phase1-lesson", collection: "lessons", text: "Phase 1 diagnostic for new clients prevents failed engagements. 3 of 5 proposals that skipped Phase 1 resulted in scope disputes. Always recommend Phase 1 for first-time clients. Fixed price EUR 5-15k depending on complexity." },
+  ],
+  queries: [
+    { query_id: "pq-1", query: "What is the standard rate for an ASIL-D safety architect?", relevant_doc_ids: ["p-rate-card"] },
+    { query_id: "pq-2", query: "Past proposals for Volvo", relevant_doc_ids: ["p-volvo-proposal"] },
+    { query_id: "pq-3", query: "Timing analysis engagement examples", relevant_doc_ids: ["p-garrett-proposal"] },
+    { query_id: "pq-4", query: "How to avoid scope creep in proposals", relevant_doc_ids: ["p-scope-lesson"] },
+    { query_id: "pq-5", query: "Should we always include a Phase 1 diagnostic?", relevant_doc_ids: ["p-phase1-lesson"] },
+    { query_id: "pq-6", query: "Fixed price quote for safety analysis", relevant_doc_ids: ["p-rate-card", "p-volvo-proposal"] },
+  ],
+};
+
+export const REGULATORY_CORPUS: BenchmarkCorpus = {
+  domain: "regulatory",
+  documents: [
+    { doc_id: "r-unr155", collection: "regulatory", text: "UN Regulation 155 on cybersecurity management systems. Effective July 2024 for new vehicle types. Requires OEMs to demonstrate cybersecurity management throughout vehicle lifecycle. Compliance mandatory for EU type approval. Impacts all Tier-1 suppliers providing connected ECUs." },
+    { doc_id: "r-iso21434", collection: "regulatory", text: "ISO/SAE 21434 Road vehicles Cybersecurity engineering. Published 2021, first amendment 2023. Defines cybersecurity lifecycle for automotive systems. Covers threat analysis, risk assessment, cybersecurity goals, verification, and validation. Referenced by UN R155 for compliance evidence." },
+    { doc_id: "r-cra", collection: "regulatory", text: "EU Cyber Resilience Act. Applies to products with digital elements sold in EU market. Mandatory vulnerability handling, security updates for product lifetime. Effective 2027 for most products. Impacts embedded automotive components if sold separately." },
+    { doc_id: "r-aspice-v4", collection: "regulatory", text: "ASPICE version 4.0 published Q1 2026. Key changes: merged SWE.1 and SWE.2 into single requirements/architecture practice. New explicit AI/ML process areas. Updated capability level criteria. Transition period: v3.1 assessments valid until 2028." },
+    { doc_id: "r-sotif", collection: "regulatory", text: "ISO 21448 SOTIF Safety of the Intended Functionality. Addresses safety risks from functional insufficiencies in sensor-based systems, ADAS, and autonomous driving. Supplements ISO 26262 for scenarios where hazards arise from nominal behavior, not systematic or random faults." },
+  ],
+  queries: [
+    { query_id: "rq-1", query: "Cybersecurity requirements for EU type approval", relevant_doc_ids: ["r-unr155"] },
+    { query_id: "rq-2", query: "What changed in ASPICE v4?", relevant_doc_ids: ["r-aspice-v4"] },
+    { query_id: "rq-3", query: "EU legislation affecting embedded automotive components", relevant_doc_ids: ["r-cra", "r-unr155"] },
+    { query_id: "rq-4", query: "Safety standard for ADAS functional insufficiencies", relevant_doc_ids: ["r-sotif"] },
+    { query_id: "rq-5", query: "ISO 21434 relationship to UN R155", relevant_doc_ids: ["r-iso21434", "r-unr155"] },
+  ],
+};
+
+export const ALL_CORPORA: BenchmarkCorpus[] = [
+  CONTRACT_CORPUS,
+  EVIDENCE_CORPUS,
+  PROPOSAL_CORPUS,
+  REGULATORY_CORPUS,
+];

--- a/tests/eval/retrieval/retrieval-benchmark.test.ts
+++ b/tests/eval/retrieval/retrieval-benchmark.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { SparseStore } from "@jarvis/agent-framework";
+import { scoreBenchmark } from "./benchmark.js";
+import type { BenchmarkResult } from "./benchmark.js";
+import { ALL_CORPORA, CONTRACT_CORPUS, EVIDENCE_CORPUS, PROPOSAL_CORPUS, REGULATORY_CORPUS } from "./corpora.js";
+import os from "node:os";
+import { join } from "node:path";
+import { unlinkSync, existsSync } from "node:fs";
+
+// ─── Sparse-only benchmark (deterministic, no model needed) ─────────────────
+
+describe("retrieval benchmark harness", () => {
+  it("scoreBenchmark computes correct metrics for perfect retrieval", () => {
+    const corpus = {
+      domain: "test",
+      documents: [
+        { doc_id: "d1", collection: "test", text: "alpha" },
+        { doc_id: "d2", collection: "test", text: "beta" },
+      ],
+      queries: [
+        { query_id: "q1", query: "alpha", relevant_doc_ids: ["d1"] },
+      ],
+    };
+    const result = scoreBenchmark(corpus, () => [{ docId: "d1", score: 1.0 }]);
+    expect(result.recall_at_5).toBe(1.0);
+    expect(result.precision_at_5).toBe(1.0);
+    expect(result.mrr).toBe(1.0);
+    expect(result.hit_rate).toBe(1.0);
+  });
+
+  it("scoreBenchmark computes correct metrics for no retrieval", () => {
+    const corpus = {
+      domain: "test",
+      documents: [{ doc_id: "d1", collection: "test", text: "alpha" }],
+      queries: [{ query_id: "q1", query: "alpha", relevant_doc_ids: ["d1"] }],
+    };
+    const result = scoreBenchmark(corpus, () => []);
+    expect(result.recall_at_5).toBe(0);
+    expect(result.precision_at_5).toBe(0);
+    expect(result.mrr).toBe(0);
+    expect(result.hit_rate).toBe(0);
+  });
+
+  it("scoreBenchmark handles partial retrieval", () => {
+    const corpus = {
+      domain: "test",
+      documents: [
+        { doc_id: "d1", collection: "test", text: "alpha" },
+        { doc_id: "d2", collection: "test", text: "beta" },
+      ],
+      queries: [
+        { query_id: "q1", query: "both", relevant_doc_ids: ["d1", "d2"] },
+      ],
+    };
+    const result = scoreBenchmark(corpus, () => [{ docId: "d1", score: 1.0 }]);
+    expect(result.recall_at_5).toBe(0.5);
+    expect(result.precision_at_5).toBe(1.0);
+    expect(result.mrr).toBe(1.0);
+    expect(result.hit_rate).toBe(1.0);
+  });
+});
+
+// ─── Sparse (BM25) benchmarks per domain ────────────────────────────────────
+
+describe("sparse retrieval benchmarks", () => {
+  let sparseStore: SparseStore;
+  const dbPath = join(os.tmpdir(), `jarvis-bench-sparse-${Date.now()}.db`);
+
+  beforeAll(() => {
+    sparseStore = new SparseStore(dbPath);
+    // Index all corpora
+    for (const corpus of ALL_CORPORA) {
+      for (const doc of corpus.documents) {
+        sparseStore.addChunks(doc.doc_id, [
+          { id: `${doc.doc_id}-0`, text: doc.text },
+        ], doc.collection);
+      }
+    }
+  });
+
+  afterAll(() => {
+    sparseStore.close();
+    if (existsSync(dbPath)) {
+      try { unlinkSync(dbPath); } catch { /* best-effort */ }
+    }
+  });
+
+  function sparseRetrieve(query: string, topK: number, collection?: string) {
+    return sparseStore.search(query, topK, collection).map(r => ({
+      docId: r.docId,
+      score: r.score,
+    }));
+  }
+
+  // Sparse-only thresholds are baselines.  The hybrid retriever (with dense
+  // embeddings) should exceed these significantly.  Target for hybrid: hit_rate >= 0.8.
+  it("contracts domain: sparse retrieval produces results", () => {
+    const result = scoreBenchmark(CONTRACT_CORPUS, sparseRetrieve);
+    expect(result.hit_rate).toBeGreaterThanOrEqual(0.15);
+    expect(result.domain).toBe("contracts");
+  });
+
+  it("evidence domain: sparse retrieval produces results", () => {
+    const result = scoreBenchmark(EVIDENCE_CORPUS, sparseRetrieve);
+    expect(result.hit_rate).toBeGreaterThanOrEqual(0.15);
+  });
+
+  it("proposals domain: sparse retrieval produces results", () => {
+    const result = scoreBenchmark(PROPOSAL_CORPUS, sparseRetrieve);
+    expect(result.hit_rate).toBeGreaterThanOrEqual(0.3);
+  });
+
+  it("regulatory domain: sparse retrieval produces results", () => {
+    const result = scoreBenchmark(REGULATORY_CORPUS, sparseRetrieve);
+    expect(result.hit_rate).toBeGreaterThanOrEqual(0.15);
+  });
+
+  it("all domains: overall MRR > 0 (baseline established)", () => {
+    const results: BenchmarkResult[] = [];
+    for (const corpus of ALL_CORPORA) {
+      results.push(scoreBenchmark(corpus, sparseRetrieve));
+    }
+    const totalQueries = results.reduce((s, r) => s + r.total_queries, 0);
+    const weightedMrr = results.reduce((s, r) => s + r.mrr * r.total_queries, 0) / totalQueries;
+    // Sparse-only baseline.  Hybrid target: MRR >= 0.7
+    expect(weightedMrr).toBeGreaterThan(0);
+  });
+});
+
+// ─── Corpus structural validation ──────────────────────────────────────────
+
+describe("benchmark corpora structural validation", () => {
+  for (const corpus of ALL_CORPORA) {
+    describe(`${corpus.domain} corpus`, () => {
+      it("has at least 4 documents", () => {
+        expect(corpus.documents.length).toBeGreaterThanOrEqual(4);
+      });
+
+      it("has at least 5 queries", () => {
+        expect(corpus.queries.length).toBeGreaterThanOrEqual(5);
+      });
+
+      it("all query relevant_doc_ids reference existing documents", () => {
+        const docIds = new Set(corpus.documents.map(d => d.doc_id));
+        for (const q of corpus.queries) {
+          for (const id of q.relevant_doc_ids) {
+            expect(docIds.has(id), `${q.query_id} references unknown doc ${id}`).toBe(true);
+          }
+        }
+      });
+
+      it("all documents have non-empty text", () => {
+        for (const doc of corpus.documents) {
+          expect(doc.text.trim().length).toBeGreaterThan(0);
+        }
+      });
+
+      it("query_ids are unique", () => {
+        const ids = corpus.queries.map(q => q.query_id);
+        expect(new Set(ids).size).toBe(ids.length);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Wire the existing hybrid retrieval stack (VectorStore + SparseStore + HybridRetriever + EmbeddingPipeline) into the live daemon runtime
- Auto-embed new documents on knowledge store ingestion
- Add retrieval quality benchmark harness with 4 domain corpora

## What changed

**Runtime wiring (3 files):**
- `daemon.ts`: Create retrieval stores at startup, pass `RagPipeline` to orchestrator deps, attach `EmbeddingPipeline` to `SqliteKnowledgeStore`
- `worker-registry.ts`: Pass `HybridRetriever` to `DefaultInferenceAdapter` so `ragQuery()` uses dense+sparse+RRF instead of keyword fallback
- `sqlite-knowledge.ts`: Add `setEmbeddingPipeline()` for deferred initialization

**Benchmark harness (3 new files):**
- `tests/eval/retrieval/benchmark.ts`: Recall@k, precision@k, MRR, hit-rate scoring
- `tests/eval/retrieval/corpora.ts`: 4 domain corpora (contracts, evidence, proposals, regulatory) — 20 documents, 24 queries with relevance judgments
- `tests/eval/retrieval/retrieval-benchmark.test.ts`: Sparse-only baselines established; hybrid targets documented as comments

## Test plan
- [x] 75 test files, 1593 tests pass
- [x] 144 contract examples validated
- [x] Sparse baseline benchmarks pass (hit-rate > 0.15 per domain)
- [ ] Hybrid benchmark with live embedding model (requires LM Studio with nomic-embed-text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)