### PR TITLE
Wave 4: Self-reflection loop — analytics + review reports

### DIFF
--- a/contracts/jarvis/v1/review-report.schema.json
+++ b/contracts/jarvis/v1/review-report.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "jarvis.v1.review-report",
+  "title": "Self-Reflection Review Report",
+  "description": "Structured weekly review artifact produced by the self-reflection agent.",
+  "definitions": {
+    "ProposalCategory": {
+      "type": "string",
+      "enum": [
+        "prompt_change",
+        "schema_enhancement",
+        "knowledge_gap",
+        "retrieval_miss",
+        "approval_friction",
+        "workflow_optimization"
+      ]
+    },
+    "ProposalPriority": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"]
+    },
+    "ImprovementProposal": {
+      "type": "object",
+      "required": ["category", "target", "observation", "recommendation", "expected_impact", "priority"],
+      "properties": {
+        "category": { "$ref": "#/definitions/ProposalCategory" },
+        "target": {
+          "type": "string",
+          "description": "Which agent, schema, collection, or workflow is affected."
+        },
+        "observation": {
+          "type": "string",
+          "description": "What the data shows, with specific numbers."
+        },
+        "recommendation": {
+          "type": "string",
+          "description": "Concrete action to take."
+        },
+        "expected_impact": {
+          "type": "string",
+          "description": "Estimated improvement."
+        },
+        "priority": { "$ref": "#/definitions/ProposalPriority" },
+        "source_run_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Run IDs that evidence this proposal."
+        },
+        "source_approval_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Approval IDs that evidence this proposal."
+        }
+      }
+    },
+    "ReviewReport": {
+      "type": "object",
+      "required": ["report_id", "period_start", "period_end", "health_score", "proposals", "agent_metrics", "approval_metrics", "knowledge_metrics"],
+      "properties": {
+        "report_id": { "type": "string" },
+        "period_start": { "type": "string", "format": "date-time" },
+        "period_end": { "type": "string", "format": "date-time" },
+        "health_score": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "proposals": {
+          "type": "array",
+          "minItems": 5,
+          "items": { "$ref": "#/definitions/ImprovementProposal" }
+        },
+        "agent_metrics": {
+          "type": "object",
+          "description": "Per-agent success/failure/step metrics."
+        },
+        "approval_metrics": {
+          "type": "object",
+          "description": "Approval funnel: rejection rate, latency, by action and severity."
+        },
+        "knowledge_metrics": {
+          "type": "object",
+          "description": "Collection coverage, staleness, thin collections."
+        },
+        "previous_report_id": {
+          "type": "string",
+          "description": "ID of the prior weekly report for week-over-week comparison."
+        }
+      }
+    }
+  }
+}

--- a/packages/jarvis-agent-framework/src/sqlite-knowledge.ts
+++ b/packages/jarvis-agent-framework/src/sqlite-knowledge.ts
@@ -322,6 +322,43 @@ export class SqliteKnowledgeStore {
     };
   }
 
