### PR TITLE
Wave 2: Wire convergence adapters into runtime

### DIFF
--- a/docs/KNOWN-TRUST-GAPS.md
+++ b/docs/KNOWN-TRUST-GAPS.md
@@ -24,9 +24,7 @@ The Telegram bot stores conversation context in process memory, shared across al
 
 ## No Credential Access Audit Log
 
-**Status: Partially mitigated** — `packages/jarvis-security/src/credential-audit.ts` provides an audited wrapper around `getCredentialsForWorker()` that logs every credential distribution to the `audit_log` table. The wrapper (`createAuditedCredentialAccessor`) records worker ID, distributed credential keys, associated run/job IDs, and timestamps. Query function `queryCredentialAccessLog()` enables retrospective investigation.
-
-**Remaining gap:** The daemon must adopt the audited accessor (replace direct `getCredentialsForWorker` calls with the wrapped version). Until then, credential reads are logged only in code paths that explicitly use the wrapper.
+**Status: Mitigated** — `packages/jarvis-security/src/credential-audit.ts` provides structured audit logging via `logCredentialAccess()`. The worker registry (`packages/jarvis-runtime/src/worker-registry.ts`) now imports and uses this module at every credential distribution point (email/gmail, calendar, browser/chrome, time/toggl, drive). Each credential access is logged to the `audit_log` table with worker ID, credential keys, and timestamps. Query function `queryCredentialAccessLog()` enables retrospective investigation.
 
 ## No Database Integrity Verification
 

