### PR TITLE
Platform/kernel convergence: OpenClaw substrate + Jarvis domain kernel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,16 @@ Each agent is a Claude Code skill invocable via slash command:
 
 Agents with schedules run automatically via scheduled tasks. Manual agents run on demand.
 
+## Platform/Kernel Boundary
+
+See `docs/ADR-PLATFORM-KERNEL-BOUNDARY.md` for the authoritative ownership split.
+
+**OpenClaw owns**: channels, sessions, browser lifecycle, webhook ingress, automation surfaces, operator chat loop
+**Jarvis owns**: domain policy, approvals, jarvis.v1 contracts, CRM/knowledge/runtime state, specialized workers
+
+Architecture boundary tests (`tests/architecture-boundary.test.ts`) enforce forbidden patterns in CI.
+Convergence roadmap: `docs/CONVERGENCE-ROADMAP.md` (12 epics, 3-year plan).
+
 ## Architecture
 
 Jarvis has two execution modes:

--- a/docs/ADR-CHAT-SURFACES.md
+++ b/docs/ADR-CHAT-SURFACES.md
@@ -1,7 +1,9 @@
 # ADR: Chat and Godmode Surface Architecture
 
-**Status**: Decided (April 2026)
+**Status**: Superseded by [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md) (April 2026)
 **Context**: Jarvis has two interactive chat surfaces beyond the runtime kernel: `/api/chat/telegram` and `/api/godmode`. This document records what they are, what they are not, and why they exist as separate surfaces.
+
+> **Note**: This ADR documented an acceptable compromise. [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md) supersedes it with a convergence commitment: these separate LLM loops will be replaced by OpenClaw session-backed operator chat (Epic 5). The compromise remains valid until Epic 5 lands.
 
 ## Decision
 

--- a/docs/ADR-MEMORY-TAXONOMY.md
+++ b/docs/ADR-MEMORY-TAXONOMY.md
@@ -1,0 +1,85 @@
+# ADR: Memory Taxonomy — Session State vs Domain Knowledge
+
+**Status**: Proposed (April 2026)
+**Context**: The convergence from direct LLM loops to OpenClaw session-backed operator chat creates a need to clarify what belongs in OpenClaw session memory versus Jarvis durable domain knowledge.
+
+## Problem
+
+Today Jarvis has two distinct memory systems that don't interact:
+
+1. **Jarvis domain state** — SQLite-backed in `runtime.db`, `crm.db`, `knowledge.db`:
+   - Agent memory (short-term per-run + long-term persistent)
+   - CRM contacts, notes, pipeline stages
+   - Knowledge documents, playbooks, entities, relations, decisions
+   - Run history, approvals, audit log
+   - Lessons captured from completed runs
+
+2. **Conversation state** — currently in-process or custom history:
+   - Telegram: durable via ChannelStore (thread-scoped messages)
+   - Dashboard/godmode: per-session SSE streaming state
+   - No compaction, no checkpoints, no branch/restore
+
+When operator chat moves to OpenClaw sessions (Epic 5), a third memory layer appears:
+3. **OpenClaw session state** — compaction, checkpoints, branch/restore, memory-wiki
+
+Without clear taxonomy, facts will be stored in the wrong place, creating fragmentation.
+
+## Decision
+
+### Memory Categories
+
+| Category | Description | Owner | Store | Lifecycle |
+|---|---|---|---|---|
+| **Conversation context** | What was said in the current operator chat session | OpenClaw | Session state + compaction | Session-scoped, compacted over time |
+| **Run state** | Active runs, their progress, intermediate results | Jarvis | `runtime.db` | Run-scoped, persists after completion |
+| **Domain facts** | CRM contacts, pipeline stages, entity relationships | Jarvis | `crm.db`, `knowledge.db` | Persistent, updated by agent runs |
+| **Operational knowledge** | Lessons, decisions, playbooks, work products | Jarvis | `knowledge.db` | Persistent, curated by agents |
+| **Audit trail** | Who did what, when, through which channel | Jarvis | `runtime.db` audit_log | Append-only, never deleted |
+| **Operator preferences** | Operator-level settings, recent context, working memory | OpenClaw | Session checkpoints / memory-wiki | Long-lived, operator-scoped |
+
+### Translation Rules
+
+When information crosses boundaries between conversation and domain:
+
+1. **Session to Domain**: When an operator conversation produces a domain-relevant fact (new contact, pipeline decision, lesson), the agent must explicitly write it to the appropriate Jarvis store. Session compaction summaries are not a substitute for structured domain writes.
+
+2. **Domain to Session**: When an operator asks about domain state, the session should query Jarvis stores (via read-only tools), not rely on stale session summaries. Domain truth lives in Jarvis DBs.
+
+3. **Session Summaries**: OpenClaw compaction summaries capture conversation intent and flow. They should reference Jarvis entities by ID (run_id, contact_id, etc.) rather than duplicating facts.
+
+4. **Checkpoint/Restore**: Restoring a session checkpoint resumes conversation context but does not roll back domain state. Jarvis state may have advanced since the checkpoint.
+
+### What Goes Where (Decision Guide)
+
+Ask: "Would a different operator need this information?"
+
+- **Yes, and it's a fact** → Jarvis knowledge.db (entity, document, lesson)
+- **Yes, and it's about a person/company** → Jarvis crm.db (contact, note, stage)
+- **Yes, and it's about a run/decision** → Jarvis runtime.db (run, approval, audit)
+- **No, it's about this conversation** → OpenClaw session state
+- **No, but I want it next time I chat** → OpenClaw operator preferences / memory-wiki
+
+### Retention Rules
+
+| Store | Retention | Backup |
+|---|---|---|
+| `runtime.db` | Indefinite (core audit trail) | Daily backup via ops:backup |
+| `crm.db` | Indefinite (business data) | Daily backup via ops:backup |
+| `knowledge.db` | Indefinite (institutional knowledge) | Daily backup via ops:backup |
+| OpenClaw sessions | Compacted per OpenClaw policy | Session checkpoints |
+| OpenClaw memory-wiki | Persistent within OpenClaw | OpenClaw managed |
+
+## Consequences
+
+- Operators get persistent conversation continuity via OpenClaw sessions without Jarvis reimplementing session management
+- Domain facts remain authoritative in Jarvis SQLite stores
+- No ambiguity about where a fact should live
+- Session restore does not create domain state inconsistencies
+- Compaction can aggressively summarize conversation turns without losing domain traceability
+
+## Review Trigger
+
+Revisit when:
+- OpenClaw memory-wiki gains structured query capabilities
+- Knowledge.db gains conversation-aware retrieval
+- Multi-operator scenarios create ownership conflicts in session state

--- a/docs/ADR-PLATFORM-KERNEL-BOUNDARY.md
+++ b/docs/ADR-PLATFORM-KERNEL-BOUNDARY.md
@@ -1,0 +1,162 @@
+# ADR: Platform/Kernel Boundary — OpenClaw as Substrate, Jarvis as Domain Kernel
+
+**Status**: Decided (April 2026)
+**Supersedes**: Portions of ADR-CHAT-SURFACES.md (which documented the compromise; this ADR replaces that compromise with a convergence target)
+
+## Context
+
+Jarvis runs as a plugin pack on OpenClaw. The plugin API spec (jarvis-plugin-api-v1.md) already declares the correct ownership boundary:
+
+- **OpenClaw owns**: sessions, session keys, channel connections, routing, Telegram delivery, browser runtime, web search/fetch, exec, session primitives, approval pauses via hooks
+- **Jarvis owns**: policies, approvals, jarvis.v1 contracts, CRM/knowledge/runtime state, typed workers, domain agents
+
+However, the implementation still duplicates four platform capabilities that should be owned solely by OpenClaw:
+
+1. **Telegram transport** — `packages/jarvis-telegram` directly polls and sends via `api.telegram.org`
+2. **Webhook ingress** — `packages/jarvis-dashboard/src/api/webhooks.ts` owns external trigger ingress with direct DB writes
+3. **Operator LLM orchestration** — `packages/jarvis-dashboard/src/api/godmode.ts` runs its own chat-completions loop against LM Studio
+4. **Browser runtime** — `packages/jarvis-browser-worker` directly owns Chrome via Puppeteer/CDP on port 9222
+
+This ADR codifies the convergence target and the rules that prevent new duplication.
+
+## Decision
+
+### Hard Boundary Rules
+
+1. **Only OpenClaw talks to Telegram.** Jarvis plugins use `sessions_send`, `sessions_spawn`, and `dispatch_*` tools to reach operators. No Jarvis package may import a Telegram SDK or call `api.telegram.org`.
+
+2. **Only OpenClaw owns external ingress.** Webhooks, cron triggers, and external events enter through OpenClaw webhook/TaskFlow surfaces. Jarvis may define how to interpret normalized events, but does not own the HTTP listener or signature validation for external triggers.
+
+3. **Only OpenClaw owns the operator chat loop.** Interactive operator chat (streaming, tool calls, intent classification) flows through OpenClaw sessions. Jarvis may register read-only tools and policy hooks, but does not maintain its own chat-completions orchestration.
+
+4. **Only OpenClaw owns browser runtime.** Browser lifecycle, profile management, and CDP connections are OpenClaw's responsibility. Jarvis defines browser job contracts (`browser.run_task`, `browser.extract`, etc.) and submits them through the job queue. Jarvis workers do not directly connect to Chrome.
+
+5. **Jarvis owns domain policy and typed execution.** The approval model, job contracts, domain agents, CRM, knowledge, runtime state, and worker orchestration are Jarvis's responsibility. OpenClaw does not define domain-specific job semantics or approval rules.
+
+6. **Jarvis owns durable domain state.** `runtime.db`, `crm.db`, and `knowledge.db` are Jarvis's source of truth. OpenClaw session state is complementary (conversation continuity), not a replacement for domain truth.
+
+### Forbidden Integration Patterns
+
+The following patterns are **forbidden** in new code and scheduled for removal in existing code:
+
+| Pattern | Why | Detection |
+|---|---|---|
+| Direct `api.telegram.org` HTTP calls from Jarvis | Duplicates OpenClaw channel ownership | Import/URL grep |
+| Direct `fetch("http://localhost:1234/v1/chat/completions")` from dashboard API | Duplicates OpenClaw session/inference ownership | Import/URL grep |
+| Direct Puppeteer/CDP `connect()` from Jarvis workers for primary browser flows | Duplicates OpenClaw browser runtime ownership | Import grep |
+| Dashboard Express routes accepting external webhook POST with direct DB insert | Duplicates OpenClaw webhook ingress | Route + DB write pattern |
+| Any Jarvis package importing `node-telegram-bot-api` or equivalent | Direct Telegram SDK usage | Package import grep |
+
+### Allowed Integration Patterns
+
+| Pattern | Example | Why |
+|---|---|---|
+| Jarvis plugin registers tools via `definePluginEntry` | `@jarvis/core` registering `jarvis_plan` | Standard OpenClaw plugin API |
+| Jarvis plugin registers `before_tool_call` hooks | Approval gating in `@jarvis/core` | OpenClaw hook API |
+| Jarvis uses `sessions_send` / `sessions_spawn` for delivery | `@jarvis/dispatch` sending completions | OpenClaw session API |
+| Jarvis submits jobs to its own queue via plugin tools | `job_submit` in `@jarvis/jobs` | Jarvis-owned domain layer |
+| Workers claim/callback via Jarvis HTTP routes | `POST /jarvis/jobs/claim` | Jarvis-owned worker contract |
+| Dashboard reads OpenClaw session state for UI | Session history display | Read-only OpenClaw client |
+
+## Package Migration Map
+
+Every package in the monorepo is assigned one of four statuses:
+
+### Core (keep and harden)
+
+These packages embody Jarvis's domain value. They stay and get stronger.
+
+| Package | Role |
+|---|---|
+| `@jarvis/core` | Policy engine, approvals, model selection, planning |
+| `@jarvis/jobs` | Job queue, claim/heartbeat/callback, artifact registry |
+| `@jarvis/dispatch` | Cross-session delivery via OpenClaw sessions |
+| `@jarvis/shared` | Base types, OpenClaw SDK bridge |
+| `@jarvis/agent-framework` | Agent runtime, memory, knowledge, entity graph |
+| `@jarvis/agents` | 14 agent definitions and system prompts |
+| `@jarvis/runtime` | Daemon, orchestrator, run lifecycle (thinned) |
+| `@jarvis/scheduler` | Domain-specific scheduling (thinned) |
+| `@jarvis/supervisor` | Process supervision |
+| `@jarvis/inference` | Model registry, selection, task profiles |
+| `@jarvis/security` | Security policy, audit |
+| `@jarvis/observability` | Metrics, tracing |
+| `@jarvis/office` | Office job compilation |
+| `@jarvis/device` | Device observation/control via desktop host worker |
+| `@jarvis/files` | Scoped filesystem operations |
+| `@jarvis/interpreter` | Code execution sandbox |
+| `@jarvis/voice` | Voice processing |
+| `@jarvis/system` | System monitoring |
+
+### Core Workers (keep, may need adapter changes)
+
+| Package | Role | Convergence Notes |
+|---|---|---|
+| `@jarvis/agent-worker` | Agent execution | Keep |
+| `@jarvis/email-worker` | Email operations | Keep |
+| `@jarvis/calendar-worker` | Calendar operations | Keep |
+| `@jarvis/crm-worker` | CRM operations | Keep |
+| `@jarvis/web-worker` | Web scraping/search | Keep |
+| `@jarvis/document-worker` | Document processing | Keep |
+| `@jarvis/office-worker` | Office file processing | Keep |
+| `@jarvis/inference-worker` | LLM inference delegation | Keep |
+| `@jarvis/interpreter-worker` | Code sandbox | Keep |
+| `@jarvis/security-worker` | Security scanning | Keep |
+| `@jarvis/system-worker` | System monitoring | Keep |
+| `@jarvis/voice-worker` | Voice transcription | Keep |
+| `@jarvis/social-worker` | Social media | Keep |
+| `@jarvis/time-worker` | Time/scheduling | Keep |
+| `@jarvis/drive-worker` | Drive watching | Keep |
+| `@jarvis/desktop-host-worker` | Windows desktop automation | Keep |
+
+### Core Plugins (keep)
+
+| Package | Role |
+|---|---|
+| `@jarvis/agent-plugin` | Agent management tools |
+| `@jarvis/email-plugin` | Email tools |
+| `@jarvis/calendar-plugin` | Calendar tools |
+| `@jarvis/crm-plugin` | CRM tools |
+| `@jarvis/web-plugin` | Web tools |
+| `@jarvis/document-plugin` | Document tools |
+
+### Adapter (wrap then replace)
+
+These packages currently duplicate platform capabilities. They will be wrapped behind OpenClaw-native interfaces, then the direct implementation removed.
+
+| Package | Current Role | Target | Timeline |
+|---|---|---|---|
+| `@jarvis/browser` | Browser job contracts | Keep contracts, remove runtime ownership | Y1-Q4 |
+| `@jarvis/browser-worker` | Direct Chrome/Puppeteer | Replace with OpenClaw browser bridge | Y1-Q4 |
+
+### Deprecated (replace then delete)
+
+These packages duplicate platform ownership and will be removed once convergence is complete.
+
+| Package | Current Role | Replacement | Timeline |
+|---|---|---|---|
+| `@jarvis/telegram` | Direct Telegram polling/sending | OpenClaw native Telegram channel | Y1-Q2 |
+| `jarvis-dashboard` (webhook routes) | External trigger HTTP ingress | OpenClaw webhook/TaskFlow ingress | Y1-Q2 |
+| `jarvis-dashboard` (godmode LLM loop) | Direct LM Studio orchestration | OpenClaw session-backed operator chat | Y1-Q3 |
+| `jarvis-dashboard` (chat/telegram LLM loop) | Direct LM Studio for Telegram relay | OpenClaw session-backed query | Y1-Q3 |
+
+### Services (evolve)
+
+| Package | Role | Convergence Notes |
+|---|---|---|
+| `jarvis-dashboard` | React web dashboard + API | Keep UI; thin API to OpenClaw session client |
+| `jarvis-telegram` | Telegram bot | Replace with OpenClaw channel config |
+
+## Consequences
+
+- Four duplicate ownership paths are explicitly scheduled for removal
+- CI will enforce the forbidden patterns, preventing regression
+- New code must use the allowed patterns or get an explicit ADR exception
+- The existing ADR-CHAT-SURFACES.md compromise (separate LLM loops acceptable) is superseded by a convergence commitment
+- The ROADMAP.md quarterly plan aligns with this boundary
+
+## Review Trigger
+
+Revisit this decision when:
+- OpenClaw's session API gains a feature that makes a Jarvis-side workaround unnecessary
+- A new Jarvis capability needs platform-level integration not covered here
+- The convergence timeline needs adjustment based on OpenClaw release cadence

--- a/docs/ARCHITECTURE-STATUS.md
+++ b/docs/ARCHITECTURE-STATUS.md
@@ -8,7 +8,14 @@ Last updated: 2026-04-08
 
 - **Shipped** -- target design is fully implemented
 - **Partial** -- core capability shipped with documented exceptions
+- **Converging** -- active work underway per [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md)
 - **Gap** -- target design is not yet implemented
+
+## Platform/Kernel Boundary
+
+See [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md) for the authoritative ownership split: OpenClaw owns channels, sessions, browser lifecycle, webhook ingress, and the operator chat loop. Jarvis owns domain policy, approvals, jarvis.v1 contracts, CRM/knowledge/runtime state, and specialized workers.
+
+Architecture boundary tests enforce forbidden patterns in CI (`tests/architecture-boundary.test.ts`).
 
 ## Comparison
 
@@ -19,15 +26,18 @@ Last updated: 2026-04-08
 | **Approval-backed mutations** | Every high-stakes action requires explicit human approval before execution. No side-door execution paths. | Shipped. 17 always-require, 33 conditional, 93 exempt. `trigger_agent` removed from chat surfaces. All mutating actions flow through the job queue with approval checks. | Shipped |
 | **Worker process isolation** | Workers run in isolated processes with independent failure domains. A crashing worker cannot corrupt the daemon or other workers. | Cooperative isolation with timeouts. Child-process workers (browser, interpreter, files, device, voice, security, social) have process boundaries. In-process workers share the Node.js event loop. Documented in [KNOWN-TRUST-GAPS.md](KNOWN-TRUST-GAPS.md). | Partial |
 | **Full channel provenance** | Every artifact delivered to a channel includes complete provenance: source run, generating job, timestamps, and full content for exact replay. | Preview provenance shipped (source run, job type, timestamps). Full content storage is optional -- large artifacts store a summary plus a link to the full output. Exact replay not guaranteed for all artifact types. | Partial |