+  // ─── Analytics for self-reflection ──────────────────────────────────────────
+
+  /** Find documents not updated in the past N days. */
+  getStaleDocuments(ageDays = 30, collection?: string): KnowledgeDocument[] {
+    const cutoff = new Date(Date.now() - ageDays * 86400000).toISOString();
+    const sql = collection
+      ? "SELECT * FROM documents WHERE updated_at < ? AND collection = ? ORDER BY updated_at ASC LIMIT 50"
+      : "SELECT * FROM documents WHERE updated_at < ? ORDER BY updated_at ASC LIMIT 50";
+    const params = collection ? [cutoff, collection] : [cutoff];
+    const rows = this.db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
+    return rows.map(r => this.rowToDocument(r));
+  }
+
+  /** Find collections with fewer than minDocs documents. */
+  getThinCollections(minDocs = 3): Array<{ collection: string; count: number }> {
+    return this.db.prepare(`
+      SELECT collection, COUNT(*) as count
+      FROM documents
+      GROUP BY collection
+      HAVING COUNT(*) < ?
+      ORDER BY count ASC
+    `).all(minDocs) as any[];
+  }
+
+  /** Collection freshness: latest document date per collection. */
+  getCollectionFreshness(): Array<{ collection: string; count: number; newest: string; oldest: string }> {
+    return this.db.prepare(`
+      SELECT collection,
+             COUNT(*) as count,
+             MAX(updated_at) as newest,
+             MIN(created_at) as oldest
+      FROM documents
+      GROUP BY collection
+      ORDER BY newest DESC
+    `).all() as any[];
+  }
+
   // ─── Helpers ────────────────────────────────────────────────────────────────
 
   private rowToDocument(row: Record<string, unknown>): KnowledgeDocument {

--- a/packages/jarvis-agents/src/index.ts
+++ b/packages/jarvis-agents/src/index.ts
@@ -12,3 +12,5 @@ export { MATURITY_LADDER, mapRuntimeMaturity } from "./maturity.js";
 export type { MaturityLevel, PromotionCriteria } from "./maturity.js";
 export { scoreFixture, SCORE_THRESHOLDS } from "./eval.js";
 export type { EvalFixture, EvalInput, EvalExpected, Scorecard, ScorecardDimension, DimensionScore } from "./eval.js";
+export { calculateHealthScore, assembleReport } from "./review-report.js";
+export type { ReviewReport, ImprovementProposal, ProposalCategory, ProposalPriority, AgentMetrics } from "./review-report.js";

--- a/packages/jarvis-agents/src/review-report.ts
+++ b/packages/jarvis-agents/src/review-report.ts
@@ -1,0 +1,143 @@
+/**
+ * Review report builder for the self-reflection agent.
+ *
+ * Collects metrics from run-store, approval-bridge, and knowledge-store,
+ * then assembles a structured ReviewReport artifact.  The report is stored
+ * in the "lessons" knowledge collection for downstream consumption.
+ *
+ * This module does NOT produce improvement proposals — that's the LLM's job.
+ * It provides the data substrate the LLM reasons over.
+ */
+
+import { randomUUID } from "node:crypto";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type ProposalCategory =
+  | "prompt_change"
+  | "schema_enhancement"
+  | "knowledge_gap"
+  | "retrieval_miss"
+  | "approval_friction"
+  | "workflow_optimization";
+
+export type ProposalPriority = "critical" | "high" | "medium" | "low";
+
+export type ImprovementProposal = {
+  category: ProposalCategory;
+  target: string;
+  observation: string;
+  recommendation: string;
+  expected_impact: string;
+  priority: ProposalPriority;
+  source_run_ids?: string[];
+  source_approval_ids?: string[];
+};
+
+export type AgentMetrics = {
+  agent_id: string;
+  total: number;
+  completed: number;
+  failed: number;
+  success_rate: number;
+  avg_steps: number;
+};
+
+export type ApprovalMetricsSummary = {
+  total: number;
+  approved: number;
+  rejected: number;
+  rejection_rate: number;
+  avg_latency_ms: number | null;
+  by_action: Array<{ action: string; total: number; rejected: number }>;
+};
+
+export type KnowledgeMetricsSummary = {
+  total_documents: number;
+  collections: Record<string, number>;
+  stale_count: number;
+  thin_collections: Array<{ collection: string; count: number }>;
+  freshness: Array<{ collection: string; count: number; newest: string }>;
+};
+
+export type ReviewReport = {
+  report_id: string;
+  period_start: string;
+  period_end: string;
+  health_score: number;
+  proposals: ImprovementProposal[];
+  agent_metrics: AgentMetrics[];
+  system_metrics: {
+    total_runs: number;
+    completed: number;
+    failed: number;
+    success_rate: number;
+    active_agents: number;
+  };
+  approval_metrics: ApprovalMetricsSummary;
+  knowledge_metrics: KnowledgeMetricsSummary;
+  failure_modes: Array<{ error: string; count: number; agent_id: string }>;
+  previous_report_id?: string;
+};
+
+// ─── Health score calculation ───────────────────────────────────────────────
+
+/**
+ * Calculate a system health score from 0-100.
+ *
+ * Weighted components:
+ * - Run success rate: 40 points (100% success = 40)
+ * - Approval rejection rate: 20 points (0% rejection = 20)
+ * - Knowledge coverage: 20 points (no thin collections = 20)
+ * - Agent coverage: 20 points (all agents ran at least once = 20)
+ */
+export function calculateHealthScore(
+  systemStats: { success_rate: number; active_agents: number },
+  approvalMetrics: { rejection_rate: number },
+  knowledgeMetrics: { thin_collections: Array<unknown> },
+  totalRegisteredAgents: number,
+): number {
+  const runScore = Math.round(systemStats.success_rate * 40);
+  const approvalScore = Math.round((1 - approvalMetrics.rejection_rate) * 20);
+  const knowledgeScore = knowledgeMetrics.thin_collections.length === 0 ? 20 : Math.max(0, 20 - knowledgeMetrics.thin_collections.length * 4);
+  const agentCoverage = totalRegisteredAgents > 0
+    ? Math.round((systemStats.active_agents / totalRegisteredAgents) * 20)
+    : 20;
+
+  return Math.min(100, Math.max(0, runScore + approvalScore + knowledgeScore + agentCoverage));
+}
+
+/**
+ * Assemble a ReviewReport from collected metrics.
+ *
+ * This produces the data frame — the LLM adds proposals, observation
+ * text, and rankings in the self-reflection agent execution.
+ */
+export function assembleReport(params: {
+  agentMetrics: AgentMetrics[];
+  systemMetrics: ReviewReport["system_metrics"];
+  approvalMetrics: ApprovalMetricsSummary;
+  knowledgeMetrics: KnowledgeMetricsSummary;
+  failureModes: ReviewReport["failure_modes"];
+  healthScore: number;
+  periodDays?: number;
+  previousReportId?: string;
+}): ReviewReport {
+  const now = new Date();
+  const periodDays = params.periodDays ?? 7;
+  const periodStart = new Date(now.getTime() - periodDays * 86400000);
+
+  return {
+    report_id: randomUUID(),
+    period_start: periodStart.toISOString(),
+    period_end: now.toISOString(),
+    health_score: params.healthScore,
+    proposals: [], // LLM fills these during agent execution
+    agent_metrics: params.agentMetrics,
+    system_metrics: params.systemMetrics,
+    approval_metrics: params.approvalMetrics,
+    knowledge_metrics: params.knowledgeMetrics,
+    failure_modes: params.failureModes,
+    previous_report_id: params.previousReportId,
+  };
+}

--- a/packages/jarvis-runtime/src/approval-bridge.ts
+++ b/packages/jarvis-runtime/src/approval-bridge.ts
@@ -188,3 +188,67 @@ export function listApprovals(
     "SELECT approval_id as id, agent_id as agent, action, payload_json as payload, requested_at as created_at, status, run_id, severity, resolved_at, resolved_by, resolution_note FROM approvals ORDER BY requested_at DESC",
   ).all() as ApprovalEntry[];
 }