--- a/packages/jarvis-core/src/hooks.ts
+++ b/packages/jarvis-core/src/hooks.ts
@@ -61,7 +61,8 @@ export type ErrorEvent = {
 
 export type HookRegistration = {
   hookPoint: string;
-  handler: (...args: unknown[]) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic container for heterogeneous hook signatures
+  handler: (...args: any[]) => any;
   priority: number;
   description: string;
 };

--- a/packages/jarvis-core/src/index.ts
+++ b/packages/jarvis-core/src/index.ts
@@ -6,7 +6,6 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import {
-  BUILT_IN_TOOLS_REQUIRING_HOOK_APPROVAL,
   CORE_COMMAND_NAMES,
   CORE_TOOL_NAMES,
   CONTRACT_VERSION,
@@ -17,6 +16,7 @@ import {
   toToolResult,
   type JarvisJobType
 } from "@jarvis/shared";
+import { createBuiltInApprovalHook, getHookCatalog } from "./hooks.js";
 
 const JOB_TYPE_LITERALS = JOB_TYPE_NAMES.map((jobType) =>
   Type.Literal(jobType),
@@ -200,26 +200,18 @@ export function createApprovalCommand() {
   };
 }
 
+/**
+ * Backward-compatible wrapper: returns the bare handler function
+ * from the built-in approval hook in the centralized catalog.
+ */
 export function createJarvisApprovalHook() {
-  return (event: { toolName: string }) => {
-    if (!BUILT_IN_TOOLS_REQUIRING_HOOK_APPROVAL.has(event.toolName)) {
-      return;
-    }
-
-    return {
-      requireApproval: {
-        title: `Approve ${event.toolName}`,
-        description: `Jarvis requires operator approval before using ${event.toolName}.`,
-        severity: event.toolName === "exec" ? ("critical" as const) : ("warning" as const),
-        timeoutMs: 300000,
-        timeoutBehavior: "deny" as const
-      }
-    };
-  };
+  return createBuiltInApprovalHook().handler;
 }
 
 export const jarvisCoreCommandNames = [...CORE_COMMAND_NAMES];
 export const jarvisCoreToolNames = [...CORE_TOOL_NAMES];
+
+export { getHookCatalog };
 
 export default definePluginEntry({
   id: "jarvis-core",
@@ -228,8 +220,21 @@ export default definePluginEntry({
   register(api) {
     api.registerTool((ctx) => createJarvisCoreTools(ctx));
     api.registerCommand(createApprovalCommand());
-    api.on("before_tool_call", createJarvisApprovalHook(), {
-      priority: 0
-    });
+
+    // ── Register before_tool_call hooks from the catalog ───────────
+    // Only before_tool_call is supported by the current OpenClaw SDK.
+    // The catalog also defines after_tool_call, before_reply, and
+    // on_error hooks — those will be registered once OpenClaw exposes
+    // those hook points (see Epic 8 convergence roadmap).
+    for (const hook of getHookCatalog()) {
+      if (hook.hookPoint === "before_tool_call") {
+        api.on("before_tool_call", hook.handler, { priority: hook.priority });
+      }
+    }
+
+    // Future hook points (defined in ./hooks.ts, ready for Epic 8):
+    //   after_tool_call  — createProvenanceHook(): audit trail enrichment
+    //   before_reply     — createReplyGuardrailHook(): PII/credential redaction
+    //   on_error         — createErrorPolicyHook(): retry/escalation decisions
   }
 });

--- a/packages/jarvis-dashboard/src/api/webhooks.ts
+++ b/packages/jarvis-dashboard/src/api/webhooks.ts
@@ -1,19 +1,20 @@
 import { Router } from 'express'
-import crypto from 'node:crypto'
 import { randomUUID } from 'node:crypto'
 import { DatabaseSync } from 'node:sqlite'
 import os from 'node:os'
 import fs from 'node:fs'
 import { join } from 'node:path'
 import { createCommand } from '@jarvis/runtime'
+import {
+  verifyWebhookSignature,
+  normalizeGithubWebhook,
+  normalizeGenericWebhook,
+  normalizeCustomWebhook,
+  webhookEventToCommand,
+} from '@jarvis/shared'
+import type { NormalizedWebhookEvent, WebhookCommandParams } from '@jarvis/shared'
 
 const JARVIS_DIR = join(os.homedir(), '.jarvis')
-
-const GITHUB_EVENT_TO_AGENT: Record<string, string> = {
-  push: 'evidence-auditor',
-  pull_request: 'contract-reviewer',
-  issues: 'orchestrator',
-}
 
 function loadWebhookSecret(): string | undefined {
   const configPath = join(JARVIS_DIR, 'config.json')
@@ -34,32 +35,36 @@ function getDb(): DatabaseSync {
 }
 
 /**
- * Insert a command into agent_commands table via the centralized command factory.
- * Also writes an audit log entry for webhook triggers.
+ * Issue a command via createCommand() and write an audit log entry.
+ * Accepts the pre-built params from webhookEventToCommand() plus
+ * a triggeredBy label for the audit row.
  */
-function insertCommand(agentId: string, triggeredBy: string, context: Record<string, unknown>): string {
+function issueCommandAndAudit(params: WebhookCommandParams, triggeredBy: string): string {
   const db = getDb()
-  // Use agent_id + timestamp as idempotency key to prevent rapid duplicate triggers
-  const idempotencyKey = `${agentId}:${triggeredBy}:${Math.floor(Date.now() / 10_000)}`
 
   try {
-    const { commandId } = createCommand(db, {
-      agentId,
-      source: 'webhook',
-      payload: context,
-      idempotencyKey,
-    })
+    const { commandId } = createCommand(db, params)
 
-    // Write audit log entry
+    // Write audit log entry — this is domain logic that stays in the ingress layer
     db.prepare(`
       INSERT INTO audit_log (audit_id, actor_type, actor_id, action, target_type, target_id, payload_json, created_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(randomUUID(), 'webhook', triggeredBy, 'trigger.created', 'agent', agentId, JSON.stringify(context), new Date().toISOString())
+    `).run(randomUUID(), 'webhook', triggeredBy, 'trigger.created', 'agent', params.agentId, JSON.stringify(params.payload), new Date().toISOString())
 
     return commandId
   } finally {
     try { db.close() } catch { /* best-effort */ }
   }
+}
+
+/**
+ * Get the raw body string from a request, falling back to JSON.stringify
+ * when the rawBody middleware is not configured.
+ */
+function getRawBody(req: import('express').Request): string {
+  return typeof (req as any).rawBody === "string"
+    ? (req as any).rawBody
+    : JSON.stringify(req.body)
 }
 
 export const webhookRouter = Router()
@@ -69,31 +74,15 @@ webhookRouter.post('/github', (req, res) => {
   const signature = req.headers['x-hub-signature-256'] as string | undefined
   const secret = loadWebhookSecret()
 
+  // --- Signature verification via shared normalizer ---
+  let signatureVerified = false
   if (secret && signature) {
-    // Use the raw request body bytes for HMAC, not re-serialized JSON.
-    // Providers sign the exact payload — JSON.stringify(req.body) can
-    // differ in whitespace/key ordering and fail verification.
-    const rawBody = typeof (req as any).rawBody === "string"
-      ? (req as any).rawBody
-      : JSON.stringify(req.body); // fallback if rawBody middleware not configured
-    const hmac = crypto.createHmac('sha256', secret)
-    hmac.update(rawBody)
-    const expected = 'sha256=' + hmac.digest('hex')
-
-    const sigBuf = Buffer.from(signature)
-    const expBuf = Buffer.from(expected)
-    // Pad both buffers to the same length to avoid leaking length information
-    const maxLen = Math.max(sigBuf.length, expBuf.length)
-    const paddedSig = Buffer.alloc(maxLen)
-    const paddedExp = Buffer.alloc(maxLen)
-    sigBuf.copy(paddedSig)
-    expBuf.copy(paddedExp)
-
-    if (sigBuf.length !== expBuf.length ||
-        !crypto.timingSafeEqual(paddedSig, paddedExp)) {
+    const rawBody = getRawBody(req)
+    if (!verifyWebhookSignature(rawBody, signature, secret)) {
       res.status(401).json({ error: 'Invalid signature' })
       return
     }
+    signatureVerified = true
   } else if (secret && !signature) {
     res.status(401).json({ error: 'Missing signature' })
     return
@@ -107,95 +96,90 @@ webhookRouter.post('/github', (req, res) => {
     return
   }
 
-  const agentId = GITHUB_EVENT_TO_AGENT[event]
-  if (!agentId) {
+  // --- Normalize via shared normalizer ---
+  const normalized = normalizeGithubWebhook({ event, payload, signatureVerified })
+  if (!normalized) {
     res.json({ status: 'ignored', event, message: `No agent mapped for event: ${event}` })
     return
   }
 
-  insertCommand(agentId, `webhook:github:${event}`, {
-    github_event: event,
-    action: payload.action,
-    repository: (payload.repository as Record<string, unknown>)?.full_name,
-    sender: (payload.sender as Record<string, unknown>)?.login,
-    payload,
-  })
+  const cmdParams = webhookEventToCommand(normalized)
+  issueCommandAndAudit(cmdParams, `webhook:github:${event}`)
 
   res.json({
     status: 'triggered',
-    agentId,
+    agentId: normalized.agent_id,
     event,
-    triggeredAt: new Date().toISOString(),
+    triggeredAt: normalized.received_at,
   })
 })
-
-/**
- * Validate HMAC signature for non-GitHub webhooks when webhook_secret is configured.
- * Expects X-Jarvis-Signature header with format: sha256=<hex>
- */
-function validateHmac(req: import('express').Request, secret: string | undefined): boolean {
-  if (!secret) return true; // no secret configured, skip validation
-
-  const signature = req.headers['x-jarvis-signature'] as string | undefined
-  if (!signature) return false
-
-  const hmac = crypto.createHmac('sha256', secret)
-  hmac.update(JSON.stringify(req.body))
-  const expected = 'sha256=' + hmac.digest('hex')
-
-  const sigBuf = Buffer.from(signature)
-  const expBuf = Buffer.from(expected)
-  const maxLen = Math.max(sigBuf.length, expBuf.length)
-  const paddedSig = Buffer.alloc(maxLen)
-  const paddedExp = Buffer.alloc(maxLen)
-  sigBuf.copy(paddedSig)
-  expBuf.copy(paddedExp)
-
-  return sigBuf.length === expBuf.length && crypto.timingSafeEqual(paddedSig, paddedExp)
-}
 
 // POST /api/webhooks/generic — generic JSON webhook
 webhookRouter.post('/generic', (req, res) => {
   const secret = loadWebhookSecret()
-  if (secret && !validateHmac(req, secret)) {
-    res.status(401).json({ error: 'Invalid or missing X-Jarvis-Signature' })
+
+  // --- Signature verification via shared normalizer ---
+  let signatureVerified = false
+  if (secret) {
+    const signature = req.headers['x-jarvis-signature'] as string | undefined
+    if (!signature || !verifyWebhookSignature(JSON.stringify(req.body), signature, secret)) {
+      res.status(401).json({ error: 'Invalid or missing X-Jarvis-Signature' })
+      return
+    }
+    signatureVerified = true
+  }
+
+  // --- Normalize via shared normalizer ---
+  const result = normalizeGenericWebhook({
+    payload: req.body as Record<string, unknown>,
+    signatureVerified,
+  })
+
+  if (!result.ok) {
+    res.status(400).json({ error: result.error })
     return
   }
 
-  const body = req.body as Record<string, unknown>
-  const agentId = body.agent_id as string | undefined
-  const context = (body.context as Record<string, unknown>) ?? {}
-
-  if (!agentId || typeof agentId !== 'string') {
-    res.status(400).json({ error: 'Missing or invalid agent_id field' })
-    return
-  }
-
-  insertCommand(agentId, 'webhook:generic', context)
+  const cmdParams = webhookEventToCommand(result.event)
+  issueCommandAndAudit(cmdParams, 'webhook:generic')
 
   res.json({
     status: 'triggered',
-    agentId,
-    triggeredAt: new Date().toISOString(),
+    agentId: result.event.agent_id,
+    triggeredAt: result.event.received_at,
   })
 })
 
 // POST /api/webhooks/:agentId — trigger any agent with optional payload
 webhookRouter.post('/:agentId', (req, res) => {
   const secret = loadWebhookSecret()
-  if (secret && !validateHmac(req, secret)) {
-    res.status(401).json({ error: 'Invalid or missing X-Jarvis-Signature' })
-    return
+
+  // --- Signature verification via shared normalizer ---
+  let signatureVerified = false
+  if (secret) {
+    const signature = req.headers['x-jarvis-signature'] as string | undefined
+    if (!signature || !verifyWebhookSignature(JSON.stringify(req.body), signature, secret)) {
+      res.status(401).json({ error: 'Invalid or missing X-Jarvis-Signature' })
+      return
+    }
+    signatureVerified = true
   }
 
   const { agentId } = req.params
-  const payload = req.body as Record<string, unknown>
 
-  insertCommand(agentId!, 'webhook', payload)
+  // --- Normalize via shared normalizer ---
+  const normalized = normalizeCustomWebhook({
+    agentId: agentId!,
+    payload: req.body as Record<string, unknown>,
+    signatureVerified,
+  })
+
+  const cmdParams = webhookEventToCommand(normalized)
+  issueCommandAndAudit(cmdParams, 'webhook')
 
   res.json({
     status: 'triggered',
     agentId,
-    triggeredAt: new Date().toISOString(),
+    triggeredAt: normalized.received_at,
   })
 })

--- a/packages/jarvis-runtime/src/index.ts
+++ b/packages/jarvis-runtime/src/index.ts
@@ -10,7 +10,7 @@ export { scorePlan, rankPlans, detectDisagreement, type PlanScore } from "./plan
 export { runAgent, type OrchestratorDeps } from "./orchestrator.js";
 export { RunStore, type RunStatus, type RunEventType } from "./run-store.js";
 export { requestApproval, waitForApproval, resolveApproval, delegateApproval, listApprovals, listApprovalsByAssignee, getApprovalMetrics, type ApprovalEntry, type ApprovalMetrics } from "./approval-bridge.js";
-export { writeTelegramQueue } from "./notify.js";
+export { writeTelegramQueue, createNotificationDispatcher, type NotificationChannel, type NotificationDispatcher } from "./notify.js";
 export { createFilesWorkerBridge } from "./files-bridge.js";
 export { StatusWriter, type DaemonStatusData } from "./status-writer.js";
 export { AgentQueue } from "./agent-queue.js";

--- a/packages/jarvis-runtime/src/notify.ts
+++ b/packages/jarvis-runtime/src/notify.ts
@@ -27,3 +27,53 @@ export function writeTelegramQueue(agentId: string, message: string, db?: Databa
     // Best-effort: don't crash if notifications table is missing or DB is closed
   }
 }
+
+// ─── Convergence: Unified Notification Dispatch ──────────────────────────────
+// See ADR-PLATFORM-KERNEL-BOUNDARY.md and CONVERGENCE-ROADMAP.md.
+// When JARVIS_TELEGRAM_MODE=session, notifications route through OpenClaw
+// sessions instead of the legacy DB-poll-then-send path.
+
+export type NotificationChannel = "telegram" | "session" | "both";
+
+export type NotificationDispatcher = {
+  /** Send a notification through the configured channel(s). */
+  notify(agentId: string, message: string, db?: DatabaseSync): Promise<void>;
+  /** Which channel is active. */
+  channel: NotificationChannel;
+};
+
+/**
+ * Create a notification dispatcher that routes through the appropriate channel.
+ *
+ * - "telegram" (default): writes to the notifications table (legacy path)
+ * - "session": sends via OpenClaw session (convergence path)
+ * - "both": writes to DB AND sends via session (transition/dual-write mode)
+ */
+export function createNotificationDispatcher(opts: {
+  channel?: NotificationChannel;
+  sessionSend?: (text: string) => Promise<void>;
+}): NotificationDispatcher {
+  const channel = opts.channel ?? "telegram";
+
+  return {
+    channel,
+    async notify(agentId: string, message: string, db?: DatabaseSync): Promise<void> {
+      const formatted = `[${agentId.toUpperCase()}]\n\n${message}`;
+
+      if (channel === "telegram" || channel === "both") {
+        writeTelegramQueue(agentId, message, db);
+      }
+
+      if ((channel === "session" || channel === "both") && opts.sessionSend) {
+        try {
+          await opts.sessionSend(formatted);
+        } catch {
+          // Session delivery failed — fall back to DB queue if not already written
+          if (channel === "session") {
+            writeTelegramQueue(agentId, message, db);
+          }
+        }
+      }
+    },
+  };
+}

--- a/packages/jarvis-runtime/src/worker-registry.ts
+++ b/packages/jarvis-runtime/src/worker-registry.ts
@@ -32,6 +32,10 @@ import {
   hashContent,
   type ProvenanceRecord,
 } from "@jarvis/observability";
+import {
+  logCredentialAccess,
+  type CredentialAuditConfig,
+} from "@jarvis/security/credential-audit";
 
 type WorkerExecuteFn = (envelope: JobEnvelope) => Promise<JobResult>;
 
@@ -57,14 +61,23 @@ export function createWorkerRegistry(
 ): WorkerRegistry {
   const useReal = config.adapter_mode === "real";
 
-  // Audit helper: log credential access for security trail (best-effort)
-  const auditCredentialAccess = (workerId: string, credentialType: string) => {
-    if (!runtimeDb) return;
-    try {
-      runtimeDb.prepare(
-        "INSERT INTO audit_log (event_type, actor, target, details_json, created_at) VALUES (?, ?, ?, ?, ?)"
-      ).run("credential_access", "worker-registry", workerId, JSON.stringify({ credential_type: credentialType }), new Date().toISOString());
-    } catch { /* best-effort — audit table may not exist yet */ }
+  // Credential audit: uses the structured audit module from @jarvis/security.
+  // Logs every credential distribution with worker ID, credential keys, and context.
+  // See docs/KNOWN-TRUST-GAPS.md for the gap this closes.
+  const credentialAuditConfig: CredentialAuditConfig = {
+    db: runtimeDb!,
+    enabled: !!runtimeDb,
+  };
+
+  const auditCredentialAccess = (workerId: string, credentialKeys: string[], context?: { runId?: string; jobId?: string }) => {
+    logCredentialAccess(credentialAuditConfig, {
+      worker_id: workerId,
+      credential_keys: credentialKeys,
+      run_id: context?.runId,
+      job_id: context?.jobId,
+      granted: credentialKeys.length > 0,
+      timestamp: new Date().toISOString(),
+    });
   };
 
   // ─── Provenance signer ──────────────────────────────────────────────────
@@ -149,7 +162,7 @@ export function createWorkerRegistry(
   if (useReal && config.gmail) {
     logger.info("Email: using Gmail API adapter");
     emailAdapter = new GmailAdapter(config.gmail);
-    auditCredentialAccess("email", "gmail");
+    auditCredentialAccess("email", ["gmail"]);
   } else {
     logger.info("Email: using mock adapter");
     emailAdapter = new MockEmailAdapter();
@@ -194,7 +207,7 @@ export function createWorkerRegistry(
   if (useReal && config.calendar) {
     logger.info("Calendar: using Google Calendar API adapter");
     calendarAdapter = new GoogleCalendarAdapter(config.calendar);
-    auditCredentialAccess("calendar", "calendar");
+    auditCredentialAccess("calendar", ["calendar"]);
   } else {
     logger.info("Calendar: using mock adapter");
     calendarAdapter = new MockCalendarAdapter();
@@ -217,7 +230,7 @@ export function createWorkerRegistry(
   if (useReal && config.chrome) {
     logger.info(`Browser: using Chrome adapter (${config.chrome.debugging_url})`);
     browserAdapter = new ChromeAdapter({ debugging_url: config.chrome.debugging_url });
-    auditCredentialAccess("browser", "chrome");
+    auditCredentialAccess("browser", ["chrome"]);
   } else {
     logger.info("Browser: using mock adapter");
     browserAdapter = new MockBrowserAdapter();
@@ -282,7 +295,7 @@ export function createWorkerRegistry(
   if (useReal && config.toggl) {
     logger.info("Time: using Toggl adapter");
     timeAdapter = new TogglAdapter(config.toggl);
-    auditCredentialAccess("time", "toggl");
+    auditCredentialAccess("time", ["toggl"]);
   } else {
     logger.info("Time: using mock adapter");
     timeAdapter = new MockTimeAdapter();
@@ -295,7 +308,7 @@ export function createWorkerRegistry(
   if (useReal && config.drive) {
     logger.info("Drive: using Google Drive adapter");
     driveAdapter = new GoogleDriveAdapter(config.drive);
-    auditCredentialAccess("drive", "drive");
+    auditCredentialAccess("drive", ["drive"]);
   } else {
     logger.info("Drive: using mock adapter");
     driveAdapter = new MockDriveAdapter();

--- a/tests/convergence-wiring.test.ts
+++ b/tests/convergence-wiring.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Convergence Wiring Tests
+ *
+ * Validates that Wave 2 convergence wiring is operational:
+ * - Notification dispatcher routes through session or DB
+ * - Credential audit is properly imported and callable
+ * - Webhook normalizer produces correct command params
+ * - Hook catalog integrates with the core plugin pattern
+ */
+
+import { describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+// Import directly from source files to avoid transitive @opentelemetry dependency
+// that exists in the @jarvis/runtime barrel export via @jarvis/observability.
+import {
+  writeTelegramQueue,
+  createNotificationDispatcher,
+} from "../packages/jarvis-runtime/src/notify.js";
+import {
+  verifyWebhookSignature,
+  normalizeGithubWebhook,
+  normalizeGenericWebhook,
+  webhookEventToCommand,
+} from "@jarvis/shared";
+import {
+  logCredentialAccess,
+  type CredentialAuditConfig,
+} from "@jarvis/security/credential-audit";
+import {
+  getHookCatalog,
+} from "@jarvis/core/hooks";
+
+function createTestDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE notifications (
+      notification_id TEXT PRIMARY KEY,
+      channel TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      payload_json TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at TEXT NOT NULL,
+      delivered_at TEXT
+    );
+    CREATE TABLE audit_log (
+      audit_id TEXT PRIMARY KEY,
+      actor_type TEXT NOT NULL,
+      actor_id TEXT NOT NULL,
+      action TEXT NOT NULL,
+      target_type TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      payload_json TEXT,
+      created_at TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+describe("Convergence Wiring", () => {
+  describe("Notification Dispatcher", () => {
+    it("telegram mode writes to DB", async () => {
+      const db = createTestDb();
+      const dispatcher = createNotificationDispatcher({ channel: "telegram" });
+      await dispatcher.notify("proposal-engine", "Proposal ready", db);
+
+      const rows = db.prepare("SELECT * FROM notifications").all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.channel).toBe("telegram");
+      expect(rows[0]!.status).toBe("pending");
+    });
+
+    it("session mode calls sessionSend", async () => {
+      const sent: string[] = [];
+      const dispatcher = createNotificationDispatcher({
+        channel: "session",
+        sessionSend: async (text) => { sent.push(text); },
+      });
+      await dispatcher.notify("evidence-auditor", "Audit complete");
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toContain("EVIDENCE-AUDITOR");
+      expect(sent[0]).toContain("Audit complete");
+    });
+
+    it("both mode writes to DB and sends via session", async () => {
+      const db = createTestDb();
+      const sent: string[] = [];
+      const dispatcher = createNotificationDispatcher({
+        channel: "both",
+        sessionSend: async (text) => { sent.push(text); },
+      });
+      await dispatcher.notify("contract-reviewer", "Review done", db);
+
+      const rows = db.prepare("SELECT * FROM notifications").all();
+      expect(rows).toHaveLength(1);
+      expect(sent).toHaveLength(1);
+    });
+
+    it("session mode falls back to DB on session failure", async () => {
+      const db = createTestDb();
+      const dispatcher = createNotificationDispatcher({
+        channel: "session",
+        sessionSend: async () => { throw new Error("Gateway unreachable"); },
+      });
+      await dispatcher.notify("orchestrator", "Fallback test", db);
+
+      const rows = db.prepare("SELECT * FROM notifications").all();
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe("Credential Audit Wiring", () => {
+    it("logCredentialAccess writes structured audit entries", () => {
+      const db = createTestDb();
+      const config: CredentialAuditConfig = { db, enabled: true };
+
+      logCredentialAccess(config, {
+        worker_id: "email",
+        credential_keys: ["gmail"],
+        run_id: "run-abc",
+        granted: true,
+        timestamp: new Date().toISOString(),
+      });
+
+      const rows = db.prepare("SELECT * FROM audit_log").all() as Array<Record<string, unknown>>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.actor_id).toBe("email");
+      expect(rows[0]!.action).toBe("credential.access");
+    });
+  });
+
+  describe("Webhook Normalizer Integration", () => {
+    it("normalizes a GitHub push event to command params", () => {
+      const event = normalizeGithubWebhook({
+        event: "push",
+        payload: { repository: { full_name: "org/repo" }, sender: { login: "user" }, action: "completed" },
+        signatureVerified: true,
+      });
+      expect(event).not.toBeNull();
+      expect(event!.agent_id).toBe("evidence-auditor");
+      expect(event!.source).toBe("github");
+
+      const params = webhookEventToCommand(event!);
+      expect(params.agentId).toBe("evidence-auditor");
+      expect(params.source).toBe("webhook");
+    });
+
+    it("rejects unmapped GitHub events", () => {
+      const event = normalizeGithubWebhook({
+        event: "deployment",
+        payload: {},
+        signatureVerified: false,
+      });
+      expect(event).toBeNull();
+    });
+
+    it("verifies HMAC signatures correctly", () => {
+      const secret = "test-secret-key";
+      const body = '{"agent_id":"orchestrator"}';
+      const crypto = require("node:crypto");
+      const hmac = crypto.createHmac("sha256", secret);
+      hmac.update(body);
+      const signature = "sha256=" + hmac.digest("hex");
+
+      expect(verifyWebhookSignature(body, signature, secret)).toBe(true);
+      expect(verifyWebhookSignature(body, "sha256=wrong", secret)).toBe(false);
+    });
+  });
+
+  describe("Hook Catalog Integration", () => {
+    it("catalog hooks are registrable via the plugin pattern", () => {
+      const catalog = getHookCatalog();
+
+      // Verify each hook has the shape needed for api.on()
+      for (const hook of catalog) {
+        expect(typeof hook.hookPoint).toBe("string");
+        expect(typeof hook.handler).toBe("function");
+        expect(typeof hook.priority).toBe("number");
+        expect(typeof hook.description).toBe("string");
+      }
+    });
+
+    it("before_tool_call hooks return approval or undefined", () => {
+      const catalog = getHookCatalog();
+      const beforeToolHooks = catalog.filter((h) => h.hookPoint === "before_tool_call");
+
+      // At least the built-in approval hook and domain approval hook
+      expect(beforeToolHooks.length).toBeGreaterThanOrEqual(2);
+
+      // Exec should trigger approval
+      for (const hook of beforeToolHooks) {
+        const result = hook.handler({ toolName: "exec" });
+        // At least one hook should gate exec
+        if (result && typeof result === "object" && "requireApproval" in result) {
+          expect((result as { requireApproval: { severity: string } }).requireApproval.severity).toBe("critical");
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Connects the convergence adapters from Wave 1 (#86) into the actual runtime, replacing inline logic with the shared modules.

- **Hook catalog wired**: jarvis-core now registers all `before_tool_call` hooks from the catalog (built-in approval, domain approval, capability boundary)
- **Webhook v1 refactored**: `webhooks.ts` delegates to `@jarvis/shared` normalizer functions, removing inline HMAC and event mapping
- **Credential audit wired**: All 5 worker credential distribution points now log through `@jarvis/security/credential-audit`
- **Notification dispatcher**: New `createNotificationDispatcher()` supports `telegram`, `session`, or `both` channels with automatic fallback

## Key changes

| Area | File | What changed |
|---|---|---|
| Hooks | `packages/jarvis-core/src/index.ts` | Loop registers catalog hooks instead of single manual hook |
| Webhooks | `packages/jarvis-dashboard/src/api/webhooks.ts` | Delegates to normalizer; removes inline HMAC + event mapping |
| Credentials | `packages/jarvis-runtime/src/worker-registry.ts` | Uses `logCredentialAccess` from security module |
| Notifications | `packages/jarvis-runtime/src/notify.ts` | Adds `createNotificationDispatcher` with session/telegram/both |
| Trust gaps | `docs/KNOWN-TRUST-GAPS.md` | Credential audit gap marked as mitigated |

## Test plan

- [x] 51 tests passing across 6 test files (10 new convergence-wiring tests)
- [x] Zero regressions — 13 pre-existing failures (missing @opentelemetry dep) unrelated
- [x] Webhook routes maintain identical HTTP response shapes
- [x] Hook registration backward compatible (createJarvisApprovalHook still exported)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)