-| **Single inference path** | All LLM inference routes through the runtime kernel's model router. One place to audit, rate-limit, and log all model calls. | Copilot surfaces (`/api/chat/telegram`, `/api/godmode`) maintain their own LLM loops for interactive queries. These are read-only and cannot trigger mutations, but their inference calls do not flow through the kernel's model router. Documented in [ADR-CHAT-SURFACES.md](ADR-CHAT-SURFACES.md). | Partial |
+| **Single inference path** | All LLM inference routes through the runtime kernel's model router. One place to audit, rate-limit, and log all model calls. | Copilot surfaces (`/api/chat/telegram`, `/api/godmode`) maintain their own LLM loops for interactive queries. These are read-only and cannot trigger mutations, but their inference calls do not flow through the kernel's model router. Superseded by convergence target in [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md). | Converging |
 | **Encrypted credentials** | Sensitive credentials (API tokens, webhook secrets, integration keys) stored encrypted at rest. Decrypted only in memory during use. | Not shipped. Credentials stored in plaintext in `~/.jarvis/config.json`. File permissions are the only protection. Encryption at rest is a planned improvement. | Gap |
+| **OpenClaw as sole channel owner** | All operator-facing channels (Telegram, webhooks, browser) route through OpenClaw. Jarvis does not own transport. | `packages/jarvis-telegram` still directly polls and sends via Telegram API. Dashboard webhooks own external ingress. Browser worker owns Chrome directly. Convergence target defined in [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md). | Converging |
+| **OpenClaw as session authority** | Operator chat flows through OpenClaw sessions with compaction, checkpoints, and branch/restore. | `godmode.ts` and `chat.ts` run their own LLM loops with direct LM Studio access. Convergence target defined in [ADR-PLATFORM-KERNEL-BOUNDARY.md](ADR-PLATFORM-KERNEL-BOUNDARY.md). | Converging |
 
 ## Summary
 
 | Status | Count |
 |---|---|
 | Shipped | 2 |
-| Partial | 4 |
+| Partial | 3 |
+| Converging | 3 |
 | Gap | 1 |
 
-The two fully shipped capabilities (durable state and approval-backed mutations) are the most critical for operational safety. The four partial items have documented exceptions with ADRs or trust-gap entries explaining the rationale. The one gap (encrypted credentials) is a known risk mitigated by filesystem permissions and localhost-only binding.
+The two fully shipped capabilities (durable state and approval-backed mutations) are the most critical for operational safety. The three converging items have active convergence work defined in the platform/kernel boundary ADR. The one gap (encrypted credentials) is a known risk mitigated by filesystem permissions and localhost-only binding.

--- a/docs/AUTOMATION-CLASSIFICATION.md
+++ b/docs/AUTOMATION-CLASSIFICATION.md
@@ -1,0 +1,65 @@
+# Automation Classification Matrix
+
+Maps daemon/scheduler responsibilities to ownership: Jarvis domain logic vs OpenClaw platform automation. See CONVERGENCE-ROADMAP.md Epic 7.
+
+## Classification Rules
+
+- **Domain automation**: Encoded in agent definitions, job contracts, or approval policy. Stays in Jarvis.
+- **Platform automation**: Generic scheduling, polling, health checks, process management. Can delegate to OpenClaw.
+- **Shared**: Both sides have legitimate interest. Jarvis defines semantics; OpenClaw provides the substrate.
+
+## Daemon Responsibilities
+
+| Responsibility | Current Owner | Classification | Convergence Target |
+|---|---|---|---|
+| **Claim queued agent_commands** | daemon.ts polling loop | Domain | Keep in Jarvis — domain command interpretation |
+| **Check due schedules** | daemon.ts + scheduler | Shared | Jarvis defines schedule semantics; OpenClaw could provide the cron trigger |
+| **Enqueue to AgentQueue** | daemon.ts | Domain | Keep in Jarvis — queue prioritization, resource locks |
+| **Process agent queue** | daemon.ts orchestrator | Domain | Keep in Jarvis — concurrency limits, agent lifecycle |
+| **Write heartbeats** | daemon.ts (every 10s) | Platform | Could be OpenClaw health probe, but low value to migrate |
+| **Model rediscovery** | daemon.ts maintenance | Domain | Keep — Jarvis-specific model registry |
+| **Dead letter checks** | daemon.ts maintenance | Shared | Jarvis defines what's dead; trigger could be OpenClaw |
+| **Stale claim recovery** | daemon.ts maintenance | Shared | Jarvis defines recovery semantics; trigger could be OpenClaw |
+| **Config reload** | daemon.ts | Platform | Could be OpenClaw lifecycle hook |
+| **Graceful shutdown** | daemon.ts SIGINT/SIGTERM | Platform | Standard process management |
+
+## Scheduler Responsibilities
+
+| Responsibility | Current Owner | Classification | Convergence Target |
+|---|---|---|---|
+| **Cron schedule evaluation** | jarvis-scheduler | Shared | Jarvis defines when agents should run; OpenClaw could fire the trigger |
+| **Schedule persistence** | runtime.db `schedules` table | Domain | Keep — agent schedule metadata is domain state |
+| **Next-run calculation** | scheduler | Shared | Pure logic, could be OpenClaw TaskFlow |
+| **Schedule CRUD** | scheduler tools | Domain | Keep — agent-specific scheduling semantics |
+
+## Recommended Delegation
+
+### High Value (migrate to OpenClaw)
+
+1. **Cron trigger firing** — OpenClaw TaskFlow or webhook-triggered schedules replace the daemon's polling loop for time-based triggers. Jarvis keeps the schedule definitions; OpenClaw fires at the right time.
+
+2. **External event routing** — Already addressed by Epic 4 (webhook convergence). External events enter via OpenClaw, not via dashboard webhook routes.
+
+3. **Generic health monitoring** — Heartbeats and liveness checks could use OpenClaw's health infrastructure, but the migration value is low.
+
+### Keep in Jarvis (domain-specific)
+
+1. **Agent command interpretation** — What happens when a command is claimed is entirely domain logic.
+2. **Queue management** — Priority, concurrency, resource locks, agent lifecycle are Jarvis-specific.
+3. **Model rediscovery** — Local LLM model probing is Jarvis-specific.
+4. **Dead letter/recovery semantics** — What constitutes a dead letter and how to recover are domain decisions.
+
+### Keep But Thin
+
+1. **The daemon polling loop itself** — Should become thinner as more triggers come from OpenClaw (webhooks, schedules) rather than daemon-internal polling. The daemon's role shifts from "poll everything" to "react to triggers + manage domain queue."
+
+2. **Maintenance cycles** — Stale claim recovery, config reload, etc. can remain daemon-internal but run less frequently if OpenClaw surfaces provide better triggers.
+
+## Migration Sequence
+
+1. First: external event triggers move to OpenClaw (Epic 4 — already addressed)
+2. Then: time-based schedule triggers can use OpenClaw cron/TaskFlow
+3. Then: daemon loop frequency can decrease (from frequent poll to event-reactive + periodic sweep)
+4. Finally: daemon becomes a pure domain kernel — reacts to OpenClaw events and manages the agent queue
+
+The daemon is never deleted. It becomes thinner — less platform automation, more domain orchestration.

--- a/docs/CONVERGENCE-ROADMAP.md
+++ b/docs/CONVERGENCE-ROADMAP.md
@@ -1,0 +1,145 @@
+# Convergence Roadmap: OpenClaw Substrate + Jarvis Domain Kernel
+
+This document maps the 12 convergence epics onto the quarterly plan. It complements ROADMAP.md (which focuses on product milestones) with the platform/kernel convergence program defined in ADR-PLATFORM-KERNEL-BOUNDARY.md.
+
+## Architectural Rule
+
+OpenClaw owns channels, sessions, browser lifecycle, webhook ingress, automation surfaces, and the primary operator chat loop. Jarvis owns domain policy, approvals, jarvis.v1 contracts, CRM/knowledge/runtime state, and specialized workers.
+
+## Epic Map
+
+| # | Epic | Quarter | Primary Packages | Exit Criteria |
+|---|---|---|---|---|
+| 1 | Architecture Boundary Codification | Y1-Q1 | docs/, tests/, CI | ADR published, CI enforces forbidden patterns, migration map complete |
+| 2 | OpenClaw Runtime Upgrade | Y1-Q1 | root, scripts/, plugins | Jarvis boots on current OpenClaw, compatibility matrix published |
+| 3 | Channel Ownership Convergence | Y1-Q2 | jarvis-telegram, jarvis-dispatch | Zero primary-path Telegram API calls from Jarvis |
+| 4 | Webhook Ingress Convergence | Y1-Q2 | jarvis-dashboard/webhooks | Zero primary-path dashboard-owned webhook ingress |
+| 5 | Operator Chat Unification | Y1-Q3 | jarvis-dashboard/godmode, chat | Zero primary-path direct LM Studio operator loops |
+| 6 | Browser Ownership Convergence | Y1-Q4 | jarvis-browser-worker, jarvis-browser | Zero primary-path direct browser runtime ownership |
+| 7 | Automation & TaskFlow Convergence | Y2-Q1 | jarvis-runtime/daemon, jarvis-scheduler | Generic automation delegates to OpenClaw; daemon thinned |
+| 8 | Approval & Hook Consolidation | Y2-Q1 | jarvis-core, jarvis-runtime | Multiple hook points active; policy centralized |
+| 9 | Session Memory & Knowledge Roles | Y2-Q2 | jarvis-dashboard, agent-framework | Memory taxonomy ADR; session compaction operational |
+| 10 | Security Gap Closure | Y2-Q3 | jarvis-runtime, config, audit | Encrypted credentials; credential-access audit; fuller provenance |
+| 11 | Packaging & Release Train | Y3-Q1 | scripts/, plugin loader | Reliable install/upgrade/rollback; compatibility checks |
+| 12 | Dead Code Removal & Conformance | Y3-Q2+ | All deprecated surfaces | Codebase smaller; docs match implementation |
+
+## Year 1: Architecture Convergence and Duplicate Removal
+
+### Q1: Boundary Codification + OpenClaw Upgrade (Epics 1-2)
+
+**Deliverables:**
+- ADR-PLATFORM-KERNEL-BOUNDARY.md (done)
+- Architecture boundary tests in CI (done)
+- OpenClaw upgrade to current stable release
+- Compatibility matrix for plugin SDK
+- Package migration map with status assignments
+
+**Acceptance:**
+- CI fails on forbidden import/URL patterns
+- Jarvis boots and passes smoke tests on new OpenClaw
+- Every package has assigned status: core, adapter, compatibility, deprecated
+
+### Q2: Channel + Webhook Convergence (Epics 3-4)
+
+**Deliverables:**
+- OpenClaw-native channel adapter replacing `jarvis-telegram`
+- Approval notifications via `sessions_send` / `dispatch_*`
+- Command routing via OpenClaw session commands
+- Webhook ingress via OpenClaw webhook/TaskFlow surfaces
+- Normalized event-to-agent mapping layer
+
+**Acceptance:**
+- No primary-path `api.telegram.org` calls from Jarvis
+- No primary-path dashboard webhook routes writing into `agent_commands`
+- Approvals, notifications, commands still work end-to-end
+- Architecture boundary tests still pass (legacy exclusions narrowed)
+
+### Q3: Operator Chat Unification (Epic 5)
+
+**Deliverables:**
+- Operator chat gateway on OpenClaw sessions
+- Godmode refactored as session client
+- Read-only tool policy preserved on session layer
+- Session-backed history replacing custom history
+
+**Acceptance:**
+- No primary-path direct LM Studio chat-completions loop in dashboard API
+- Operator chat still supports streaming, artifacts, research mode
+- Session state survives restart via OpenClaw semantics
+
+### Q4: Browser Convergence (Epic 6)
+
+**Deliverables:**
+- OpenClaw browser bridge/adapter
+- Browser job types re-mapped to managed profiles
+- chrome-adapter.ts replaced or behind bridge
+- Evidence artifact flow preserved
+
+**Acceptance:**
+- No primary-path direct browser ownership in Jarvis
+- Browser tasks produce equivalent artifacts
+- Approval enforcement still works for risky browser actions
+
+**Year 1 Success Metric:** Four primary-path duplications eliminated. The biggest duplications (Telegram, webhooks, operator chat, browser) are gone or behind thin compatibility bridges.
+
+## Year 2: Operational Strength
+
+### Q5: Automation + Hook Consolidation (Epics 7-8)
+
+- Daemon thinned; generic automation delegates to OpenClaw TaskFlow
+- Hook catalog expanded beyond single `before_tool_call`
+- Policy middleware standardized for mutating actions, reply guardrails, provenance
+
+### Q6: Session Memory + Knowledge (Epic 9)
+
+- Memory taxonomy ADR published
+- OpenClaw compaction/checkpoint operational for operator sessions
+- Jarvis stores remain authoritative for domain state
+
+### Q7: Security Gap Closure (Epic 10)
+
+- Credential storage hardened (encrypted or OS keystore)
+- Credential-access audit logging
+- Fuller provenance for channel deliveries and artifacts
+
+### Q8: Product Hardening
+
+- Compatibility shim removal
+- Dead code deletion from old paths
+- Dashboard API simplification
+- Reduced places for accidental boundary bypass
+
+**Year 2 Success Metric:** 80-90% of operator interactions flow through OpenClaw sessions. Architecture is stable, not aspirational.
+
+## Year 3: Durable Product Platform
+
+### Q9-12: Packaging, Extension, Controls, Consolidation (Epics 11-12)
+
+- Reliable install/upgrade/rollback
+- Plugin compatibility enforcement
+- Final deprecated path removal
+- Remaining Jarvis code reads as domain product, not second agent platform
+
+**Year 3 Success Metric:** Codebase smaller in duplicated platform ownership than Year 1 start. New engineer can tell in minutes which layer owns what.
+
+## Cross-Epic Definition of Done
+
+Five global exit conditions for the full program:
+
+1. Zero primary-path direct Telegram transport owned by Jarvis
+2. Zero primary-path dashboard-owned public webhook ingress writing to runtime state
+3. Zero primary-path direct dashboard-to-model orchestration outside approved inference boundary
+4. Zero primary-path direct browser runtime ownership for managed browser workflows
+5. Zero undocumented boundary exceptions between OpenClaw and Jarvis
+
+## Capacity Split
+
+| Year | Convergence/Deletion | Hardening/Quality | Packaging/Features |
+|---|---|---|---|
+| Y1 | 40% | 30% | 30% |
+| Y2 | 20% | 40% | 40% |
+| Y3 | 10% | 30% | 60% |
+
+## Management Constraint
+
+Each quarter needs **deletions**, not just wrappers. The program succeeds only if the codebase ends each year smaller in duplicated platform ownership than it was at the start.

--- a/docs/KNOWN-TRUST-GAPS.md
+++ b/docs/KNOWN-TRUST-GAPS.md
@@ -24,7 +24,9 @@ The Telegram bot stores conversation context in process memory, shared across al
 
 ## No Credential Access Audit Log
 
-When `getCredentialsForWorker()` distributes secrets to workers, this is not recorded in the audit log. There is no way to retrospectively determine which workers accessed which credentials during a run. The audit log covers approvals, settings changes, and auth events, but not credential reads.
+**Status: Partially mitigated** — `packages/jarvis-security/src/credential-audit.ts` provides an audited wrapper around `getCredentialsForWorker()` that logs every credential distribution to the `audit_log` table. The wrapper (`createAuditedCredentialAccessor`) records worker ID, distributed credential keys, associated run/job IDs, and timestamps. Query function `queryCredentialAccessLog()` enables retrospective investigation.
+
+**Remaining gap:** The daemon must adopt the audited accessor (replace direct `getCredentialsForWorker` calls with the wrapped version). Until then, credential reads are logged only in code paths that explicitly use the wrapper.
 
 ## No Database Integrity Verification
 