+
+// ─── Approval analytics for self-reflection ───────────────────────────────
+
+export type ApprovalMetrics = {
+  total: number;
+  approved: number;
+  rejected: number;
+  expired: number;
+  pending: number;
+  rejection_rate: number;
+  avg_latency_ms: number | null;
+  by_action: Array<{ action: string; total: number; rejected: number }>;
+  by_severity: Array<{ severity: string; total: number; rejected: number }>;
+};
+
+/** Aggregated approval metrics over the past N days. */
+export function getApprovalMetrics(db: DatabaseSync, days = 7): ApprovalMetrics {
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+  const totals = db.prepare(`
+    SELECT
+      COUNT(*) as total,
+      SUM(CASE WHEN status = 'approved' THEN 1 ELSE 0 END) as approved,
+      SUM(CASE WHEN status = 'rejected' THEN 1 ELSE 0 END) as rejected,
+      SUM(CASE WHEN status = 'expired' THEN 1 ELSE 0 END) as expired,
+      SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending
+    FROM approvals
+    WHERE requested_at >= ?
+  `).get(cutoff) as any;
+
+  const latency = db.prepare(`
+    SELECT AVG(
+      (julianday(resolved_at) - julianday(requested_at)) * 86400000
+    ) as avg_ms
+    FROM approvals
+    WHERE requested_at >= ? AND resolved_at IS NOT NULL
+  `).get(cutoff) as { avg_ms: number | null };
+
+  const byAction = db.prepare(`
+    SELECT action,
+           COUNT(*) as total,
+           SUM(CASE WHEN status = 'rejected' THEN 1 ELSE 0 END) as rejected
+    FROM approvals
+    WHERE requested_at >= ?
+    GROUP BY action ORDER BY total DESC
+  `).all(cutoff) as any[];
+
+  const bySeverity = db.prepare(`
+    SELECT severity,
+           COUNT(*) as total,
+           SUM(CASE WHEN status = 'rejected' THEN 1 ELSE 0 END) as rejected
+    FROM approvals
+    WHERE requested_at >= ?
+    GROUP BY severity ORDER BY total DESC
+  `).all(cutoff) as any[];
+
+  return {
+    ...totals,
+    rejection_rate: totals.total > 0 ? Math.round((totals.rejected / totals.total) * 1000) / 1000 : 0,
+    avg_latency_ms: latency.avg_ms ? Math.round(latency.avg_ms) : null,
+    by_action: byAction,
+    by_severity: bySeverity,
+  };
+}

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -9,7 +9,7 @@ export { buildPlanMultiViewpoint, type MultiPlanResult } from "./planner-multi.j
 export { scorePlan, rankPlans, detectDisagreement, type PlanScore } from "./plan-evaluator.js";
 export { runAgent, type OrchestratorDeps } from "./orchestrator.js";
 export { RunStore, type RunStatus, type RunEventType } from "./run-store.js";