--- a/docs/OPENCLAW-COMPATIBILITY-MATRIX.md
+++ b/docs/OPENCLAW-COMPATIBILITY-MATRIX.md
@@ -1,0 +1,82 @@
+# OpenClaw Compatibility Matrix
+
+Tracks which OpenClaw SDK features Jarvis uses, which it ignores, and which it needs for convergence.
+
+Last updated: 2026-04-08
+OpenClaw dependency: `^2026.4.8`
+
+## SDK Features Used
+
+| Feature | Used By | How |
+|---|---|---|
+| `definePluginEntry` | All 6 plugins | Standard plugin registration |
+| `api.registerTool` | All plugins | Tool registration via factory |
+| `api.registerCommand` | core, dispatch, office, device, files, browser | Slash command registration |
+| `api.on("before_tool_call")` | `@jarvis/core` | Approval hook gating |
+| `api.config` | dispatch, shared | Gateway URL/token resolution |
+| `api.runtime.subagent.run` | dispatch | Worker-agent spawning |
+| `callGatewayTool` (via browser-support) | shared/gateway.ts | Session messaging |
+| `OpenClawPluginToolContext` | All plugins | Tool execution context |
+| `PluginCommandContext` | All plugins | Command execution context |
+| `AnyAgentTool` type | All plugins | Tool definition type |
+
+## SDK Features NOT Yet Used (Needed for Convergence)
+
+| Feature | Needed For | Epic |
+|---|---|---|
+| Native Telegram channel config | Replace jarvis-telegram | Epic 3 |
+| Webhook ingress plugin | Replace dashboard webhooks | Epic 4 |
+| Session streaming/SSE | Replace godmode LLM loop | Epic 5 |
+| Session compaction/checkpoints | Operator session continuity | Epic 9 |
+| Session branch/restore | Operator session management | Epic 9 |
+| Browser plugin/managed profiles | Replace direct Puppeteer | Epic 6 |
+| TaskFlow | Replace generic daemon automation | Epic 7 |
+| Memory-wiki | Long-horizon operator memory | Epic 9 |
+| Hook: `before_reply` | Reply-time guardrails/redaction | Epic 8 |
+| Hook: `after_tool_call` | Provenance enrichment | Epic 8 |
+
+## Plugin Entry Points
+
+| Plugin ID | Package | Entry |
+|---|---|---|
+| `jarvis-core` | `@jarvis/core` | `packages/jarvis-core/src/index.ts` |
+| `jarvis-jobs` | `@jarvis/jobs` | `packages/jarvis-jobs/src/index.ts` |
+| `jarvis-dispatch` | `@jarvis/dispatch` | `packages/jarvis-dispatch/src/index.ts` |
+| `jarvis-office` | `@jarvis/office` | `packages/jarvis-office/src/index.ts` |
+| `jarvis-device` | `@jarvis/device` | `packages/jarvis-device/src/index.ts` |
+| `jarvis-files` | `@jarvis/files` | `packages/jarvis-files/src/index.ts` |
+| `jarvis-browser` | `@jarvis/browser` | `packages/jarvis-browser/src/index.ts` |
+
+Additional plugins (email, calendar, crm, web, document, agent) register through the same pattern.
+
+## Hook Usage Inventory
+
+| Hook Point | Plugin | Purpose | Priority |
+|---|---|---|---|
+| `before_tool_call` | `@jarvis/core` | Approval gating for sensitive tools | 0 |
+
+**Expansion targets (Epic 8):**
+- `before_tool_call` — broader policy enforcement across more tool categories
+- `before_reply` — response guardrails, PII redaction, compliance checks
+- `after_tool_call` — provenance stamping, audit enrichment
+- `on_error` — centralized error policy, retry decisions
+
+## Gateway Communication
+
+All gateway communication flows through `packages/jarvis-shared/src/gateway.ts`:
+
+- `resolveGatewayCallOptions()` — resolves URL/token from config or env
+- `invokeGatewayMethod()` — generic gateway RPC via `callGatewayTool`
+- `sendSessionMessage()` — convenience wrapper for `sessions.send`
+
+Default gateway: `ws://127.0.0.1:18789`
+Configurable via: `JARVIS_GATEWAY_URL`, `JARVIS_GATEWAY_TOKEN`, or OpenClaw config
+
+## Breaking Change Risks
+
+| Area | Risk | Mitigation |
+|---|---|---|
+| Plugin SDK API changes | Method signatures could change | Pin `^2026.4.8`, test on upgrade |
+| Hook event shape changes | `before_tool_call` event structure | TypeScript compilation catches type breaks |
+| Session API changes | `sessions.send` parameter shape | Gateway abstraction in shared/gateway.ts |
+| Browser plugin API | New for Jarvis, API may evolve | Abstract behind BrowserBridge interface (Epic 6) |

--- a/packages/jarvis-browser/src/openclaw-bridge.ts
+++ b/packages/jarvis-browser/src/openclaw-bridge.ts
@@ -1,0 +1,422 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  invokeGatewayMethod,
+  type GatewayCallOptions,
+  type ArtifactRef
+} from "@jarvis/shared";
+
+// ── Shared types ─────────────────────────────────────────────────────────────
+
+export type NavigateOptions = {
+  waitForSelector?: string;
+  timeoutMs?: number;
+};
+
+export type PageInfo = {
+  url: string;
+  title: string;
+  status: number;
+};
+
+export type ExtractOptions = {
+  format?: "text" | "html" | "markdown";
+  selector?: string;
+};
+
+export type ExtractResult = {
+  content: string;
+  format: string;
+  url: string;
+};
+
+export type CaptureOptions = {
+  fullPage?: boolean;
+  selector?: string;
+  format?: "png" | "jpeg";
+};
+
+export type DownloadOptions = {
+  targetDir?: string;
+  timeoutMs?: number;
+};
+
+export type BrowserStep = {
+  action: string;
+  params: Record<string, unknown>;
+};
+
+export type TaskOptions = {
+  url?: string;
+  task?: string;
+  timeoutMs?: number;
+};
+
+export type TaskResult = {
+  steps_completed: number;
+  artifacts: ArtifactRef[];
+  evidence: Record<string, unknown>;
+};
+
+// ── BrowserBridge interface ──────────────────────────────────────────────────
+
+export interface BrowserBridge {
+  /** Navigate to URL and return page info. */
+  navigate(url: string, options?: NavigateOptions): Promise<PageInfo>;
+
+  /** Extract content from the current page. */
+  extract(selector?: string, options?: ExtractOptions): Promise<ExtractResult>;
+
+  /** Take a screenshot and return an artifact reference. */
+  capture(options?: CaptureOptions): Promise<ArtifactRef>;
+
+  /** Download a file from URL and return an artifact reference. */
+  download(url: string, options?: DownloadOptions): Promise<ArtifactRef>;
+
+  /** Execute a multi-step browser task. */
+  runTask(steps: BrowserStep[], options?: TaskOptions): Promise<TaskResult>;
+
+  /** Close / release the browser session. */
+  close(): Promise<void>;
+}
+
+// ── OpenClawBrowserBridge ────────────────────────────────────────────────────
+
+export type OpenClawBridgeConfig = {
+  openclawConfig?: OpenClawConfig;
+  gatewayOverrides?: GatewayCallOptions;
+};
+
+/**
+ * Browser bridge that delegates to the OpenClaw gateway.
+ *
+ * Every operation is translated into an `invokeGatewayMethod` call targeting
+ * the gateway's browser namespace.  Artifact registration semantics
+ * (artifact_id, path, path_context, etc.) are preserved by forwarding the
+ * gateway response unchanged.
+ */
+export class OpenClawBrowserBridge implements BrowserBridge {
+  private readonly config: OpenClawConfig | undefined;
+  private readonly overrides: GatewayCallOptions;
+
+  constructor(cfg: OpenClawBridgeConfig = {}) {
+    this.config = cfg.openclawConfig;
+    this.overrides = cfg.gatewayOverrides ?? {};
+  }
+
+  private invoke<T>(method: string, params?: unknown): Promise<T> {
+    return invokeGatewayMethod<T>(method, this.config, params, this.overrides);
+  }
+
+  // ── navigate ────────────────────────────────────────────────────────────────
+
+  async navigate(url: string, options: NavigateOptions = {}): Promise<PageInfo> {
+    const result = await this.invoke<{
+      url: string;
+      title: string;
+      status: number;
+    }>("browser.navigate", {
+      url,
+      wait_for_selector: options.waitForSelector,
+      timeout_ms: options.timeoutMs
+    });
+    return {
+      url: result.url,
+      title: result.title,
+      status: result.status
+    };
+  }
+
+  // ── extract ─────────────────────────────────────────────────────────────────
+
+  async extract(
+    selector?: string,
+    options: ExtractOptions = {},
+  ): Promise<ExtractResult> {
+    const result = await this.invoke<{
+      content: string;
+      format: string;
+      url: string;
+    }>("browser.extract", {
+      selector: selector ?? options.selector,
+      format: options.format ?? "text"
+    });
+    return {
+      content: result.content,
+      format: result.format,
+      url: result.url
+    };
+  }
+
+  // ── capture ─────────────────────────────────────────────────────────────────
+
+  async capture(options: CaptureOptions = {}): Promise<ArtifactRef> {
+    return this.invoke<ArtifactRef>("browser.capture", {
+      full_page: options.fullPage ?? true,
+      selector: options.selector,
+      format: options.format ?? "png"
+    });
+  }
+
+  // ── download ────────────────────────────────────────────────────────────────
+
+  async download(
+    url: string,
+    options: DownloadOptions = {},
+  ): Promise<ArtifactRef> {
+    return this.invoke<ArtifactRef>("browser.download", {
+      url,
+      target_dir: options.targetDir,
+      timeout_ms: options.timeoutMs
+    });
+  }
+
+  // ── runTask ─────────────────────────────────────────────────────────────────
+
+  async runTask(
+    steps: BrowserStep[],
+    options: TaskOptions = {},
+  ): Promise<TaskResult> {
+    return this.invoke<TaskResult>("browser.run_task", {
+      steps,
+      url: options.url,
+      task: options.task ?? "multi-step browser task",
+      timeout_ms: options.timeoutMs
+    });
+  }
+
+  // ── close ───────────────────────────────────────────────────────────────────
+
+  async close(): Promise<void> {
+    await this.invoke<void>("browser.close", {});
+  }
+}
+
+// ── LegacyPuppeteerBridge ────────────────────────────────────────────────────
+
+export type LegacyBridgeConfig = {
+  debuggingUrl?: string;
+};
+
+/**
+ * Compatibility bridge that wraps the existing direct-Puppeteer approach
+ * through `@jarvis/browser-worker`'s ChromeAdapter.
+ *
+ * This is the fallback path while OpenClaw browser ownership is being rolled
+ * out.  It imports the worker's adapter lazily to avoid pulling in Puppeteer
+ * when the OpenClaw bridge is in use.
+ */
+export class LegacyPuppeteerBridge implements BrowserBridge {
+  private readonly debuggingUrl: string;
+  private adapter: LegacyAdapter | null = null;
+
+  constructor(cfg: LegacyBridgeConfig = {}) {
+    this.debuggingUrl = cfg.debuggingUrl ?? "http://127.0.0.1:9222";
+  }
+
+  /**
+   * Lazy-load the adapter.  We use a runtime-only dynamic import so that
+   * TypeScript does not pull the browser-worker package into this project's
+   * compilation unit (which would violate rootDir boundaries).  Packages
+   * without puppeteer-core installed won't fail at load time either.
+   */
+  private async getAdapter(): Promise<LegacyAdapter> {
+    if (this.adapter) return this.adapter;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- runtime-only dynamic import
+    const workerPkg = "@jarvis/browser-worker";
+    const mod = await (import(workerPkg) as Promise<{ ChromeAdapter: new (cfg: { debugging_url: string }) => LegacyAdapter }>);
+    this.adapter = new mod.ChromeAdapter({ debugging_url: this.debuggingUrl });
+    return this.adapter;
+  }
+
+  // ── navigate ────────────────────────────────────────────────────────────────
+
+  async navigate(url: string, options: NavigateOptions = {}): Promise<PageInfo> {
+    const adapter = await this.getAdapter();
+    const outcome = await adapter.navigate({ url });
+
+    // Optionally wait for a selector after navigation.
+    if (options.waitForSelector) {
+      await adapter.waitFor({
+        selector: options.waitForSelector,
+        timeout_ms: options.timeoutMs ?? 30_000
+      });
+    }
+
+    return {
+      url: outcome.structured_output.url,
+      title: outcome.structured_output.title,
+      status: outcome.structured_output.status
+    };
+  }
+
+  // ── extract ─────────────────────────────────────────────────────────────────
+
+  async extract(
+    selector?: string,
+    options: ExtractOptions = {},
+  ): Promise<ExtractResult> {
+    const adapter = await this.getAdapter();
+    const format = options.format ?? "text";
+    const outcome = await adapter.extract({
+      selector: selector ?? options.selector,
+      format: format === "markdown" ? "text" : format
+    });
+    return {
+      content: outcome.structured_output.content,
+      format: outcome.structured_output.format,
+      url: outcome.structured_output.url
+    };
+  }
+
+  // ── capture ─────────────────────────────────────────────────────────────────
+
+  async capture(options: CaptureOptions = {}): Promise<ArtifactRef> {
+    const adapter = await this.getAdapter();
+    const format = options.format ?? "png";
+    const path = `capture-${Date.now()}.${format}`;
+    const outcome = await adapter.screenshot({
+      full_page: options.fullPage ?? true,
+      selector: options.selector,
+      path
+    });
+    return {
+      artifact_id: `capture-${Date.now()}`,
+      path: outcome.structured_output.path,
+      path_context: "local_fs"
+    };
+  }
+
+  // ── download ────────────────────────────────────────────────────────────────
+
+  async download(
+    url: string,
+    options: DownloadOptions = {},
+  ): Promise<ArtifactRef> {
+    const adapter = await this.getAdapter();
+    const outcome = await adapter.download({
+      url,
+      dest_path: options.targetDir,
+      timeout_ms: options.timeoutMs
+    });
+    return {
+      artifact_id: `download-${Date.now()}`,
+      path: outcome.structured_output.dest_path,
+      path_context: "local_fs"
+    };
+  }
+
+  // ── runTask ─────────────────────────────────────────────────────────────────
+
+  async runTask(
+    steps: BrowserStep[],
+    options: TaskOptions = {},
+  ): Promise<TaskResult> {
+    const adapter = await this.getAdapter();
+    const workerSteps = steps.map((step) => ({
+      action: step.action as "navigate" | "click" | "type" | "wait" | "evaluate" | "screenshot",
+      selector: step.params.selector as string | undefined,
+      value: step.params.value as string | undefined,
+      url: step.params.url as string | undefined,
+      script: step.params.script as string | undefined
+    }));
+
+    const outcome = await adapter.runTask({
+      task: options.task ?? "multi-step browser task",
+      url: options.url,
+      steps: workerSteps,
+      timeout_ms: options.timeoutMs
+    });
+
+    return {
+      steps_completed: outcome.structured_output.steps_completed,
+      artifacts: [],
+      evidence: {
+        url: outcome.structured_output.url,
+        title: outcome.structured_output.title,
+        result: outcome.structured_output.result
+      }
+    };
+  }
+
+  // ── close ───────────────────────────────────────────────────────────────────
+
+  async close(): Promise<void> {
+    this.adapter = null;
+  }
+}
+
+/**
+ * Minimal surface of the ChromeAdapter consumed by LegacyPuppeteerBridge.
+ * Keeps the bridge decoupled from the full worker type graph at compile time.
+ */
+type LegacyAdapter = {
+  navigate(input: { url: string; wait_until?: string }): Promise<{
+    structured_output: { url: string; title: string; status: number };
+  }>;
+  waitFor(input: { selector: string; timeout_ms?: number }): Promise<unknown>;
+  extract(input: { selector?: string; format?: string }): Promise<{
+    structured_output: { content: string; format: string; url: string };
+  }>;
+  screenshot(input: {
+    full_page?: boolean;
+    selector?: string;
+    path?: string;
+  }): Promise<{ structured_output: { path: string; width: number; height: number } }>;
+  download(input: {
+    url: string;
+    dest_path?: string;
+    timeout_ms?: number;
+  }): Promise<{ structured_output: { dest_path: string } }>;
+  runTask(input: {
+    task: string;
+    url?: string;
+    steps?: Array<{
+      action: string;
+      selector?: string;
+      value?: string;
+      url?: string;
+      script?: string;
+    }>;
+    timeout_ms?: number;
+  }): Promise<{
+    structured_output: {
+      steps_completed: number;
+      result: unknown;
+      url: string;
+      title: string;
+    };
+  }>;
+};
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+export type BrowserBridgeFactoryConfig = {
+  openclawConfig?: OpenClawConfig;
+  gatewayOverrides?: GatewayCallOptions;
+  debuggingUrl?: string;
+};
+
+/**
+ * Create the appropriate BrowserBridge implementation.
+ *
+ * Selection order:
+ * 1. `JARVIS_BROWSER_MODE=openclaw`  -> {@link OpenClawBrowserBridge}
+ * 2. `JARVIS_BROWSER_MODE=legacy`    -> {@link LegacyPuppeteerBridge}
+ * 3. If no env var is set, default to `legacy` for backward compatibility.
+ */
+export function createBrowserBridge(
+  cfg: BrowserBridgeFactoryConfig = {},
+): BrowserBridge {
+  const mode = (process.env.JARVIS_BROWSER_MODE ?? "legacy").toLowerCase();
+
+  if (mode === "openclaw") {
+    return new OpenClawBrowserBridge({
+      openclawConfig: cfg.openclawConfig,
+      gatewayOverrides: cfg.gatewayOverrides
+    });
+  }
+
+  return new LegacyPuppeteerBridge({
+    debuggingUrl: cfg.debuggingUrl
+  });
+}

--- a/packages/jarvis-core/src/hooks.ts
+++ b/packages/jarvis-core/src/hooks.ts
@@ -1,0 +1,300 @@
+/**
+ * Jarvis Hook Catalog
+ *
+ * Centralized policy enforcement via OpenClaw hook registration.
+ * Expands beyond the single before_tool_call approval hook to cover:
+ * - Pre-tool policy (approval gating, capability checks)
+ * - Post-tool provenance (audit enrichment, artifact tracking)
+ * - Pre-reply guardrails (PII redaction, compliance checks)
+ * - Error policy (centralized retry/escalation decisions)
+ *
+ * See ADR-PLATFORM-KERNEL-BOUNDARY.md and CONVERGENCE-ROADMAP.md (Epic 8).
+ */
+
+import {
+  BUILT_IN_TOOLS_REQUIRING_HOOK_APPROVAL,
+  JOB_APPROVAL_REQUIREMENT,
+  JOB_TYPE_NAMES,
+} from "@jarvis/shared";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type ApprovalSeverity = "info" | "warning" | "critical";
+
+export type ApprovalGateResult = {
+  requireApproval: {
+    title: string;
+    description: string;
+    severity: ApprovalSeverity;
+    timeoutMs: number;
+    timeoutBehavior: "deny" | "allow";
+  };
+};
+
+export type ToolCallEvent = {
+  toolName: string;
+  toolCallId?: string;
+  params?: Record<string, unknown>;
+  sessionKey?: string;
+};
+
+export type ToolResultEvent = {
+  toolName: string;
+  toolCallId?: string;
+  result?: unknown;
+  durationMs?: number;
+  sessionKey?: string;
+};
+
+export type ReplyEvent = {
+  content: string;
+  sessionKey?: string;
+  toolCalls?: Array<{ name: string; result?: unknown }>;
+};
+
+export type ErrorEvent = {
+  toolName?: string;
+  error: Error | string;
+  sessionKey?: string;
+  retryCount?: number;
+};
+
+export type HookRegistration = {
+  hookPoint: string;
+  handler: (...args: unknown[]) => unknown;
+  priority: number;
+  description: string;
+};
+
+// ─── Pre-Tool Hooks ──────────────────────────────────────────────────
+
+/**
+ * Approval gating for built-in OpenClaw tools.
+ * This is the existing hook, now part of the unified catalog.
+ */
+export function createBuiltInApprovalHook() {
+  return {
+    hookPoint: "before_tool_call" as const,
+    priority: 0,
+    description: "Approval gating for sensitive built-in tools (exec, apply_patch, browser)",
+    handler: (event: ToolCallEvent): ApprovalGateResult | undefined => {
+      if (!BUILT_IN_TOOLS_REQUIRING_HOOK_APPROVAL.has(event.toolName)) {
+        return undefined;
+      }
+
+      return {
+        requireApproval: {
+          title: `Approve ${event.toolName}`,
+          description: `Jarvis requires operator approval before using ${event.toolName}.`,
+          severity: event.toolName === "exec" ? "critical" : "warning",
+          timeoutMs: 300_000,
+          timeoutBehavior: "deny",
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Approval gating for Jarvis domain tools that trigger mutating jobs.
+ * Complements the built-in approval hook with domain-specific policy.
+ */
+export function createDomainApprovalHook() {
+  // Tools that always need approval when the underlying job requires it
+  const MUTATING_TOOLS = new Set([
+    "email_send",
+    "email_draft",   // drafts are less critical but track them
+    "crm_move_stage",
+    "crm_update_contact",
+  ]);
+
+  return {
+    hookPoint: "before_tool_call" as const,
+    priority: 10,
+    description: "Approval gating for Jarvis domain tools that trigger mutating jobs",
+    handler: (event: ToolCallEvent): ApprovalGateResult | undefined => {
+      if (!MUTATING_TOOLS.has(event.toolName)) {
+        return undefined;
+      }
+
+      const severity: ApprovalSeverity =
+        event.toolName === "email_send" ? "critical" : "warning";
+
+      return {
+        requireApproval: {
+          title: `Approve ${event.toolName}`,
+          description: `Domain policy requires approval for ${event.toolName}.`,
+          severity,
+          timeoutMs: 600_000,
+          timeoutBehavior: "deny",
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Capability boundary enforcement.
+ * Prevents tools from being called in contexts where they shouldn't be available
+ * (e.g., read-only operator sessions calling mutating tools).
+ */
+export function createCapabilityBoundaryHook() {
+  const READ_ONLY_TOOLS = new Set([
+    "jarvis_plan",
+    "jarvis_get_job",
+    "jarvis_list_artifacts",
+    "job_status",
+    "job_artifacts",
+    "email_search",
+    "email_read",
+    "email_list_threads",
+    "crm_search",
+    "crm_list_pipeline",
+  ]);
+
+  return {
+    hookPoint: "before_tool_call" as const,
+    priority: -10,  // Run before approval hooks
+    description: "Capability boundary enforcement for read-only vs mutating contexts",
+    handler: (event: ToolCallEvent & { context?: { readOnly?: boolean } }) => {
+      // If context declares read-only, block mutating tools
+      if (event.context?.readOnly && !READ_ONLY_TOOLS.has(event.toolName)) {
+        return {
+          deny: {
+            reason: `Tool ${event.toolName} is not available in read-only context.`,
+            code: "CAPABILITY_BOUNDARY",
+          },
+        };
+      }
+      return undefined;
+    },
+  };
+}
+
+// ─── Post-Tool Hooks ─────────────────────────────────────────────────
+
+/**
+ * Provenance enrichment after tool execution.
+ * Records tool usage for audit trail and artifact provenance.
+ */
+export function createProvenanceHook() {
+  return {
+    hookPoint: "after_tool_call" as const,
+    priority: 0,
+    description: "Records tool execution for audit trail and artifact provenance",
+    handler: (event: ToolResultEvent) => {
+      // Provenance data to be appended to the session/run context
+      return {
+        provenance: {
+          tool_name: event.toolName,
+          tool_call_id: event.toolCallId,
+          duration_ms: event.durationMs,
+          timestamp: new Date().toISOString(),
+        },
+      };
+    },
+  };
+}
+
+// ─── Pre-Reply Hooks ─────────────────────────────────────────────────
+
+/**
+ * Reply guardrails for operator-facing responses.
+ * Checks for PII patterns, credential leakage, and compliance issues.
+ */
+export function createReplyGuardrailHook() {
+  // Patterns that should never appear in operator-facing replies
+  const SENSITIVE_PATTERNS = [
+    /\bsk-[a-zA-Z0-9]{20,}\b/,          // API keys
+    /\b[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}\b/, // Credit card numbers
+    /\bghp_[a-zA-Z0-9]{36}\b/,           // GitHub personal access tokens
+    /\bbot[0-9]{8,}:[A-Za-z0-9_-]{35}\b/, // Telegram bot tokens
+  ];
+
+  return {
+    hookPoint: "before_reply" as const,
+    priority: 0,
+    description: "Redacts sensitive patterns from operator-facing replies",
+    handler: (event: ReplyEvent) => {
+      let content = event.content;
+      let redacted = false;
+
+      for (const pattern of SENSITIVE_PATTERNS) {
+        if (pattern.test(content)) {
+          content = content.replace(pattern, "[REDACTED]");
+          redacted = true;
+        }
+      }
+
+      if (redacted) {
+        return {
+          modifiedContent: content,
+          warning: "Sensitive data redacted from reply.",
+        };
+      }
+
+      return undefined;
+    },
+  };
+}
+
+// ─── Error Hooks ─────────────────────────────────────────────────────
+
+/**
+ * Centralized error policy.
+ * Decides whether errors should be retried, escalated, or swallowed.
+ */
+export function createErrorPolicyHook() {
+  const RETRYABLE_ERRORS = new Set([
+    "ECONNREFUSED",
+    "ETIMEDOUT",
+    "ENOTFOUND",
+    "WORKER_UNAVAILABLE",
+  ]);
+
+  const MAX_RETRIES = 3;
+
+  return {
+    hookPoint: "on_error" as const,
+    priority: 0,
+    description: "Centralized error retry and escalation policy",
+    handler: (event: ErrorEvent) => {
+      const errorMessage =
+        event.error instanceof Error ? event.error.message : String(event.error);
+
+      const isRetryable = RETRYABLE_ERRORS.has(
+        errorMessage.split(":")[0] ?? "",
+      );
+      const withinRetryLimit = (event.retryCount ?? 0) < MAX_RETRIES;
+
+      if (isRetryable && withinRetryLimit) {
+        return {
+          action: "retry" as const,
+          backoffMs: 1000 * Math.pow(2, event.retryCount ?? 0),
+        };
+      }
+
+      return {
+        action: "escalate" as const,
+        reason: errorMessage,
+      };
+    },
+  };
+}
+
+// ─── Hook Catalog ────────────────────────────────────────────────────
+
+/**
+ * Returns the complete hook catalog for registration.
+ * Each hook is self-describing with hookPoint, priority, and description.
+ */
+export function getHookCatalog(): HookRegistration[] {
+  return [
+    createBuiltInApprovalHook(),
+    createDomainApprovalHook(),
+    createCapabilityBoundaryHook(),
+    createProvenanceHook(),
+    createReplyGuardrailHook(),
+    createErrorPolicyHook(),
+  ];
+}

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -7,6 +7,7 @@ import { approvalsRouter } from './approvals.js'
 import { chatRouter } from './chat.js'
 import { daemonRouter } from './daemon.js'
 import { webhookRouter } from './webhooks.js'
+import { webhookV2Router } from './webhooks-v2.js'
 import { pluginsRouter } from './plugins.js'
 import { runsRouter } from './runs.js'
 import { attentionRouter } from './attention.js'
@@ -17,6 +18,7 @@ import { backupRouter } from './backup.js'
 import { safemodeRouter } from './safemode.js'
 import { portalRouter } from './portal.js'
 import { godmodeRouter } from './godmode.js'
+import { createSessionChatRoute } from './session-chat-adapter.js'
 import { modelsRouter } from './models.js'
 import { queueRouter } from './queue.js'
 import { policyRouter } from './policy.js'
@@ -104,6 +106,7 @@ app.use('/api/approvals', approvalsRouter)
 app.use('/api/chat', chatRouter)
 app.use('/api/daemon', daemonRouter)
 app.use('/api/webhooks', webhookRouter)
+app.use('/api/webhooks-v2', webhookV2Router)
 app.use('/api/plugins', pluginsRouter)
 app.use('/api/runs', runsRouter)
 app.use('/api/attention', attentionRouter)
@@ -114,6 +117,7 @@ app.use('/api/backup', backupRouter)
 app.use('/api/safemode', safemodeRouter)
 app.use('/portal/api', portalRouter)
 app.use('/api/godmode', godmodeRouter)
+app.use('/api/godmode/v2', createSessionChatRoute())
 app.use('/api/models', modelsRouter)
 app.use('/api/queue', queueRouter)
 app.use('/api/policy', policyRouter)

--- a/packages/jarvis-dashboard/src/api/session-chat-adapter.ts
+++ b/packages/jarvis-dashboard/src/api/session-chat-adapter.ts
@@ -1,0 +1,574 @@
+/**
+ * session-chat-adapter.ts -- OpenClaw session-backed operator chat adapter.
+ *
+ * Bridges the godmode UX (intent classification, artifact extraction,
+ * multi-surface streaming) with OpenClaw session delivery. The dashboard
+ * becomes a client of OpenClaw sessions rather than a sibling orchestrator.
+ *
+ * Target state (from ADR-CHAT-SURFACES.md): "Only OpenClaw owns the
+ * operator chat loop." This adapter is the migration bridge:
+ *
+ *   Dashboard UI  -->  SessionChatAdapter  -->  OpenClaw Gateway
+ *                                          |
+ *                                          '--> Legacy godmode (fallback)
+ *
+ * The v2 route provides the same REST interface as /api/godmode but
+ * delegates to the session adapter. When the gateway is unreachable it
+ * falls back to the legacy godmode endpoint transparently.
+ */
+
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import {
+  invokeGatewayMethod,
+  sendSessionMessage,
+  type GatewayCallOptions,
+} from '@jarvis/shared'
+import {
+  READONLY_TOOL_NAMES,
+  type ReadOnlyToolName,
+} from './tool-infra.js'
+
+// ---- Types ----------------------------------------------------------------
+
+export type SessionChatMode = 'chat' | 'research' | 'artifact' | 'code' | 'cowork'
+
+export interface SessionChatResponse {
+  reply: string
+  artifacts?: Array<{ type: string; content: string; name?: string }>
+  tool_calls?: Array<{ name: string; result: unknown }>
+  session_key: string
+}
+
+export interface SessionInfo {
+  session_key: string
+  created_at: string
+  last_active: string
+  message_count: number
+}
+
+/** Shape returned by the gateway's sessions.send method. */
+interface GatewaySendResult {
+  reply?: string
+  content?: string
+  artifacts?: Array<{ type: string; content: string; name?: string }>
+  tool_calls?: Array<{ name: string; result: unknown }>
+  session_key?: string
+  key?: string
+}
+
+/** Shape returned by the gateway's sessions.list method. */
+interface GatewaySessionEntry {
+  key?: string
+  session_key?: string
+  created_at?: string
+  last_active?: string
+  message_count?: number
+  messages?: number
+}
+
+/** Shape returned by the gateway's sessions.create method. */
+interface GatewayCreateResult {
+  key?: string
+  session_key?: string
+}
+
+// ---- OpenClaw tool registration shape ------------------------------------
+
+export interface SessionToolRegistration {
+  name: string
+  description: string
+  parameters: Record<string, unknown>
+  read_only: true
+}
+
+// ---- Adapter class -------------------------------------------------------
+
+export class SessionChatAdapter {
+  private readonly gatewayUrl: string
+  private readonly gatewayToken: string
+  private readonly timeoutMs: number
+
+  constructor(config: {
+    gatewayUrl?: string
+    gatewayToken?: string
+    timeoutMs?: number
+  } = {}) {
+    this.gatewayUrl =
+      config.gatewayUrl ??
+      process.env.JARVIS_GATEWAY_URL ??
+      `ws://127.0.0.1:${process.env.JARVIS_GATEWAY_PORT ?? '18789'}`
+    this.gatewayToken =
+      config.gatewayToken ??
+      process.env.JARVIS_GATEWAY_TOKEN ??
+      ''
+    this.timeoutMs = config.timeoutMs ?? 60_000
+  }
+
+  // -- Public API ----------------------------------------------------------
+
+  /**
+   * Send a message to an operator session and get the response.
+   *
+   * The mode hint is forwarded as metadata so OpenClaw can route to the
+   * appropriate surface prompt / plugin configuration.
+   */
+  async sendMessage(params: {
+    sessionKey: string
+    message: string
+    mode?: SessionChatMode
+  }): Promise<SessionChatResponse> {
+    const overrides = this.callOptions()
+
+    // Build the message payload. The mode is sent as a prefix directive
+    // that the session plugin can interpret, keeping the wire format simple.
+    const modeDirective = params.mode && params.mode !== 'chat'
+      ? `[mode:${params.mode}] `
+      : ''
+
+    const raw = await sendSessionMessage(
+      {
+        sessionKey: params.sessionKey,
+        message: `${modeDirective}${params.message}`,
+        timeoutMs: this.timeoutMs,
+      },
+      undefined, // no OpenClawConfig -- we use overrides
+      overrides,
+    ) as GatewaySendResult
+
+    return normalizeResponse(raw, params.sessionKey)
+  }
+
+  /**
+   * List active operator sessions known to the gateway.
+   */
+  async listSessions(): Promise<SessionInfo[]> {
+    const overrides = this.callOptions()
+    const raw = await invokeGatewayMethod<{ sessions?: GatewaySessionEntry[] }>(
+      'sessions.list',
+      undefined,
+      {},
+      overrides,
+    )
+
+    const entries = raw.sessions ?? []
+    return entries.map(normalizeSessionInfo)
+  }
+
+  /**
+   * Get or create the default session for a given operator.
+   *
+   * Convention: the default session key is `operator:<operatorId>`.
+   * If the session does not exist the gateway creates one.
+   */
+  async getOrCreateOperatorSession(operatorId: string): Promise<string> {
+    const sessionKey = `operator:${operatorId}`
+    const overrides = this.callOptions()
+
+    try {
+      // Try to create -- gateway returns the existing key if it already exists
+      const raw = await invokeGatewayMethod<GatewayCreateResult>(
+        'sessions.create',
+        undefined,
+        { key: sessionKey },
+        overrides,
+      )
+      return raw.key ?? raw.session_key ?? sessionKey
+    } catch {
+      // If create fails (e.g. session already exists), return the key
+      return sessionKey
+    }
+  }
+
+  /**
+   * Probe whether the gateway is reachable.
+   * Returns true if a lightweight method succeeds within a short timeout.
+   */
+  async isGatewayAvailable(): Promise<boolean> {
+    try {
+      await invokeGatewayMethod(
+        'sessions.list',
+        undefined,
+        {},
+        { ...this.callOptions(), timeoutMs: 3_000 },
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  // -- Internals -----------------------------------------------------------
+
+  private callOptions(): GatewayCallOptions {
+    return {
+      gatewayUrl: this.gatewayUrl,
+      gatewayToken: this.gatewayToken,
+      timeoutMs: this.timeoutMs,
+    }
+  }
+}
+
+// ---- Response normalizers ------------------------------------------------
+
+function normalizeResponse(
+  raw: GatewaySendResult,
+  sessionKey: string,
+): SessionChatResponse {
+  return {
+    reply: raw.reply ?? raw.content ?? '',
+    artifacts: raw.artifacts,
+    tool_calls: raw.tool_calls,
+    session_key: raw.session_key ?? raw.key ?? sessionKey,
+  }
+}
+
+function normalizeSessionInfo(entry: GatewaySessionEntry): SessionInfo {
+  return {
+    session_key: entry.key ?? entry.session_key ?? '',
+    created_at: entry.created_at ?? '',
+    last_active: entry.last_active ?? '',
+    message_count: entry.message_count ?? entry.messages ?? 0,
+  }
+}
+
+// ---- Tool mapping --------------------------------------------------------
+
+/**
+ * Map the current read-only tool set from tool-infra.ts into OpenClaw
+ * session tool registrations.
+ *
+ * Each tool is marked read_only so the session plugin can enforce the
+ * same safety invariant as the legacy godmode: no mutations flow through
+ * the dashboard chat surface.
+ *
+ * The returned array can be passed to `sessions.registerTools` or included
+ * in a plugin manifest's `tools` section.
+ */
+export function mapGodmodeToolsToSessionTools(): SessionToolRegistration[] {
+  const toolMeta: Record<ReadOnlyToolName, { description: string; parameters: Record<string, unknown> }> = {
+    web_search: {
+      description: 'Search the web for current information',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'Search query' } },
+        required: ['query'],
+      },
+    },
+    web_fetch: {
+      description: 'Fetch and read content from a specific URL',
+      parameters: {
+        type: 'object',
+        properties: { url: { type: 'string', description: 'URL to fetch' } },
+        required: ['url'],
+      },
+    },
+    crm_search: {
+      description: 'Search the CRM pipeline for contacts',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'Company or person name' } },
+        required: ['query'],
+      },
+    },
+    knowledge_search: {
+      description: 'Search the Jarvis knowledge base',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Search topic' },
+          collection: { type: 'string', description: 'Collection: lessons, playbooks, iso26262, contracts, proposals' },
+        },
+        required: ['query'],
+      },
+    },
+    system_info: {
+      description: 'Get current system info: CPU, memory, disk usage',
+      parameters: { type: 'object', properties: {} },
+    },
+    list_files: {
+      description: 'List files and folders at a path',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string', description: 'Directory path' } },
+        required: ['path'],
+      },
+    },
+    file_read: {
+      description: 'Read a file from the project directory',
+      parameters: {
+        type: 'object',
+        properties: { path: { type: 'string', description: 'File path relative to project root' } },
+        required: ['path'],
+      },
+    },
+    file_list: {
+      description: 'List files in a directory with optional recursion',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Directory path relative to project root' },
+          recursive: { type: 'boolean', description: 'Include subdirectories' },
+        },
+      },
+    },
+    gmail_search: {
+      description: 'Search Gmail emails using Gmail search syntax',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Gmail search query' },
+          max_results: { type: 'number', description: 'Max emails to return' },
+        },
+        required: ['query'],
+      },
+    },
+    gmail_read: {
+      description: 'Read a specific email by message ID',
+      parameters: {
+        type: 'object',
+        properties: { message_id: { type: 'string', description: 'Gmail message ID' } },
+        required: ['message_id'],
+      },
+    },
+    agent_status: {
+      description: 'Get status of all Jarvis agents. Read-only.',
+      parameters: { type: 'object', properties: {} },
+    },
+    browse_page: {
+      description: 'Open a URL in the browser and extract page content',
+      parameters: {
+        type: 'object',
+        properties: { url: { type: 'string', description: 'URL to navigate to' } },
+        required: ['url'],
+      },
+    },
+  }
+
+  // Build registrations only for tools in the canonical READONLY_TOOL_NAMES list
+  return READONLY_TOOL_NAMES.map((name) => {
+    const meta = toolMeta[name]
+    return {
+      name,
+      description: meta.description,
+      parameters: meta.parameters,
+      read_only: true as const,
+    }
+  })
+}
+
+// ---- Express route -------------------------------------------------------
+
+/**
+ * Create the v2 godmode route that delegates to the session adapter.
+ *
+ * Mount as: `app.use('/api/godmode/v2', createSessionChatRoute())`
+ *
+ * POST /api/godmode/v2
+ *   Body: { message: string, mode?: SessionChatMode, session_key?: string }
+ *   Response: { reply: string, artifacts?: [...], session_key: string }
+ *
+ * When the gateway is unavailable, falls back to proxying the request
+ * to the legacy godmode endpoint on the same Express app.
+ */
+export function createSessionChatRoute(adapterOverride?: SessionChatAdapter): Router {
+  const router = Router()
+
+  // Lazily-initialized adapter -- reused across requests
+  let _adapter: SessionChatAdapter | undefined = adapterOverride
+
+  function getAdapter(): SessionChatAdapter {
+    if (!_adapter) {
+      _adapter = new SessionChatAdapter()
+    }
+    return _adapter
+  }
+
+  // POST / -- main entry point
+  router.post('/', async (req: Request, res: Response) => {
+    const { message, mode, session_key } = req.body as {
+      message?: string
+      mode?: SessionChatMode
+      session_key?: string
+    }
+
+    if (!message?.trim()) {
+      res.status(400).json({ error: 'message is required' })
+      return
+    }
+
+    const adapter = getAdapter()
+
+    // Check gateway availability before committing to the session path
+    const gatewayUp = await adapter.isGatewayAvailable()
+
+    if (!gatewayUp) {
+      // Fall back to legacy godmode by proxying the request internally.
+      // The legacy endpoint uses SSE, so we rewrite the request body to
+      // match its expected shape and pipe the response.
+      await legacyFallback(req, res, message, mode)
+      return
+    }
+
+    try {
+      // Resolve session key -- use provided key, or create a default one
+      const resolvedKey = session_key ?? await adapter.getOrCreateOperatorSession('default')
+
+      const response = await adapter.sendMessage({
+        sessionKey: resolvedKey,
+        message,
+        mode,
+      })
+
+      res.json(response)
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+
+      // If the session call failed, try the legacy fallback
+      console.warn(`[session-chat-adapter] Gateway call failed, falling back to legacy: ${errMsg}`)
+      await legacyFallback(req, res, message, mode)
+    }
+  })
+
+  // GET /sessions -- list operator sessions
+  router.get('/sessions', async (_req: Request, res: Response) => {
+    const adapter = getAdapter()
+    try {
+      const sessions = await adapter.listSessions()
+      res.json({ sessions })
+    } catch (err) {
+      res.status(502).json({
+        error: 'Gateway unavailable',
+        detail: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })
+
+  // GET /tools -- return the session tool registrations
+  router.get('/tools', (_req: Request, res: Response) => {
+    res.json({ tools: mapGodmodeToolsToSessionTools() })
+  })
+
+  return router
+}
+
+// ---- Legacy fallback -----------------------------------------------------
+
+/**
+ * Forward a v2 request to the legacy /api/godmode endpoint.
+ *
+ * The legacy endpoint streams SSE, so we collect the full response and
+ * return it as a single JSON object matching the v2 shape.
+ */
+async function legacyFallback(
+  _req: Request,
+  res: Response,
+  message: string,
+  mode?: SessionChatMode,
+): Promise<void> {
+  // Dynamic import to avoid circular dependency at module load time.
+  // The legacy godmode router is mounted on the same Express app, so
+  // we import its dependencies and call llmChat directly rather than
+  // making an HTTP round-trip.
+  try {
+    const http = await import('http')
+
+    // Build the internal request to /api/godmode
+    const PORT = Number(process.env.PORT ?? 4242)
+    const body = JSON.stringify({ message, mode })
+
+    const collected = await new Promise<string>((resolve, reject) => {
+      const proxyReq = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: PORT,
+          path: '/api/godmode',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+            // Forward auth header if present
+            ...(_req.headers.authorization
+              ? { Authorization: _req.headers.authorization }
+              : {}),
+          },
+        },
+        (proxyRes) => {
+          let data = ''
+          proxyRes.on('data', (chunk: Buffer) => { data += chunk.toString() })
+          proxyRes.on('end', () => resolve(data))
+          proxyRes.on('error', reject)
+        },
+      )
+      proxyReq.on('error', reject)
+      proxyReq.setTimeout(60_000, () => {
+        proxyReq.destroy()
+        reject(new Error('Legacy godmode timeout'))
+      })
+      proxyReq.write(body)
+      proxyReq.end()
+    })
+
+    // The legacy response is SSE. Extract token content and artifacts.
+    const reply = extractReplyFromSSE(collected)
+    const artifacts = extractArtifactsFromSSE(collected)
+
+    res.json({
+      reply,
+      artifacts: artifacts.length > 0 ? artifacts : undefined,
+      session_key: 'legacy',
+    } satisfies SessionChatResponse)
+  } catch (err) {
+    res.status(502).json({
+      error: 'Both gateway and legacy godmode are unavailable',
+      detail: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+// ---- SSE parsing helpers -------------------------------------------------
+
+/** Collect all `token` events from an SSE stream into a single reply string. */
+function extractReplyFromSSE(sse: string): string {
+  const tokens: string[] = []
+  for (const line of sse.split('\n')) {
+    if (!line.startsWith('data: ')) continue
+    const payload = line.slice(6).trim()
+    if (payload === '[DONE]') continue
+    try {
+      const obj = JSON.parse(payload) as { type?: string; content?: string }
+      if (obj.type === 'token' && obj.content) {
+        tokens.push(obj.content)
+      }
+    } catch { /* skip malformed */ }
+  }
+  return tokens.join('')
+}
+
+/** Collect all `artifact` events from an SSE stream. */
+function extractArtifactsFromSSE(
+  sse: string,
+): Array<{ type: string; content: string; name?: string }> {
+  const artifacts: Array<{ type: string; content: string; name?: string }> = []
+  for (const line of sse.split('\n')) {
+    if (!line.startsWith('data: ')) continue
+    const payload = line.slice(6).trim()
+    if (payload === '[DONE]') continue
+    try {
+      const obj = JSON.parse(payload) as {
+        type?: string
+        kind?: string
+        content?: string
+        title?: string
+      }
+      if (obj.type === 'artifact' && obj.content) {
+        artifacts.push({
+          type: obj.kind ?? 'unknown',
+          content: obj.content,
+          name: obj.title,
+        })
+      }
+    } catch { /* skip malformed */ }
+  }
+  return artifacts
+}

--- a/packages/jarvis-dashboard/src/api/webhooks-v2.ts
+++ b/packages/jarvis-dashboard/src/api/webhooks-v2.ts
@@ -1,0 +1,278 @@
+/**
+ * Webhook ingress v2 — uses the transport-agnostic normalizer from @jarvis/shared.
+ *
+ * This router is a backwards-compatible replacement for webhooks.ts (v1).
+ * It produces identical HTTP responses but delegates all domain logic to
+ * the pure functions in @jarvis/shared/webhook-normalizer so that the
+ * same logic can be reused in an OpenClaw webhook/TaskFlow surface.
+ *
+ * Every response includes the deprecation header:
+ *   X-Jarvis-Deprecation: webhook-v1
+ *
+ * Callers should migrate to the OpenClaw webhook ingress when available.
+ */
+
+import { Router } from "express";
+import { randomUUID } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import os from "node:os";
+import fs from "node:fs";
+import { join } from "node:path";
+import { createCommand } from "@jarvis/runtime";
+import {
+  verifyWebhookSignature,
+  normalizeGithubWebhook,
+  normalizeGenericWebhook,
+  normalizeCustomWebhook,
+  webhookEventToCommand,
+  type NormalizedWebhookEvent,
+  type WebhookCommandParams,
+} from "@jarvis/shared";
+
+// ─── Shared Helpers ─────────────────────────────────────────────────────────
+
+const JARVIS_DIR = join(os.homedir(), ".jarvis");
+
+const DEPRECATION_HEADER = "X-Jarvis-Deprecation";
+const DEPRECATION_VALUE = "webhook-v1";
+
+function loadWebhookSecret(): string | undefined {
+  const configPath = join(JARVIS_DIR, "config.json");
+  if (!fs.existsSync(configPath)) return undefined;
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    return raw.webhook_secret as string | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getDb(): DatabaseSync {
+  const db = new DatabaseSync(join(JARVIS_DIR, "runtime.db"));
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  return db;
+}
+
+/**
+ * Execute a NormalizedWebhookEvent: persist the command and write an audit entry.
+ */
+function executeWebhookEvent(
+  event: NormalizedWebhookEvent,
+  triggeredBy: string,
+): string {
+  const params: WebhookCommandParams = webhookEventToCommand(event);
+  const db = getDb();
+
+  try {
+    const { commandId } = createCommand(db, {
+      agentId: params.agentId,
+      source: params.source,
+      payload: params.payload,
+      idempotencyKey: params.idempotencyKey,
+    });
+
+    // Write audit log entry
+    db.prepare(
+      `
+      INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    ).run(
+      randomUUID(),
+      "webhook",
+      triggeredBy,
+      "trigger.created",
+      "agent",
+      event.agent_id,
+      JSON.stringify(event.context),
+      new Date().toISOString(),
+    );
+
+    return commandId;
+  } finally {
+    try {
+      db.close();
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Extract the raw body string for HMAC verification.
+ * Providers sign the exact bytes — re-serializing JSON can alter whitespace.
+ */
+function getRawBody(req: import("express").Request): string {
+  return typeof (req as any).rawBody === "string"
+    ? (req as any).rawBody
+    : JSON.stringify(req.body);
+}
+
+// ─── Router ─────────────────────────────────────────────────────────────────
+
+export const webhookV2Router = Router();
+
+// Attach deprecation header to every response from this router.
+webhookV2Router.use((_req, res, next) => {
+  res.setHeader(DEPRECATION_HEADER, DEPRECATION_VALUE);
+  next();
+});
+
+// POST /api/webhooks-v2/github — GitHub webhook handler
+webhookV2Router.post("/github", (req, res) => {
+  const signature = req.headers["x-hub-signature-256"] as string | undefined;
+  const secret = loadWebhookSecret();
+
+  // --- Signature verification ---
+  let signatureVerified = false;
+
+  if (secret && signature) {
+    const rawBody = getRawBody(req);
+    if (!verifyWebhookSignature(rawBody, signature, secret)) {
+      console.warn(
+        "[webhooks-v2] GitHub signature verification failed (deprecated direct ingress)",
+      );
+      res.status(401).json({ error: "Invalid signature" });
+      return;
+    }
+    signatureVerified = true;
+  } else if (secret && !signature) {
+    res.status(401).json({ error: "Missing signature" });
+    return;
+  }
+
+  // --- Normalize ---
+  const event = req.headers["x-github-event"] as string | undefined;
+  if (!event) {
+    res.status(400).json({ error: "Missing X-GitHub-Event header" });
+    return;
+  }
+
+  const payload = req.body as Record<string, unknown>;
+  const normalized = normalizeGithubWebhook({
+    event,
+    payload,
+    signatureVerified,
+  });
+
+  if (!normalized) {
+    res.json({
+      status: "ignored",
+      event,
+      message: `No agent mapped for event: ${event}`,
+    });
+    return;
+  }
+
+  // --- Execute ---
+  console.info(
+    `[webhooks-v2] DEPRECATED direct GitHub webhook -> ${normalized.agent_id}. Migrate to OpenClaw webhook surface.`,
+  );
+  executeWebhookEvent(normalized, `webhook:github:${event}`);
+
+  res.json({
+    status: "triggered",
+    agentId: normalized.agent_id,
+    event,
+    triggeredAt: normalized.received_at,
+  });
+});
+
+// POST /api/webhooks-v2/generic — generic JSON webhook
+webhookV2Router.post("/generic", (req, res) => {
+  const secret = loadWebhookSecret();
+
+  // --- Signature verification ---
+  let signatureVerified = false;
+
+  if (secret) {
+    const signature = req.headers["x-jarvis-signature"] as string | undefined;
+    if (!signature) {
+      res.status(401).json({ error: "Invalid or missing X-Jarvis-Signature" });
+      return;
+    }
+    const rawBody = JSON.stringify(req.body);
+    if (!verifyWebhookSignature(rawBody, signature, secret)) {
+      console.warn(
+        "[webhooks-v2] Generic signature verification failed (deprecated direct ingress)",
+      );
+      res.status(401).json({ error: "Invalid or missing X-Jarvis-Signature" });
+      return;
+    }
+    signatureVerified = true;
+  }
+
+  // --- Normalize ---
+  const body = req.body as Record<string, unknown>;
+  const result = normalizeGenericWebhook({
+    payload: body,
+    signatureVerified,
+  });
+
+  if (!result.ok) {
+    res.status(400).json({ error: result.error });
+    return;
+  }
+
+  // --- Execute ---
+  console.info(
+    `[webhooks-v2] DEPRECATED direct generic webhook -> ${result.event.agent_id}. Migrate to OpenClaw webhook surface.`,
+  );
+  executeWebhookEvent(result.event, "webhook:generic");
+
+  res.json({
+    status: "triggered",
+    agentId: result.event.agent_id,
+    triggeredAt: result.event.received_at,
+  });
+});
+
+// POST /api/webhooks-v2/:agentId — trigger any agent with optional payload
+webhookV2Router.post("/:agentId", (req, res) => {
+  const secret = loadWebhookSecret();
+
+  // --- Signature verification ---
+  let signatureVerified = false;
+
+  if (secret) {
+    const signature = req.headers["x-jarvis-signature"] as string | undefined;
+    if (!signature) {
+      res.status(401).json({ error: "Invalid or missing X-Jarvis-Signature" });
+      return;
+    }
+    const rawBody = JSON.stringify(req.body);
+    if (!verifyWebhookSignature(rawBody, signature, secret)) {
+      console.warn(
+        "[webhooks-v2] Custom signature verification failed (deprecated direct ingress)",
+      );
+      res.status(401).json({ error: "Invalid or missing X-Jarvis-Signature" });
+      return;
+    }
+    signatureVerified = true;
+  }
+
+  // --- Normalize ---
+  const { agentId } = req.params;
+  const payload = req.body as Record<string, unknown>;
+  const normalized = normalizeCustomWebhook({
+    agentId: agentId!,
+    payload,
+    signatureVerified,
+  });
+
+  // --- Execute ---
+  console.info(
+    `[webhooks-v2] DEPRECATED direct custom webhook -> ${normalized.agent_id}. Migrate to OpenClaw webhook surface.`,
+  );
+  executeWebhookEvent(normalized, "webhook");
+
+  res.json({
+    status: "triggered",
+    agentId: normalized.agent_id,
+    triggeredAt: normalized.received_at,
+  });
+});

--- a/packages/jarvis-security/src/credential-audit.ts
+++ b/packages/jarvis-security/src/credential-audit.ts
@@ -1,0 +1,184 @@
+/**
+ * Credential Access Audit
+ *
+ * Wraps credential distribution with audit logging.
+ * Closes the trust gap documented in KNOWN-TRUST-GAPS.md:
+ * "When getCredentialsForWorker() distributes secrets to workers,
+ * this is not recorded in the audit log."
+ *
+ * See CONVERGENCE-ROADMAP.md Epic 10.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type CredentialAccessEvent = {
+  worker_id: string;
+  credential_keys: string[];
+  run_id?: string;
+  job_id?: string;
+  granted: boolean;
+  reason?: string;
+  timestamp: string;
+};
+
+export type CredentialAuditConfig = {
+  db: DatabaseSync;
+  enabled: boolean;
+};
+
+// ─── Audit Logger ────────────────────────────────────────────────────
+
+/**
+ * Records a credential access event in the audit log.
+ *
+ * Uses the existing audit_log table in runtime.db with:
+ * - actor_type: "worker"
+ * - action: "credential.access"
+ * - target_type: "credential"
+ */
+export function logCredentialAccess(
+  config: CredentialAuditConfig,
+  event: CredentialAccessEvent,
+): void {
+  if (!config.enabled) return;
+
+  try {
+    config.db
+      .prepare(
+        `INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        randomUUID(),
+        "worker",
+        event.worker_id,
+        event.granted ? "credential.access" : "credential.denied",
+        "credential",
+        event.credential_keys.join(","),
+        JSON.stringify({
+          keys: event.credential_keys,
+          run_id: event.run_id,
+          job_id: event.job_id,
+          reason: event.reason,
+        }),
+        event.timestamp,
+      );
+  } catch {
+    // Best-effort — audit logging failure should not block credential distribution
+  }
+}
+
+/**
+ * Creates an audited version of getCredentialsForWorker.
+ *
+ * Wraps the original function to log every credential access,
+ * providing the audit trail the trust-gap doc identifies as missing.
+ *
+ * Usage:
+ * ```ts
+ * const getCreds = createAuditedCredentialAccessor(auditConfig, getCredentialsForWorker);
+ * const creds = getCreds("email", config, { runId: "run-123", jobId: "job-456" });
+ * ```
+ */
+export function createAuditedCredentialAccessor<TConfig, TResult>(
+  auditConfig: CredentialAuditConfig,
+  originalAccessor: (workerId: string, config: TConfig) => TResult,
+): (
+  workerId: string,
+  config: TConfig,
+  context?: { runId?: string; jobId?: string },
+) => TResult {
+  return (
+    workerId: string,
+    config: TConfig,
+    context?: { runId?: string; jobId?: string },
+  ): TResult => {
+    const result = originalAccessor(workerId, config);
+
+    // Determine which keys were actually distributed
+    const distributedKeys =
+      result && typeof result === "object"
+        ? Object.keys(result as Record<string, unknown>).filter(
+            (k) => (result as Record<string, unknown>)[k] !== undefined,
+          )
+        : [];
+
+    logCredentialAccess(auditConfig, {
+      worker_id: workerId,
+      credential_keys: distributedKeys,
+      run_id: context?.runId,
+      job_id: context?.jobId,
+      granted: true,
+      timestamp: new Date().toISOString(),
+    });
+
+    return result;
+  };
+}
+
+/**
+ * Query credential access history for a specific worker or time range.
+ * Useful for security audits and incident investigation.
+ */
+export function queryCredentialAccessLog(
+  db: DatabaseSync,
+  options: {
+    workerId?: string;
+    since?: string;
+    limit?: number;
+  } = {},
+): CredentialAccessEvent[] {
+  const conditions: string[] = [
+    "(action = 'credential.access' OR action = 'credential.denied')",
+  ];
+  const params: unknown[] = [];
+
+  if (options.workerId) {
+    conditions.push("actor_id = ?");
+    params.push(options.workerId);
+  }
+  if (options.since) {
+    conditions.push("created_at >= ?");
+    params.push(options.since);
+  }
+
+  const limit = options.limit ?? 100;
+  params.push(limit);
+
+  const sql = `
+    SELECT actor_id, action, target_id, payload_json, created_at
+    FROM audit_log
+    WHERE ${conditions.join(" AND ")}
+    ORDER BY created_at DESC
+    LIMIT ?
+  `;
+
+  const rows = db.prepare(sql).all(...params) as Array<{
+    actor_id: string;
+    action: string;
+    target_id: string;
+    payload_json: string;
+    created_at: string;
+  }>;
+
+  return rows.map((row) => {
+    const payload = JSON.parse(row.payload_json) as {
+      keys?: string[];
+      run_id?: string;
+      job_id?: string;
+      reason?: string;
+    };
+    return {
+      worker_id: row.actor_id,
+      credential_keys: payload.keys ?? row.target_id.split(","),
+      run_id: payload.run_id,
+      job_id: payload.job_id,
+      granted: row.action === "credential.access",
+      reason: payload.reason,
+      timestamp: row.created_at,
+    };
+  });
+}

--- a/packages/jarvis-shared/src/index.ts
+++ b/packages/jarvis-shared/src/index.ts
@@ -20,3 +20,4 @@ export * from "./crm.js";
 export * from "./web.js";
 export * from "./worker-executor.js";
 export * from "./schema-validator.js";
+export * from "./webhook-normalizer.js";

--- a/packages/jarvis-shared/src/webhook-normalizer.ts
+++ b/packages/jarvis-shared/src/webhook-normalizer.ts
@@ -1,0 +1,240 @@
+/**
+ * Transport-agnostic webhook normalization layer.
+ *
+ * This module owns the domain logic for interpreting incoming webhooks:
+ *   - Signature verification (HMAC-SHA256)
+ *   - GitHub event-to-agent mapping
+ *   - Payload normalization into a canonical shape
+ *   - Conversion to the parameters createCommand() expects
+ *
+ * It does NOT own WHERE webhooks arrive (Express, OpenClaw TaskFlow, etc.).
+ * That belongs to the ingress layer that calls these functions.
+ */
+
+import crypto from "node:crypto";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type WebhookSource = "github" | "generic" | "custom";
+
+export type NormalizedWebhookEvent = {
+  /** Origin system: 'github' | 'generic' | 'custom' */
+  source: WebhookSource;
+  /** GitHub event name or custom type identifier */
+  event_type: string;
+  /** Resolved target agent */
+  agent_id: string;
+  /** Normalized payload forwarded to the agent */
+  context: Record<string, unknown>;
+  /** Deduplication key (agent + trigger + time-bucket) */
+  idempotency_key: string;
+  /** ISO-8601 timestamp of ingestion */
+  received_at: string;
+  /** Whether the HMAC signature was verified */
+  signature_verified: boolean;
+};
+
+/**
+ * Shape returned by webhookEventToCommand() — matches the fields
+ * that createCommand() in @jarvis/runtime expects.
+ */
+export type WebhookCommandParams = {
+  agentId: string;
+  source: "webhook";
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+};
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Maps GitHub event names to the Jarvis agent that handles them.
+ * Exported so both the normalizer and tests can reference the canonical mapping.
+ */
+export const GITHUB_EVENT_TO_AGENT: Readonly<Record<string, string>> = {
+  push: "evidence-auditor",
+  pull_request: "contract-reviewer",
+  issues: "orchestrator",
+} as const;
+
+// ─── Signature Verification ─────────────────────────────────────────────────
+
+/**
+ * Verify an HMAC-SHA256 signature against a raw body.
+ *
+ * @param rawBody   - The exact bytes the sender signed (string or Buffer).
+ * @param signature - The signature header value, e.g. "sha256=<hex>".
+ * @param secret    - The shared secret used to compute the HMAC.
+ * @returns `true` when the signature is valid, `false` otherwise.
+ *
+ * Uses constant-time comparison (crypto.timingSafeEqual) and pads
+ * both buffers to equal length to avoid leaking length information.
+ */
+export function verifyWebhookSignature(
+  rawBody: string | Buffer,
+  signature: string,
+  secret: string,
+): boolean {
+  const hmac = crypto.createHmac("sha256", secret);
+  hmac.update(rawBody);
+  const expected = "sha256=" + hmac.digest("hex");
+
+  const sigBuf = Buffer.from(signature);
+  const expBuf = Buffer.from(expected);
+
+  // Pad both to the same length to prevent leaking length via timingSafeEqual
+  const maxLen = Math.max(sigBuf.length, expBuf.length);
+  const paddedSig = Buffer.alloc(maxLen);
+  const paddedExp = Buffer.alloc(maxLen);
+  sigBuf.copy(paddedSig);
+  expBuf.copy(paddedExp);
+
+  return (
+    sigBuf.length === expBuf.length &&
+    crypto.timingSafeEqual(paddedSig, paddedExp)
+  );
+}
+
+// ─── GitHub Normalizer ──────────────────────────────────────────────────────
+
+export type NormalizeGithubOpts = {
+  /** The X-GitHub-Event header value. */
+  event: string;
+  /** Parsed JSON body from the webhook. */
+  payload: Record<string, unknown>;
+  /** Whether the caller already verified the signature. */
+  signatureVerified: boolean;
+};
+
+/**
+ * Normalize a GitHub webhook into a NormalizedWebhookEvent.
+ *
+ * Returns `null` when the event type has no mapped agent (the caller
+ * should respond with a 200 "ignored" status rather than an error).
+ */
+export function normalizeGithubWebhook(
+  opts: NormalizeGithubOpts,
+): NormalizedWebhookEvent | null {
+  const agentId = GITHUB_EVENT_TO_AGENT[opts.event];
+  if (!agentId) return null;
+
+  const now = new Date().toISOString();
+
+  return {
+    source: "github",
+    event_type: opts.event,
+    agent_id: agentId,
+    context: {
+      github_event: opts.event,
+      action: opts.payload.action,
+      repository: (opts.payload.repository as Record<string, unknown>)
+        ?.full_name,
+      sender: (opts.payload.sender as Record<string, unknown>)?.login,
+      payload: opts.payload,
+    },
+    idempotency_key: `${agentId}:webhook:github:${opts.event}:${Math.floor(Date.now() / 10_000)}`,
+    received_at: now,
+    signature_verified: opts.signatureVerified,
+  };
+}
+
+// ─── Generic Normalizer ─────────────────────────────────────────────────────
+
+export type NormalizeGenericOpts = {
+  /** Parsed JSON body — must contain `agent_id` at the top level. */
+  payload: Record<string, unknown>;
+  /** Whether the caller already verified the signature. */
+  signatureVerified: boolean;
+};
+
+export type NormalizeGenericResult =
+  | { ok: true; event: NormalizedWebhookEvent }
+  | { ok: false; error: string };
+
+/**
+ * Normalize a generic webhook payload into a NormalizedWebhookEvent.
+ *
+ * Returns an error result when `agent_id` is missing or not a string.
+ */
+export function normalizeGenericWebhook(
+  opts: NormalizeGenericOpts,
+): NormalizeGenericResult {
+  const agentId = opts.payload.agent_id;
+  if (!agentId || typeof agentId !== "string") {
+    return { ok: false, error: "Missing or invalid agent_id field" };
+  }
+
+  const context = (opts.payload.context as Record<string, unknown>) ?? {};
+  const now = new Date().toISOString();
+
+  return {
+    ok: true,
+    event: {
+      source: "generic",
+      event_type: "generic",
+      agent_id: agentId,
+      context,
+      idempotency_key: `${agentId}:webhook:generic:${Math.floor(Date.now() / 10_000)}`,
+      received_at: now,
+      signature_verified: opts.signatureVerified,
+    },
+  };
+}
+
+// ─── Custom (per-agent) Normalizer ──────────────────────────────────────────
+
+export type NormalizeCustomOpts = {
+  /** Agent ID from the URL path parameter. */
+  agentId: string;
+  /** Parsed JSON body — forwarded as-is. */
+  payload: Record<string, unknown>;
+  /** Whether the caller already verified the signature. */
+  signatureVerified: boolean;
+};
+
+/**
+ * Normalize a custom per-agent webhook (POST /webhooks/:agentId).
+ */
+export function normalizeCustomWebhook(
+  opts: NormalizeCustomOpts,
+): NormalizedWebhookEvent {
+  const now = new Date().toISOString();
+
+  return {
+    source: "custom",
+    event_type: "custom",
+    agent_id: opts.agentId,
+    context: opts.payload,
+    idempotency_key: `${opts.agentId}:webhook:custom:${Math.floor(Date.now() / 10_000)}`,
+    received_at: now,
+    signature_verified: opts.signatureVerified,
+  };
+}
+
+// ─── Event -> Command Conversion ────────────────────────────────────────────
+
+/**
+ * Convert a NormalizedWebhookEvent to the parameters expected by
+ * createCommand() from @jarvis/runtime.
+ *
+ * The caller is responsible for obtaining a DatabaseSync handle and
+ * invoking createCommand(db, params).
+ */
+export function webhookEventToCommand(
+  event: NormalizedWebhookEvent,
+): WebhookCommandParams {
+  return {
+    agentId: event.agent_id,
+    source: "webhook",
+    payload: {
+      ...event.context,
+      _webhook: {
+        source: event.source,
+        event_type: event.event_type,
+        received_at: event.received_at,
+        signature_verified: event.signature_verified,
+      },
+    },
+    idempotencyKey: event.idempotency_key,
+  };
+}

--- a/packages/jarvis-telegram/package.json
+++ b/packages/jarvis-telegram/package.json
@@ -7,7 +7,8 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@jarvis/runtime": "file:../jarvis-runtime"
+    "@jarvis/runtime": "file:../jarvis-runtime",
+    "@jarvis/shared": "file:../jarvis-shared"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/packages/jarvis-telegram/src/deprecated-bot.ts
+++ b/packages/jarvis-telegram/src/deprecated-bot.ts
@@ -1,0 +1,38 @@
+/**
+ * @deprecated The standalone JarvisBot that talks directly to the Telegram API
+ * is deprecated. Use TelegramSessionAdapter from './session-adapter.js' instead,
+ * which routes all Telegram delivery through OpenClaw sessions.
+ *
+ * Set JARVIS_TELEGRAM_MODE=session to use the new path.
+ * This shim will be removed once the migration is complete.
+ */
+
+import { JarvisBot } from './bot.js'
+
+let deprecationWarned = false
+
+function emitDeprecationWarning(): void {
+  if (deprecationWarned) return
+  deprecationWarned = true
+  console.warn(
+    '[jarvis-telegram] DEPRECATION: JarvisBot (direct Telegram API mode) is deprecated. ' +
+    'Set JARVIS_TELEGRAM_MODE=session to use the OpenClaw session adapter instead. ' +
+    'Direct Telegram API access will be removed in a future release.'
+  )
+}
+
+/**
+ * @deprecated Use TelegramSessionAdapter instead.
+ *
+ * Re-exports the legacy JarvisBot class with a deprecation warning on first use.
+ * This ensures existing code that imports from this module continues to work
+ * during the transition period.
+ */
+export class DeprecatedJarvisBot extends JarvisBot {
+  constructor(config: ConstructorParameters<typeof JarvisBot>[0]) {
+    emitDeprecationWarning()
+    super(config)
+  }
+}
+
+export { JarvisBot }

--- a/packages/jarvis-telegram/src/index.ts
+++ b/packages/jarvis-telegram/src/index.ts
@@ -1,8 +1,112 @@
-import { loadConfig } from './config.js'
+import { loadConfig, openRuntimeDb } from './config.js'
 import { JarvisBot } from './bot.js'
+import { ChannelStore } from '@jarvis/runtime'
+import { TelegramSessionAdapter } from './session-adapter.js'
 import { processTelegramQueue } from './relay.js'
 
-async function main() {
+// ─── Exports ────────────────────────────────────────────────────────────────
+
+// Preferred: session-based adapter (OpenClaw-native)
+export { TelegramSessionAdapter, mapTelegramCommandToSession } from './session-adapter.js'
+export type { SessionAdapterConfig } from './session-adapter.js'
+
+// Legacy: direct Telegram API bot (deprecated, kept for compatibility)
+export { DeprecatedJarvisBot, JarvisBot } from './deprecated-bot.js'
+
+// Shared utilities
+export { processTelegramQueue } from './relay.js'
+export type { ApprovalEntry } from './approvals.js'
+export type { CommandContext } from './commands.js'
+
+// ─── Session mode startup ───────────────────────────────────────────────────
+
+/**
+ * Start the Telegram adapter in session mode.
+ * Messages are delivered via OpenClaw's session system rather than direct API calls.
+ * The OpenClaw gateway handles the actual Telegram bot integration.
+ */
+async function startSessionMode(): Promise<void> {
+  const sessionKey = process.env.JARVIS_TELEGRAM_SESSION_KEY ?? 'telegram:main'
+
+  console.log(`[jarvis-telegram] Starting in SESSION mode (key: ${sessionKey})`)
+  console.log('[jarvis-telegram] Messages will be delivered via OpenClaw gateway sessions.')
+
+  // Initialize channel store for message tracking (best-effort)
+  let channelStore: ChannelStore | undefined
+  let threadId: string | undefined
+  try {
+    const db = openRuntimeDb()
+    db.exec('PRAGMA foreign_keys = ON')
+    channelStore = new ChannelStore(db)
+    threadId = channelStore.getOrCreateThread('telegram', sessionKey, 'Telegram session')
+  } catch {
+    console.warn('[jarvis-telegram] Channel tracking unavailable -- continuing without it')
+  }
+
+  const adapter = new TelegramSessionAdapter({
+    sessionKey,
+    channelStore,
+    threadId,
+  })
+
+  // In session mode, the OpenClaw gateway drives inbound message delivery.
+  // This process only needs to:
+  // 1. Poll for pending approvals and send notifications via session
+  // 2. Process the relay queue for agent notifications
+
+  const approvalInterval = setInterval(async () => {
+    try {
+      await adapter.checkApprovals()
+    } catch (e) {
+      console.error('[jarvis-telegram] Approval check error:', e)
+    }
+  }, 15_000)
+
+  const relayInterval = setInterval(async () => {
+    try {
+      const sent = await processTelegramQueue(msg => adapter.send(msg), channelStore, threadId)
+      if (sent > 0) console.log(`[jarvis-telegram] Relayed ${sent} queued messages via session`)
+    } catch (e) {
+      console.error('[jarvis-telegram] Relay error:', e)
+    }
+  }, 30_000)
+
+  // Send startup notification via session
+  try {
+    await adapter.send('Jarvis Telegram adapter online (session mode). Send /help for commands.')
+  } catch (e) {
+    console.warn('[jarvis-telegram] Could not send startup message:', e)
+  }
+
+  // Graceful shutdown
+  process.on('SIGINT', () => {
+    clearInterval(approvalInterval)
+    clearInterval(relayInterval)
+    console.log('\n[jarvis-telegram] Session adapter stopped.')
+    process.exit(0)
+  })
+
+  // Keep the process alive
+  console.log('[jarvis-telegram] Session adapter running. Press Ctrl+C to stop.')
+  await new Promise<never>(() => {
+    // Block indefinitely -- intervals keep running
+  })
+}
+
+// ─── Legacy mode startup ────────────────────────────────────────────────────
+
+/**
+ * Start the Telegram bot in legacy mode (direct Telegram API).
+ * This is the original standalone bot behavior.
+ *
+ * @deprecated Use session mode (JARVIS_TELEGRAM_MODE=session) instead.
+ */
+async function startLegacyMode(): Promise<void> {
+  console.warn(
+    '[jarvis-telegram] Starting in LEGACY mode (direct Telegram API). ' +
+    'Set JARVIS_TELEGRAM_MODE=session to use the OpenClaw session adapter.'
+  )
+
   const config = loadConfig()
   if (!config) {
     console.error('No Telegram config found at ~/.jarvis/config.json')
@@ -13,8 +117,7 @@ async function main() {
   const bot = new JarvisBot(config.telegram)
 
   // Relay loop: check queue every 30s
-  let relayInterval: ReturnType<typeof setInterval>
-  relayInterval = setInterval(async () => {
+  const relayInterval = setInterval(async () => {
     try {
       const sent = await processTelegramQueue(msg => bot.send(msg))
       if (sent > 0) console.log(`Relayed ${sent} queued messages`)
@@ -34,8 +137,26 @@ async function main() {
   await bot.start()
 }
 
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const mode = (process.env.JARVIS_TELEGRAM_MODE ?? 'legacy').toLowerCase()
+
+  switch (mode) {
+    case 'session':
+      await startSessionMode()
+      break
+    case 'legacy':
+      await startLegacyMode()
+      break
+    default:
+      console.error(`Unknown JARVIS_TELEGRAM_MODE: "${mode}". Use "session" or "legacy".`)
+      process.exit(1)
+  }
+}
+
 // Only run when invoked directly
-const isMainModule = process.argv[1]?.endsWith('index.ts') || process.argv[1]?.endsWith('index.js');
+const isMainModule = process.argv[1]?.endsWith('index.ts') || process.argv[1]?.endsWith('index.js')
 if (isMainModule) {
   main().catch(console.error)
 }

--- a/packages/jarvis-telegram/src/session-adapter.ts
+++ b/packages/jarvis-telegram/src/session-adapter.ts
@@ -1,0 +1,432 @@
+import { randomUUID } from 'node:crypto'
+import { DatabaseSync } from 'node:sqlite'
+import {
+  sendSessionMessage,
+  type GatewayCallOptions,
+} from '@jarvis/shared'
+import { createCommand, ChannelStore } from '@jarvis/runtime'
+import type { ApprovalEntry } from './approvals.js'
+import { loadApprovals, resolveApproval, claimUnnotifiedPending, formatApprovalMessage } from './approvals.js'
+import { openRuntimeDb, CRM_DB } from './config.js'
+import { handleFreeText, type ChatContext } from './chat-handler.js'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Agents that can be triggered via slash commands. */
+const TRIGGER_AGENTS = [
+  'orchestrator', 'self-reflection', 'regulatory-watch', 'knowledge-curator',
+  'proposal-engine', 'evidence-auditor', 'contract-reviewer', 'staffing-monitor',
+] as const
+
+type TriggerAgentId = (typeof TRIGGER_AGENTS)[number]
+
+/** Map of Telegram slash commands to agent IDs. */
+const COMMAND_TO_AGENT: Record<string, TriggerAgentId> = {
+  '/orchestrator': 'orchestrator',
+  '/reflect': 'self-reflection',
+  '/regulatory': 'regulatory-watch',
+  '/knowledge': 'knowledge-curator',
+  '/proposal': 'proposal-engine',
+  '/evidence': 'evidence-auditor',
+  '/contract': 'contract-reviewer',
+  '/staffing': 'staffing-monitor',
+}
+
+type TelegramCommand =
+  | { kind: 'status' }
+  | { kind: 'crm' }
+  | { kind: 'approve'; shortId: string }
+  | { kind: 'reject'; shortId: string }
+  | { kind: 'help' }
+  | { kind: 'agent_trigger'; agentId: TriggerAgentId; rawText: string }
+  | { kind: 'free_text'; text: string }
+  | { kind: 'unknown'; command: string }
+
+export type SessionAdapterConfig = {
+  /** OpenClaw session key for the Telegram channel (e.g. "telegram:main"). */
+  sessionKey: string
+  /** Optional gateway connection overrides. Falls back to env vars. */
+  gatewayOverrides?: GatewayCallOptions
+  /** Optional channel store for message tracking. */
+  channelStore?: ChannelStore
+  /** Optional thread ID for channel message recording. */
+  threadId?: string
+}
+
+// ─── Command Parser ─────────────────────────────────────────────────────────
+
+/**
+ * Parse raw Telegram text into a structured command descriptor.
+ * This replaces the switch/case in commands.ts with a pure mapping function.
+ */
+export function mapTelegramCommandToSession(text: string): TelegramCommand {
+  const trimmed = text.trim()
+  const parts = trimmed.split(/\s+/)
+  const cmd = parts[0]?.toLowerCase() ?? ''
+  const arg = parts[1] ?? ''
+
+  if (!cmd.startsWith('/')) {
+    return { kind: 'free_text', text: trimmed }
+  }
+
+  switch (cmd) {
+    case '/status':
+      return { kind: 'status' }
+    case '/crm':
+      return { kind: 'crm' }
+    case '/approve':
+      return { kind: 'approve', shortId: arg }
+    case '/reject':
+      return { kind: 'reject', shortId: arg }
+    case '/help':
+      return { kind: 'help' }
+    default: {
+      const agentId = COMMAND_TO_AGENT[cmd]
+      if (agentId) {
+        return { kind: 'agent_trigger', agentId, rawText: trimmed }
+      }
+      return { kind: 'unknown', command: cmd }
+    }
+  }
+}
+
+// ─── Session Adapter ────────────────────────────────────────────────────────
+
+/**
+ * OpenClaw session-based adapter for Telegram delivery.
+ *
+ * Instead of calling `https://api.telegram.org/bot{token}/sendMessage` directly,
+ * this routes all outbound messages through `sendSessionMessage` from @jarvis/shared,
+ * which delivers via the OpenClaw gateway's `sessions.send` method.
+ *
+ * The OpenClaw gateway is responsible for the actual Telegram API integration.
+ * Jarvis only talks to OpenClaw sessions -- it never touches external APIs directly.
+ */
+export class TelegramSessionAdapter {
+  private readonly sessionKey: string
+  private readonly gatewayOverrides: GatewayCallOptions
+  private readonly channelStore: ChannelStore | undefined
+  private readonly threadId: string | undefined
+
+  constructor(config: SessionAdapterConfig) {
+    this.sessionKey = config.sessionKey
+    this.gatewayOverrides = config.gatewayOverrides ?? {}
+    this.channelStore = config.channelStore
+    this.threadId = config.threadId
+  }
+
+  // ─── Core send ──────────────────────────────────────────────────────
+
+  /**
+   * Send a text message via the OpenClaw session instead of direct Telegram API.
+   * Truncates to 4096 chars (Telegram limit) before sending.
+   */
+  async send(text: string): Promise<void> {
+    const truncated = text.slice(0, 4096)
+    const idempotencyKey = `tg-session-${randomUUID()}`
+
+    await sendSessionMessage(
+      {
+        sessionKey: this.sessionKey,
+        message: truncated,
+        idempotencyKey,
+      },
+      undefined, // no OpenClawConfig -- relies on env vars via resolveGatewayCallOptions
+      this.gatewayOverrides,
+    )
+
+    // Record outbound message in channel store (best-effort)
+    if (this.channelStore && this.threadId) {
+      try {
+        this.channelStore.recordMessage({
+          threadId: this.threadId,
+          channel: 'telegram',
+          direction: 'outbound',
+          contentPreview: truncated,
+          sender: 'jarvis',
+        })
+      } catch { /* best-effort */ }
+    }
+  }
+
+  // ─── Approval notifications ─────────────────────────────────────────
+
+  /**
+   * Send an approval notification via the session channel.
+   * Replaces the direct Telegram API call in JarvisBot.checkApprovals().
+   */
+  async notifyApproval(entry: ApprovalEntry): Promise<void> {
+    const message = formatApprovalMessage(entry)
+    await this.send(message)
+
+    // Record specifically as an approval notification
+    if (this.channelStore && this.threadId) {
+      try {
+        this.channelStore.recordMessage({
+          threadId: this.threadId,
+          channel: 'telegram',
+          direction: 'outbound',
+          contentPreview: `Approval needed: ${entry.action} by ${entry.agent}`,
+          sender: 'jarvis',
+          runId: entry.run_id,
+        })
+      } catch { /* best-effort */ }
+    }
+  }
+
+  /**
+   * Check for pending approvals and send notifications via session.
+   * Equivalent to JarvisBot.checkApprovals() but routed through OpenClaw.
+   */
+  async checkApprovals(): Promise<void> {
+    let db: DatabaseSync | undefined
+    try {
+      db = openRuntimeDb()
+    } catch {
+      return
+    }
+
+    try {
+      const claimed = claimUnnotifiedPending(db)
+      for (const entry of claimed) {
+        try {
+          await this.notifyApproval(entry)
+        } catch {
+          // Notification row already inserted by claimUnnotifiedPending,
+          // so this entry won't be re-sent. Send failure is acceptable
+          // since the approval still appears in the dashboard.
+        }
+      }
+    } finally {
+      try { db.close() } catch { /* ignore */ }
+    }
+  }
+
+  // ─── Command response delivery ──────────────────────────────────────
+
+  /**
+   * Deliver a command response via the session channel.
+   * The commandId is included for traceability in the channel store.
+   */
+  async deliverCommandResponse(commandId: string, response: string): Promise<void> {
+    await this.send(response)
+
+    if (this.channelStore && this.threadId) {
+      try {
+        this.channelStore.recordMessage({
+          threadId: this.threadId,
+          channel: 'telegram',
+          direction: 'outbound',
+          contentPreview: response,
+          sender: 'jarvis',
+          commandId,
+        })
+      } catch { /* best-effort */ }
+    }
+  }
+
+  // ─── Full command handling (via session) ─────────────────────────────
+
+  /**
+   * Handle a Telegram message by mapping it to a session command and
+   * delivering the response through the OpenClaw session.
+   *
+   * This is the session-mode equivalent of JarvisBot.pollOnce() processing.
+   */
+  async handleMessage(text: string, sender?: string): Promise<string> {
+    const command = mapTelegramCommandToSession(text)
+
+    switch (command.kind) {
+      case 'status':
+        return getStatusViaSession()
+
+      case 'crm':
+        return getCrmTop5ViaSession()
+
+      case 'approve':
+        return handleApprovalViaSession(command.shortId, 'approved', {
+          channelStore: this.channelStore,
+          threadId: this.threadId,
+          sender,
+        })
+
+      case 'reject':
+        return handleApprovalViaSession(command.shortId, 'rejected', {
+          channelStore: this.channelStore,
+          threadId: this.threadId,
+          sender,
+        })
+
+      case 'help':
+        return getHelpText()
+
+      case 'agent_trigger':
+        return triggerAgentViaSession(command.agentId, command.rawText, {
+          channelStore: this.channelStore,
+          threadId: this.threadId,
+          sender,
+        })
+
+      case 'free_text': {
+        const chatCtx: ChatContext = {
+          channelStore: this.channelStore,
+          threadId: this.threadId,
+        }
+        const { text: reply } = await handleFreeText(command.text, chatCtx)
+        return reply
+      }
+
+      case 'unknown':
+        return `Unknown command: ${command.command}\n\nSend /help for available commands.`
+    }
+  }
+}
+
+// ─── Session-mode query handlers ────────────────────────────────────────────
+//
+// These mirror the functions in commands.ts but are designed for the session
+// adapter path. They read from the same databases but deliver results via
+// the session channel rather than direct Telegram API.
+
+function getStatusViaSession(): string {
+  const agents = [
+    'orchestrator', 'self-reflection', 'regulatory-watch', 'knowledge-curator',
+    'proposal-engine', 'evidence-auditor', 'contract-reviewer', 'staffing-monitor',
+  ]
+  const lines = ['JARVIS STATUS\n']
+  let db: DatabaseSync | undefined
+
+  try {
+    db = openRuntimeDb()
+
+    for (const agentId of agents) {
+      const row = db.prepare(
+        'SELECT started_at, status FROM runs WHERE agent_id = ? ORDER BY started_at DESC LIMIT 1'
+      ).get(agentId) as { started_at: string; status: string } | undefined
+      const ts = row ? new Date(row.started_at).toLocaleDateString() : 'never'
+      const status = row?.status ?? ''
+      lines.push(`${agentId}: ${ts}${status ? ` (${status})` : ''}`)
+    }
+
+    const pending = loadApprovals(db, 'pending')
+    lines.push(`\nPending approvals: ${pending.length}`)
+  } catch {
+    lines.push('(could not read runtime.db)')
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+
+  return lines.join('\n')
+}
+
+function getCrmTop5ViaSession(): string {
+  let db: DatabaseSync | undefined
+  try {
+    db = new DatabaseSync(CRM_DB)
+    const contacts = db.prepare(
+      "SELECT name, company, stage, score FROM contacts WHERE stage NOT IN ('won','lost','parked') ORDER BY score DESC LIMIT 5"
+    ).all() as Array<{ name: string; company: string; stage: string; score: number }>
+
+    if (contacts.length === 0) return 'CRM: No active contacts.'
+    const lines = ['TOP CRM CONTACTS\n']
+    for (const c of contacts) {
+      lines.push(`${c.name} @ ${c.company} -- ${c.stage} (score: ${c.score})`)
+    }
+    return lines.join('\n')
+  } catch {
+    return 'CRM: Could not read database.'
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+}
+
+type SessionCommandContext = {
+  channelStore?: ChannelStore
+  threadId?: string
+  sender?: string
+}
+
+function triggerAgentViaSession(
+  agentId: string,
+  messageText: string,
+  ctx: SessionCommandContext,
+): string {
+  let db: DatabaseSync | undefined
+  try {
+    db = openRuntimeDb()
+    const { commandId } = createCommand(db, {
+      agentId,
+      source: 'telegram',
+      channelStore: ctx.channelStore,
+      threadId: ctx.threadId,
+      messagePreview: messageText,
+      sender: ctx.sender,
+    })
+    return `Triggered ${agentId} (${commandId.slice(0, 8)}). It will run within the next scheduled cycle.`
+  } catch (e) {
+    return `Failed to trigger ${agentId}: ${String(e)}`
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+}
+
+function handleApprovalViaSession(
+  shortId: string,
+  status: 'approved' | 'rejected',
+  ctx: SessionCommandContext,
+): string {
+  if (!shortId) return 'Usage: /approve <id> or /reject <id>'
+  if (shortId.length < 6) return 'Approval ID must be at least 6 characters for safety.'
+
+  let db: DatabaseSync | undefined
+  try {
+    db = openRuntimeDb()
+    const pending = loadApprovals(db, 'pending')
+    const target = pending.find(a => a.id.startsWith(shortId))
+    if (!target) return `No pending approval found with ID starting: ${shortId}`
+
+    const ok = resolveApproval(db, target.id, status)
+    if (!ok) return `Failed to ${status === 'approved' ? 'approve' : 'reject'} -- may already be resolved.`
+
+    // Record the approval action in the channel store
+    if (ctx.channelStore && ctx.threadId) {
+      try {
+        ctx.channelStore.recordMessage({
+          threadId: ctx.threadId,
+          channel: 'telegram',
+          direction: 'inbound',
+          contentPreview: `/${status === 'approved' ? 'approve' : 'reject'} ${shortId}`,
+          sender: ctx.sender,
+          runId: target.run_id,
+        })
+      } catch { /* best-effort */ }
+    }
+
+    const icon = status === 'approved' ? '[OK]' : '[REJECTED]'
+    return `${icon} ${target.action} by ${target.agent} has been ${status}.`
+  } catch (e) {
+    return `Failed to process approval: ${String(e)}`
+  } finally {
+    try { db?.close() } catch { /* ignore */ }
+  }
+}
+
+function getHelpText(): string {
+  return `JARVIS BOT COMMANDS
+
+/status        -- All agents last-run + pending approvals
+/crm           -- Top 5 active pipeline contacts
+/orchestrator  -- Trigger orchestrator
+/reflect       -- Trigger self-reflection
+/regulatory    -- Trigger regulatory watch
+/knowledge     -- Trigger knowledge curator
+/proposal      -- Trigger proposal engine
+/evidence      -- Trigger evidence auditor
+/contract      -- Trigger contract reviewer
+/staffing      -- Trigger staffing monitor
+/approve <id>  -- Approve a gated action
+/reject <id>   -- Reject a gated action
+/help          -- This message
+
+You can also send free-text messages and I'll understand what you need.`
+}

--- a/tests/architecture-boundary.test.ts
+++ b/tests/architecture-boundary.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Architecture Boundary Tests
+ *
+ * Enforces the platform/kernel boundary defined in ADR-PLATFORM-KERNEL-BOUNDARY.md.
+ * These tests fail the build if code introduces forbidden integration patterns that
+ * duplicate OpenClaw platform ownership.
+ *
+ * Four boundary rules:
+ * 1. Only OpenClaw talks to Telegram
+ * 2. Only OpenClaw owns external webhook ingress
+ * 3. Only OpenClaw owns the operator chat loop (LLM orchestration)
+ * 4. Only OpenClaw owns browser runtime
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..");
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+  reason: string;
+}
+
+function getSourceFiles(): string[] {
+  const result = execSync(
+    `git ls-files "packages/**/*.ts" "packages/**/*.mts" "scripts/**/*.ts" "scripts/**/*.mjs"`,
+    { cwd: ROOT, encoding: "utf8" }
+  );
+  return result.split("\n").filter(Boolean);
+}
+
+function readSource(relativePath: string): string {
+  const fullPath = resolve(ROOT, relativePath);
+  if (!existsSync(fullPath)) return "";
+  return readFileSync(fullPath, "utf8");
+}
+
+function scanForPattern(
+  files: string[],
+  pattern: RegExp,
+  reason: string,
+  exclude?: RegExp
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const file of files) {
+    if (exclude?.test(file)) continue;
+    const source = readSource(file);
+    const lines = source.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (pattern.test(lines[i])) {
+        const trimmed = lines[i].trim();
+        // Skip comments
+        if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
+        violations.push({ file, line: i + 1, text: trimmed, reason });
+      }
+    }
+  }
+  return violations;
+}
+
+function formatViolations(violations: Violation[]): string {
+  return violations
+    .map((v) => `  ${v.file}:${v.line} — ${v.reason}\n    ${v.text}`)
+    .join("\n");
+}
+
+// ─── Known Legacy Exclusions ─────────────────────────────────────────
+// These files ARE the duplication targets. They're excluded from boundary
+// checks because they are the files scheduled for replacement/removal.
+// Each exclusion references the convergence epic that will address it.
+
+const LEGACY_TELEGRAM = /packages[\\/]jarvis-telegram[\\/]/;               // Epic 3
+const LEGACY_GODMODE = /packages[\\/]jarvis-dashboard[\\/]src[\\/]api[\\/](godmode|chat)\.(ts|mts)$/; // Epic 5
+const LEGACY_WEBHOOKS = /packages[\\/]jarvis-dashboard[\\/]src[\\/]api[\\/]webhooks\.(ts|mts)$/;      // Epic 4
+const LEGACY_BROWSER_WORKER = /packages[\\/]jarvis-browser-worker[\\/]/;   // Epic 6
+
+const ALL_LEGACY = new RegExp(
+  [
+    LEGACY_TELEGRAM.source,
+    LEGACY_GODMODE.source,
+    LEGACY_WEBHOOKS.source,
+    LEGACY_BROWSER_WORKER.source,
+  ].join("|")
+);
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+const allFiles = getSourceFiles();
+
+describe("Architecture Boundary: Platform/Kernel Split", () => {
+  describe("Rule 1: Only OpenClaw talks to Telegram", () => {
+    it("no api.telegram.org URL in non-legacy source", () => {
+      const violations = scanForPattern(
+        allFiles,
+        /api\.telegram\.org/,
+        "Direct Telegram API URL (ADR rule 1: only OpenClaw talks to Telegram)",
+        ALL_LEGACY
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+
+    it("no node-telegram-bot-api import in non-legacy source", () => {
+      const violations = scanForPattern(
+        allFiles,
+        /from\s+["']node-telegram-bot-api["']|require\(["']node-telegram-bot-api["']\)/,
+        "Telegram SDK import (ADR rule 1: only OpenClaw talks to Telegram)",
+        ALL_LEGACY
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+
+    it("no TelegramBot constructor in non-legacy source", () => {
+      const violations = scanForPattern(
+        allFiles,
+        /new\s+TelegramBot\s*\(/,
+        "TelegramBot instantiation (ADR rule 1: only OpenClaw talks to Telegram)",
+        ALL_LEGACY
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+  });
+
+  describe("Rule 2: Only OpenClaw owns external webhook ingress", () => {
+    it("no new webhook Express routes with direct DB insertion outside legacy", () => {
+      const violations = scanForPattern(
+        allFiles,
+        /router\.(post|put)\s*\(\s*["'][^"']*webhook/i,
+        "Webhook route definition (ADR rule 2: external ingress via OpenClaw)",
+        ALL_LEGACY
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+  });
+
+  describe("Rule 3: Only OpenClaw owns the operator chat loop", () => {
+    it("no direct LM Studio chat/completions URL outside inference packages", () => {
+      const exclude = new RegExp(
+        [
+          ALL_LEGACY.source,
+          /packages[\\/]jarvis-inference[\\/]/.source,
+          /packages[\\/]jarvis-inference-worker[\\/]/.source,
+        ].join("|")
+      );
+      const violations = scanForPattern(
+        allFiles,
+        /localhost:1234\/v1\/chat\/completions/,
+        "Direct model API URL outside inference layer (ADR rule 3: operator chat via OpenClaw sessions)",
+        exclude
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+  });
+
+  describe("Rule 4: Only OpenClaw owns browser runtime", () => {
+    it("no puppeteer connect/launch in non-legacy source", () => {
+      const violations = scanForPattern(
+        allFiles,
+        /puppeteer\.(connect|launch)\s*\(/,
+        "Direct Puppeteer connect/launch (ADR rule 4: browser runtime via OpenClaw)",
+        ALL_LEGACY
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+
+    it("no direct CDP WebSocket URL in non-legacy source", () => {
+      const violations = scanForPattern(
+        allFiles,
+        /ws:\/\/(127\.0\.0\.1|localhost):9222/,
+        "Direct CDP WebSocket URL (ADR rule 4: browser runtime via OpenClaw)",
+        ALL_LEGACY
+      );
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
+  });
+
+  describe("ADR documentation completeness", () => {
+    it("ADR-PLATFORM-KERNEL-BOUNDARY.md exists", () => {
+      const adrPath = resolve(ROOT, "docs/ADR-PLATFORM-KERNEL-BOUNDARY.md");
+      expect(existsSync(adrPath)).toBe(true);
+    });
+
+    it("ADR documents the migration map with all four statuses", () => {
+      const content = readFileSync(resolve(ROOT, "docs/ADR-PLATFORM-KERNEL-BOUNDARY.md"), "utf8");
+      expect(content).toContain("Package Migration Map");
+      expect(content).toContain("Core (keep and harden)");
+      expect(content).toContain("Adapter (wrap then replace)");
+      expect(content).toContain("Deprecated (replace then delete)");
+    });
+  });
+
+  describe("Legacy inventory (convergence tracker)", () => {
+    const LEGACY_TARGETS = [
+      { path: "packages/jarvis-telegram/src/index.ts", epic: "Epic 3: Channel Convergence", rule: 1 },
+      { path: "packages/jarvis-dashboard/src/api/webhooks.ts", epic: "Epic 4: Webhook Convergence", rule: 2 },
+      { path: "packages/jarvis-dashboard/src/api/godmode.ts", epic: "Epic 5: Godmode Unification", rule: 3 },
+      { path: "packages/jarvis-dashboard/src/api/chat.ts", epic: "Epic 5: Chat Convergence", rule: 3 },
+    ];
+
+    it("tracks remaining legacy duplication files", () => {
+      const remaining = LEGACY_TARGETS.filter((t) => existsSync(resolve(ROOT, t.path)));
+
+      // Informational — logs which legacy files still exist
+      if (remaining.length > 0) {
+        console.log(`\n  Legacy duplication: ${remaining.length}/${LEGACY_TARGETS.length} files remain`);
+        for (const r of remaining) {
+          console.log(`    [Rule ${r.rule}] ${r.path} — ${r.epic}`);
+        }
+      }
+
+      // This assertion will become expect(0) once convergence is complete
+      expect(remaining.length).toBeLessThanOrEqual(LEGACY_TARGETS.length);
+    });
+  });
+});

--- a/tests/credential-audit.test.ts
+++ b/tests/credential-audit.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Credential Access Audit Tests
+ *
+ * Verifies that credential distribution is auditable (Epic 10).
+ * Closes the trust gap: "getCredentialsForWorker() is not recorded in the audit log."
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import {
+  logCredentialAccess,
+  createAuditedCredentialAccessor,
+  queryCredentialAccessLog,
+  type CredentialAuditConfig,
+  type CredentialAccessEvent,
+} from "@jarvis/security/credential-audit";
+
+function createTestDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE audit_log (
+      audit_id TEXT PRIMARY KEY,
+      actor_type TEXT NOT NULL,
+      actor_id TEXT NOT NULL,
+      action TEXT NOT NULL,
+      target_type TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      payload_json TEXT,
+      created_at TEXT NOT NULL
+    )
+  `);
+  return db;
+}
+
+describe("Credential Access Audit", () => {
+  let db: DatabaseSync;
+  let auditConfig: CredentialAuditConfig;
+
+  beforeEach(() => {
+    db = createTestDb();
+    auditConfig = { db, enabled: true };
+  });
+
+  describe("logCredentialAccess", () => {
+    it("records a credential access event in audit_log", () => {
+      logCredentialAccess(auditConfig, {
+        worker_id: "email",
+        credential_keys: ["gmail"],
+        run_id: "run-123",
+        job_id: "job-456",
+        granted: true,
+        timestamp: "2026-04-08T12:00:00Z",
+      });
+
+      const rows = db.prepare("SELECT * FROM audit_log").all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.actor_type).toBe("worker");
+      expect(rows[0]!.actor_id).toBe("email");
+      expect(rows[0]!.action).toBe("credential.access");
+      expect(rows[0]!.target_type).toBe("credential");
+      expect(rows[0]!.target_id).toBe("gmail");
+    });
+
+    it("records denied access attempts", () => {
+      logCredentialAccess(auditConfig, {
+        worker_id: "inference",
+        credential_keys: [],
+        granted: false,
+        reason: "No credentials configured for worker",
+        timestamp: "2026-04-08T12:00:00Z",
+      });
+
+      const rows = db.prepare("SELECT * FROM audit_log").all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.action).toBe("credential.denied");
+    });
+
+    it("does nothing when audit is disabled", () => {
+      const disabledConfig: CredentialAuditConfig = { db, enabled: false };
+      logCredentialAccess(disabledConfig, {
+        worker_id: "email",
+        credential_keys: ["gmail"],
+        granted: true,
+        timestamp: "2026-04-08T12:00:00Z",
+      });
+
+      const rows = db.prepare("SELECT * FROM audit_log").all();
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe("createAuditedCredentialAccessor", () => {
+    it("wraps an accessor and logs the distributed keys", () => {
+      const mockAccessor = (workerId: string, _config: unknown) => {
+        if (workerId === "email") return { gmail: { token: "t" } };
+        return {};
+      };
+
+      const audited = createAuditedCredentialAccessor(auditConfig, mockAccessor);
+      const result = audited("email", {}, { runId: "run-1", jobId: "job-1" });
+
+      expect(result).toEqual({ gmail: { token: "t" } });
+
+      const rows = db.prepare("SELECT * FROM audit_log").all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+
+      const payload = JSON.parse(rows[0]!.payload_json as string) as Record<string, unknown>;
+      expect(payload.keys).toEqual(["gmail"]);
+      expect(payload.run_id).toBe("run-1");
+      expect(payload.job_id).toBe("job-1");
+    });
+
+    it("logs empty key set for workers with no credentials", () => {
+      const mockAccessor = () => ({});
+      const audited = createAuditedCredentialAccessor(auditConfig, mockAccessor);
+      audited("inference", {});
+
+      const rows = db.prepare("SELECT * FROM audit_log").all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+
+      const payload = JSON.parse(rows[0]!.payload_json as string) as Record<string, unknown>;
+      expect(payload.keys).toEqual([]);
+    });
+  });
+
+  describe("queryCredentialAccessLog", () => {
+    beforeEach(() => {
+      // Seed some audit entries
+      for (const entry of [
+        { worker: "email", keys: ["gmail"], time: "2026-04-08T10:00:00Z" },
+        { worker: "browser", keys: ["chrome"], time: "2026-04-08T11:00:00Z" },
+        { worker: "email", keys: ["gmail"], time: "2026-04-08T12:00:00Z" },
+      ]) {
+        logCredentialAccess(auditConfig, {
+          worker_id: entry.worker,
+          credential_keys: entry.keys,
+          granted: true,
+          timestamp: entry.time,
+        });
+      }
+    });
+
+    it("returns all entries by default", () => {
+      const entries = queryCredentialAccessLog(db);
+      expect(entries).toHaveLength(3);
+    });
+
+    it("filters by worker_id", () => {
+      const entries = queryCredentialAccessLog(db, { workerId: "email" });
+      expect(entries).toHaveLength(2);
+      expect(entries.every((e) => e.worker_id === "email")).toBe(true);
+    });
+
+    it("filters by since timestamp", () => {
+      const entries = queryCredentialAccessLog(db, {
+        since: "2026-04-08T11:00:00Z",
+      });
+      expect(entries).toHaveLength(2);
+    });
+
+    it("respects limit", () => {
+      const entries = queryCredentialAccessLog(db, { limit: 1 });
+      expect(entries).toHaveLength(1);
+    });
+  });
+});

--- a/tests/hook-catalog.test.ts
+++ b/tests/hook-catalog.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Hook Catalog Tests
+ *
+ * Verifies the expanded hook infrastructure (Epic 8).
+ * Tests each hook's behavior independently and the catalog completeness.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createBuiltInApprovalHook,
+  createDomainApprovalHook,
+  createCapabilityBoundaryHook,
+  createProvenanceHook,
+  createReplyGuardrailHook,
+  createErrorPolicyHook,
+  getHookCatalog,
+  type ToolCallEvent,
+  type ToolResultEvent,
+  type ReplyEvent,
+  type ErrorEvent,
+} from "@jarvis/core/hooks";
+
+describe("Hook Catalog", () => {
+  describe("catalog completeness", () => {
+    it("returns all six hooks", () => {
+      const catalog = getHookCatalog();
+      expect(catalog).toHaveLength(6);
+    });
+
+    it("covers all four hook points", () => {
+      const catalog = getHookCatalog();
+      const hookPoints = new Set(catalog.map((h) => h.hookPoint));
+      expect(hookPoints).toContain("before_tool_call");
+      expect(hookPoints).toContain("after_tool_call");
+      expect(hookPoints).toContain("before_reply");
+      expect(hookPoints).toContain("on_error");
+    });
+
+    it("every hook has a description", () => {
+      const catalog = getHookCatalog();
+      for (const hook of catalog) {
+        expect(hook.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("built-in approval hook", () => {
+    const hook = createBuiltInApprovalHook();
+
+    it("gates exec with critical severity", () => {
+      const result = hook.handler({ toolName: "exec" });
+      expect(result?.requireApproval.severity).toBe("critical");
+    });
+
+    it("gates browser with warning severity", () => {
+      const result = hook.handler({ toolName: "browser" });
+      expect(result?.requireApproval.severity).toBe("warning");
+    });
+
+    it("passes read-only tools", () => {
+      const result = hook.handler({ toolName: "jarvis_plan" });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("domain approval hook", () => {
+    const hook = createDomainApprovalHook();
+
+    it("gates email_send with critical severity", () => {
+      const result = hook.handler({ toolName: "email_send" });
+      expect(result?.requireApproval.severity).toBe("critical");
+    });
+
+    it("gates crm_move_stage with warning severity", () => {
+      const result = hook.handler({ toolName: "crm_move_stage" });
+      expect(result?.requireApproval.severity).toBe("warning");
+    });
+
+    it("passes non-mutating tools", () => {
+      const result = hook.handler({ toolName: "email_search" });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("capability boundary hook", () => {
+    const hook = createCapabilityBoundaryHook();
+
+    it("allows read-only tools in read-only context", () => {
+      const result = hook.handler({
+        toolName: "email_search",
+        context: { readOnly: true },
+      } as ToolCallEvent & { context?: { readOnly?: boolean } });
+      expect(result).toBeUndefined();
+    });
+
+    it("denies mutating tools in read-only context", () => {
+      const result = hook.handler({
+        toolName: "email_send",
+        context: { readOnly: true },
+      } as ToolCallEvent & { context?: { readOnly?: boolean } });
+      expect(result).toHaveProperty("deny");
+    });
+
+    it("allows all tools when not in read-only context", () => {
+      const result = hook.handler({ toolName: "email_send" });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("provenance hook", () => {
+    const hook = createProvenanceHook();
+
+    it("records tool execution provenance", () => {
+      const result = hook.handler({
+        toolName: "email_search",
+        toolCallId: "tc-123",
+        durationMs: 450,
+      });
+      expect(result?.provenance).toBeDefined();
+      expect(result?.provenance.tool_name).toBe("email_search");
+      expect(result?.provenance.duration_ms).toBe(450);
+      expect(result?.provenance.timestamp).toBeDefined();
+    });
+  });
+
+  describe("reply guardrail hook", () => {
+    const hook = createReplyGuardrailHook();
+
+    it("redacts API keys from replies", () => {
+      const result = hook.handler({
+        content: "Here is your key: sk-abcdefghijklmnopqrstuvwx",
+      });
+      expect(result?.modifiedContent).toContain("[REDACTED]");
+      expect(result?.modifiedContent).not.toContain("sk-");
+    });
+
+    it("redacts GitHub tokens from replies", () => {
+      const result = hook.handler({
+        content: "Token: ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+      });
+      expect(result?.modifiedContent).toContain("[REDACTED]");
+    });
+
+    it("passes clean replies", () => {
+      const result = hook.handler({
+        content: "The proposal is ready for review.",
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("error policy hook", () => {
+    const hook = createErrorPolicyHook();
+
+    it("retries connection refused errors", () => {
+      const result = hook.handler({
+        error: new Error("ECONNREFUSED: connection refused"),
+        retryCount: 0,
+      });
+      expect(result?.action).toBe("retry");
+      expect(result?.backoffMs).toBe(1000);
+    });
+
+    it("escalates after max retries", () => {
+      const result = hook.handler({
+        error: new Error("ECONNREFUSED: connection refused"),
+        retryCount: 3,
+      });
+      expect(result?.action).toBe("escalate");
+    });
+
+    it("escalates non-retryable errors immediately", () => {
+      const result = hook.handler({
+        error: new Error("INVALID_INPUT: bad payload"),
+        retryCount: 0,
+      });
+      expect(result?.action).toBe("escalate");
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@jarvis/shared": `${rootDir}packages/jarvis-shared/src/index.ts`,
+      "@jarvis/core/hooks": `${rootDir}packages/jarvis-core/src/hooks.ts`,
       "@jarvis/core": `${rootDir}packages/jarvis-core/src/index.ts`,
       "@jarvis/jobs": `${rootDir}packages/jarvis-jobs/src/index.ts`,
       "@jarvis/dispatch": `${rootDir}packages/jarvis-dispatch/src/index.ts`,
@@ -25,6 +26,7 @@ export default defineConfig({
       "@jarvis/voice-worker": `${rootDir}packages/jarvis-voice-worker/src/index.ts`,
       "@jarvis/interpreter": `${rootDir}packages/jarvis-interpreter/src/index.ts`,
       "@jarvis/interpreter-worker": `${rootDir}packages/jarvis-interpreter-worker/src/index.ts`,
+      "@jarvis/security/credential-audit": `${rootDir}packages/jarvis-security/src/credential-audit.ts`,
       "@jarvis/security": `${rootDir}packages/jarvis-security/src/index.ts`,
       "@jarvis/security-worker": `${rootDir}packages/jarvis-security-worker/src/index.ts`,
       "@jarvis/agent-framework": `${rootDir}packages/jarvis-agent-framework/src/index.ts`,


### PR DESCRIPTION
## Summary

Establishes the architectural foundation for making OpenClaw the operating substrate while keeping Jarvis as the domain kernel. Implements the first wave of all 12 convergence epics:

- **ADR + CI enforcement**: Platform/kernel boundary codified with 10 architecture tests that fail the build on forbidden patterns (direct Telegram API, direct LM Studio loops, direct Puppeteer, direct webhook DB writes)
- **4 convergence adapters**: Session-backed replacements for Telegram, webhooks, godmode, and browser — each with legacy compatibility mode
- **Expanded hook catalog**: 6 hooks across 4 hook points (approval gating, capability boundaries, provenance, reply guardrails, error policy)
- **Credential audit**: Closes the documented trust gap for unaudited credential distribution
- **3 ADRs + 3 reference docs**: Memory taxonomy, automation classification, compatibility matrix, convergence roadmap

## Key files

| Epic | File | Purpose |
|---|---|---|
| 1 | `docs/ADR-PLATFORM-KERNEL-BOUNDARY.md` | Authoritative ownership split |
| 1 | `tests/architecture-boundary.test.ts` | CI enforcement (10 tests) |
| 3 | `packages/jarvis-telegram/src/session-adapter.ts` | OpenClaw session-backed Telegram |
| 4 | `packages/jarvis-shared/src/webhook-normalizer.ts` | Transport-agnostic webhook normalization |
| 5 | `packages/jarvis-dashboard/src/api/session-chat-adapter.ts` | Session-backed operator chat |
| 6 | `packages/jarvis-browser/src/openclaw-bridge.ts` | BrowserBridge interface + factory |
| 8 | `packages/jarvis-core/src/hooks.ts` | Expanded hook catalog (6 hooks) |
| 10 | `packages/jarvis-security/src/credential-audit.ts` | Credential access audit |

## Test plan

- [x] 38 new tests passing (architecture boundary, hook catalog, credential audit)
- [x] 1202 existing tests still passing
- [x] Zero regressions — 28 pre-existing smoke failures (missing @opentelemetry dep) unrelated
- [x] All convergence adapters default to `legacy` mode — no behavioral change until explicitly switched
- [ ] Verify CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)