-export { requestApproval, waitForApproval, resolveApproval, delegateApproval, listApprovals, listApprovalsByAssignee, type ApprovalEntry } from "./approval-bridge.js";
+export { requestApproval, waitForApproval, resolveApproval, delegateApproval, listApprovals, listApprovalsByAssignee, getApprovalMetrics, type ApprovalEntry, type ApprovalMetrics } from "./approval-bridge.js";
 export { writeTelegramQueue } from "./notify.js";
 export { createFilesWorkerBridge } from "./files-bridge.js";
 export { StatusWriter, type DaemonStatusData } from "./status-writer.js";

--- a/packages/jarvis-runtime/src/run-store.ts
+++ b/packages/jarvis-runtime/src/run-store.ts
@@ -290,6 +290,68 @@ export class RunStore {
     return (result as { changes: number }).changes;
   }
 
+  // ─── Analytics queries for self-reflection ──────────────────────────────
+
+  /** Per-agent success/failure counts over the past N days. */
+  getAgentStats(days = 7): Array<{
+    agent_id: string;
+    total: number;
+    completed: number;
+    failed: number;
+    success_rate: number;
+    avg_steps: number;
+  }> {
+    const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+    return this.db.prepare(`
+      SELECT agent_id,
+             COUNT(*) as total,
+             SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+             SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+             ROUND(CAST(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS REAL) / MAX(COUNT(*), 1), 3) as success_rate,
+             ROUND(AVG(COALESCE(current_step, 0)), 1) as avg_steps
+      FROM runs
+      WHERE started_at >= ?
+      GROUP BY agent_id
+      ORDER BY total DESC
+    `).all(cutoff) as any[];
+  }
+
+  /** Failure mode summary: most common error messages over the past N days. */
+  getFailureModes(days = 7, limit = 10): Array<{ error: string; count: number; agent_id: string }> {
+    const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+    return this.db.prepare(`
+      SELECT error, COUNT(*) as count, agent_id
+      FROM runs
+      WHERE status = 'failed' AND started_at >= ? AND error IS NOT NULL
+      GROUP BY error, agent_id
+      ORDER BY count DESC
+      LIMIT ?
+    `).all(cutoff, limit) as any[];
+  }
+
+  /** System-wide stats over the past N days. */
+  getSystemStats(days = 7): {
+    total_runs: number;
+    completed: number;
+    failed: number;
+    success_rate: number;
+    active_agents: number;
+  } {
+    const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+    const row = this.db.prepare(`
+      SELECT COUNT(*) as total_runs,
+             SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+             SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+             COUNT(DISTINCT agent_id) as active_agents
+      FROM runs
+      WHERE started_at >= ?
+    `).get(cutoff) as any;
+    return {
+      ...row,
+      success_rate: row.total_runs > 0 ? Math.round((row.completed / row.total_runs) * 1000) / 1000 : 0,
+    };
+  }
+
   /** Mark a run's associated command as completed, failed, or cancelled. */
   completeCommand(runId: string, status: "completed" | "failed" | "cancelled"): void {
     this.db.prepare(`

--- a/packages/jarvis-runtime/src/workflows.ts
+++ b/packages/jarvis-runtime/src/workflows.ts
@@ -240,4 +240,28 @@ export const V1_WORKFLOWS: WorkflowDefinition[] = [
       retry_requires_approval: false,
     },
   },
+  {
+    workflow_id: "self-review",
+    name: "System Self-Review",
+    description: "Analyze agent performance, approval friction, knowledge quality, and produce a ranked improvement report. Review-first: proposals are never auto-applied.",
+    agent_ids: ["self-reflection"],
+    expected_output: "Weekly review report with health score and ranked improvement proposals",
+    inputs: [
+      { name: "period_days", label: "Analysis period (days)", type: "text", required: false, placeholder: "7" },
+    ],
+    approval_summary: "No approval needed (read-only analysis)",
+    preview_available: false,
+    pack: "core",
+    output_fields: [
+      { name: "health_score", label: "System health score (0-100)", type: "text", required: true },
+      { name: "proposals", label: "Improvement proposals", type: "list", required: true },
+      { name: "report", label: "Full review report", type: "document", required: true },
+    ],
+    safety_rules: {
+      outbound_default: "blocked",
+      preview_recommended: false,
+      retry_safe: true,
+      retry_requires_approval: false,
+    },
+  },
 ];

--- a/tests/self-reflection-loop.test.ts
+++ b/tests/self-reflection-loop.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import os from "node:os";
+import { join } from "node:path";
+import { unlinkSync, existsSync } from "node:fs";
+import { runMigrations, KNOWLEDGE_MIGRATIONS, RunStore, getApprovalMetrics } from "@jarvis/runtime";
+import { SqliteKnowledgeStore } from "@jarvis/agent-framework";
+import { calculateHealthScore, assembleReport } from "@jarvis/agents";
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function createRuntimeDb(): { db: DatabaseSync; path: string } {
+  const dbPath = join(os.tmpdir(), `jarvis-reflect-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA foreign_keys = ON;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  runMigrations(db);
+  return { db, path: dbPath };
+}
+
+// ─── RunStore analytics ─────────────────────────────────────────────────────
+
+describe("RunStore analytics", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+  let store: RunStore;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createRuntimeDb());
+    store = new RunStore(db);
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch {}
+    if (existsSync(dbPath)) try { unlinkSync(dbPath); } catch {}
+  });
+
+  it("getAgentStats returns per-agent metrics", () => {
+    // Insert runs directly for analytics testing (bypass state machine)
+    const now = new Date().toISOString();
+    db.prepare("INSERT INTO runs (run_id, agent_id, status, started_at, current_step) VALUES (?, ?, ?, ?, ?)").run("r1", "evidence-auditor", "completed", now, 5);
+    db.prepare("INSERT INTO runs (run_id, agent_id, status, started_at, current_step, error) VALUES (?, ?, ?, ?, ?, ?)").run("r2", "evidence-auditor", "failed", now, 3, "timeout");
+
+    const stats = store.getAgentStats(7);
+    const ea = stats.find(s => s.agent_id === "evidence-auditor");
+    expect(ea).toBeDefined();
+    expect(ea!.total).toBe(2);
+    expect(ea!.completed).toBe(1);
+    expect(ea!.failed).toBe(1);
+    expect(ea!.success_rate).toBe(0.5);
+  });
+
+  it("getFailureModes returns error summaries", () => {
+    const now = new Date().toISOString();
+    db.prepare("INSERT INTO runs (run_id, agent_id, status, started_at, error) VALUES (?, ?, ?, ?, ?)").run("r3", "orchestrator", "failed", now, "timeout after 30s");
+    db.prepare("INSERT INTO runs (run_id, agent_id, status, started_at, error) VALUES (?, ?, ?, ?, ?)").run("r4", "orchestrator", "failed", now, "timeout after 30s");
+
+    const modes = store.getFailureModes(7);
+    expect(modes.length).toBeGreaterThanOrEqual(1);
+    expect(modes[0].count).toBe(2);
+  });
+
+  it("getSystemStats returns overall summary", () => {
+    const now = new Date().toISOString();
+    db.prepare("INSERT INTO runs (run_id, agent_id, status, started_at) VALUES (?, ?, ?, ?)").run("r5", "proposal-engine", "completed", now);
+    db.prepare("INSERT INTO runs (run_id, agent_id, status, started_at) VALUES (?, ?, ?, ?)").run("r6", "staffing-monitor", "completed", now);
+
+    const stats = store.getSystemStats(7);
+    expect(stats.total_runs).toBeGreaterThanOrEqual(2);
+    expect(stats.active_agents).toBeGreaterThanOrEqual(2);
+    expect(stats.success_rate).toBeGreaterThan(0);
+  });
+});
+
+// ─── Approval analytics ─────────────────────────────────────────────────────
+
+describe("Approval analytics", () => {
+  let db: DatabaseSync;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ db, path: dbPath } = createRuntimeDb());
+  });
+
+  afterEach(() => {
+    try { db.close(); } catch {}
+    if (existsSync(dbPath)) try { unlinkSync(dbPath); } catch {}
+  });
+
+  it("getApprovalMetrics aggregates approval data", () => {
+    const now = new Date().toISOString();
+    db.prepare(
+      "INSERT INTO approvals (approval_id, run_id, agent_id, action, severity, status, requested_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run("a1", "r1", "contract-reviewer", "document.generate_report", "warning", "pending", now);
+    db.prepare(
+      "INSERT INTO approvals (approval_id, run_id, agent_id, action, severity, status, requested_at, resolved_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run("a2", "r2", "proposal-engine", "email.send", "critical", "approved", now, now);
+
+    const metrics = getApprovalMetrics(db, 7);
+    expect(metrics.total).toBe(2);
+    expect(metrics.pending).toBe(1);
+    expect(metrics.approved).toBe(1);
+    expect(metrics.by_action.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── Knowledge store analytics ──────────────────────────────────────────────
+
+describe("SqliteKnowledgeStore analytics", () => {
+  let store: SqliteKnowledgeStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = join(os.tmpdir(), `jarvis-kb-reflect-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    // Run knowledge migrations to create tables before opening the store
+    const setupDb = new DatabaseSync(dbPath);
+    setupDb.exec("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+    runMigrations(setupDb, KNOWLEDGE_MIGRATIONS);
+    setupDb.close();
+    store = new SqliteKnowledgeStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    if (existsSync(dbPath)) try { unlinkSync(dbPath); } catch {}
+  });
+
+  it("getThinCollections finds collections with few documents", () => {
+    store.addDocument({ collection: "proposals" as any, title: "Only one", content: "Single doc", tags: [] });
+    const thin = store.getThinCollections(3);
+    expect(thin.some(c => c.collection === "proposals" && c.count < 3)).toBe(true);
+  });
+
+  it("getCollectionFreshness returns per-collection dates", () => {
+    store.addDocument({ collection: "contracts" as any, title: "Test", content: "Content", tags: [] });
+    const freshness = store.getCollectionFreshness();
+    expect(freshness.some(c => c.collection === "contracts")).toBe(true);
+    expect(freshness[0].newest).toBeTruthy();
+  });
+
+  it("getStaleDocuments returns empty for fresh documents", () => {
+    store.addDocument({ collection: "lessons" as any, title: "Fresh", content: "Content", tags: [] });
+    const stale = store.getStaleDocuments(30);
+    expect(stale).toHaveLength(0);
+  });
+});
+
+// ─── Health score calculation ───────────────────────────────────────────────
+
+describe("calculateHealthScore", () => {
+  it("perfect system scores 100", () => {
+    const score = calculateHealthScore(
+      { success_rate: 1.0, active_agents: 8 },
+      { rejection_rate: 0 },
+      { thin_collections: [] },
+      8,
+    );
+    expect(score).toBe(100);
+  });
+
+  it("50% success rate with full coverage still scores 80", () => {
+    const score = calculateHealthScore(
+      { success_rate: 0.5, active_agents: 8 },
+      { rejection_rate: 0 },
+      { thin_collections: [] },
+      8,
+    );
+    // 20 (run: 0.5*40) + 20 (approval) + 20 (knowledge) + 20 (agent coverage) = 80
+    expect(score).toBe(80);
+  });
+
+  it("zero runs and zero agents scores low", () => {
+    const score = calculateHealthScore(
+      { success_rate: 0, active_agents: 0 },
+      { rejection_rate: 0 },
+      { thin_collections: [] },
+      8,
+    );
+    // 0 (run) + 20 (approval) + 20 (knowledge) + 0 (agents) = 40
+    expect(score).toBe(40);
+  });
+
+  it("thin collections reduce knowledge score", () => {
+    const scoreClean = calculateHealthScore(
+      { success_rate: 1.0, active_agents: 8 },
+      { rejection_rate: 0 },
+      { thin_collections: [] },
+      8,
+    );
+    const scoreThin = calculateHealthScore(
+      { success_rate: 1.0, active_agents: 8 },
+      { rejection_rate: 0 },
+      { thin_collections: [1, 2, 3] as any[] },
+      8,
+    );
+    expect(scoreThin).toBeLessThan(scoreClean);
+  });
+
+  it("high rejection rate reduces approval score", () => {
+    const score = calculateHealthScore(
+      { success_rate: 1.0, active_agents: 8 },
+      { rejection_rate: 0.5 },
+      { thin_collections: [] },
+      8,
+    );
+    // 40 (run) + 10 (approval: (1-0.5)*20) + 20 (knowledge) + 20 (agents) = 90
+    expect(score).toBe(90);
+  });
+});
+
+// ─── Report assembly ────────────────────────────────────────────────────────
+
+describe("assembleReport", () => {
+  it("produces a valid ReviewReport structure", () => {
+    const report = assembleReport({
+      agentMetrics: [{ agent_id: "evidence-auditor", total: 10, completed: 8, failed: 2, success_rate: 0.8, avg_steps: 5 }],
+      systemMetrics: { total_runs: 10, completed: 8, failed: 2, success_rate: 0.8, active_agents: 3 },
+      approvalMetrics: { total: 5, approved: 4, rejected: 1, rejection_rate: 0.2, avg_latency_ms: 5000, by_action: [] },
+      knowledgeMetrics: {
+        total_documents: 50,
+        collections: { lessons: 20, proposals: 15, contracts: 15 },
+        stale_count: 3,
+        thin_collections: [],
+        freshness: [{ collection: "lessons", count: 20, newest: new Date().toISOString() }],
+      },
+      failureModes: [{ error: "timeout", count: 2, agent_id: "orchestrator" }],
+      healthScore: 75,
+    });
+
+    expect(report.report_id).toBeTruthy();
+    expect(report.health_score).toBe(75);
+    expect(report.proposals).toHaveLength(0);
+    expect(report.agent_metrics).toHaveLength(1);
+    expect(report.system_metrics.total_runs).toBe(10);
+    expect(report.period_start).toBeTruthy();
+  });
+
+  it("links to previous report when provided", () => {
+    const report = assembleReport({
+      agentMetrics: [],
+      systemMetrics: { total_runs: 0, completed: 0, failed: 0, success_rate: 0, active_agents: 0 },
+      approvalMetrics: { total: 0, approved: 0, rejected: 0, rejection_rate: 0, avg_latency_ms: null, by_action: [] },
+      knowledgeMetrics: { total_documents: 0, collections: {}, stale_count: 0, thin_collections: [], freshness: [] },
+      failureModes: [],
+      healthScore: 50,
+      previousReportId: "prev-report-123",
+    });
+    expect(report.previous_report_id).toBe("prev-report-123");
+  });
+});


### PR DESCRIPTION
## Summary
- Add analytics query methods to RunStore, approval-bridge, and SqliteKnowledgeStore for self-reflection agent consumption
- Create review report schema, health score calculator, and report builder
- Add self-review workflow to V1_WORKFLOWS for dashboard triggering

## Changes

### Analytics queries (3 files)
- `run-store.ts`: `getAgentStats()`, `getFailureModes()`, `getSystemStats()` — per-agent success rates, failure modes, system summary over configurable time window
- `approval-bridge.ts`: `getApprovalMetrics()` — rejection rates, latency, breakdown by action and severity
- `sqlite-knowledge.ts`: `getStaleDocuments()`, `getThinCollections()`, `getCollectionFreshness()` — knowledge quality metrics

### Review report infrastructure (3 new files)
- `review-report.schema.json`: ProposalCategory enum, ImprovementProposal, ReviewReport JSON schemas
- `review-report.ts`: `calculateHealthScore()` (weighted 40/20/20/20) + `assembleReport()` builder
- Self-review workflow in `workflows.ts`

### Design principle
Builder collects metrics, LLM produces proposals. Reports store in "lessons" collection. Proposals are **never auto-applied** — review-first by design.

## Test plan
- [x] 77 test files, 1611 tests pass
- [x] 144 contract examples validated
- [x] RunStore analytics: agent stats, failure modes, system stats
- [x] Approval metrics: aggregation, rejection rates
- [x] Knowledge analytics: thin collections, freshness, staleness
- [x] Health score: perfect=100, degraded<100, edge cases
- [x] Report assembly: valid structure, previous report linkage

🤖 Generated with [Claude Code](https://claude.com/claude-code)