### PR TITLE
Fix 10 boot, dashboard, and Telegram bugs

### DIFF
--- a/packages/jarvis-agent-framework/src/runtime.ts
+++ b/packages/jarvis-agent-framework/src/runtime.ts
@@ -45,6 +45,10 @@ export class AgentRuntime {
     return this.definitions.get(agentId);
   }
 
+  listAgents(): AgentDefinition[] {
+    return Array.from(this.definitions.values());
+  }
+
   /**
    * Create a new run object. The caller (orchestrator) owns the run lifecycle
    * and persists it via RunStore — AgentRuntime no longer caches run state.

--- a/packages/jarvis-dashboard/src/api/chat.ts
+++ b/packages/jarvis-dashboard/src/api/chat.ts
@@ -21,10 +21,13 @@ import {
   getGmailAccessToken,
   httpsPost,
   httpsGet,
+  detectLlm,
+  listLocalModels,
+  listAllModels,
   type FetchUrlOptions,
 } from './tool-infra.js'
 
-const LMS_URL = process.env.LMS_URL ?? 'http://localhost:1234'
+const FALLBACK_LMS_URL = process.env.LMS_URL ?? 'http://localhost:1234'
 const DEFAULT_MODEL = process.env.LMS_MODEL ?? 'qwen/qwen3.5-35b-a3b'
 
 /** Fetch options for chat.ts -- browser-like User-Agent */
@@ -107,9 +110,9 @@ Rules:
 
 // ─── Non-streaming LLM call (for tool-use follow-up) ──────────────────────────
 
-function llmChat(messages: Array<{ role: string; content: string }>, model: string): Promise<string> {
+function llmChat(messages: Array<{ role: string; content: string }>, model: string, baseUrl?: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const lmsUrl = new URL(`${LMS_URL}/v1/chat/completions`)
+    const lmsUrl = new URL(`${baseUrl ?? FALLBACK_LMS_URL}/v1/chat/completions`)
     const body = JSON.stringify({ model, messages, stream: false, temperature: 0.3, max_tokens: 2048 })
     const req = http.request({
       hostname: lmsUrl.hostname, port: Number(lmsUrl.port) || 1234,
@@ -202,11 +205,12 @@ Be direct and specific. Use your tools actively when the user asks you to look s
   socket?.setNoDelay?.(true)
 
   const chosenModel = model ?? DEFAULT_MODEL
+  const detected = await detectLlm().catch(() => ({ baseUrl: FALLBACK_LMS_URL, provider: 'lmstudio' as const }))
 
   // First pass: stream the LLM response, collecting the full text
   let fullResponse = ''
   try {
-    fullResponse = await streamToClient(res, msgs, chosenModel)
+    fullResponse = await streamToClient(res, msgs, chosenModel, detected.baseUrl)
   } catch (e) {
     res.write(`data: ${JSON.stringify({ error: e instanceof Error ? e.message : String(e) })}\n\n`)
     res.write('data: [DONE]\n\n')
@@ -228,7 +232,7 @@ Be direct and specific. Use your tools actively when the user asks you to look s
       msgs.push({ role: 'user', content: `[Tool Result for ${call.name}]:\n${result}\n\nNow use this information to answer the original question. Do NOT output any more tool calls.` })
 
       try {
-        await streamToClient(res, msgs, chosenModel)
+        await streamToClient(res, msgs, chosenModel, detected.baseUrl)
       } catch { /* best effort */ }
     }
   }
@@ -238,9 +242,9 @@ Be direct and specific. Use your tools actively when the user asks you to look s
 })
 
 // Stream LLM response to SSE client, return full collected text
-function streamToClient(res: import('express').Response, messages: Array<{ role: string; content: string }>, model: string): Promise<string> {
+function streamToClient(res: import('express').Response, messages: Array<{ role: string; content: string }>, model: string, baseUrl?: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const lmsUrl = new URL(`${LMS_URL}/v1/chat/completions`)
+    const lmsUrl = new URL(`${baseUrl ?? FALLBACK_LMS_URL}/v1/chat/completions`)
     const body = JSON.stringify({ model, messages, stream: true, temperature: 0.3, max_tokens: 2048 })
 
     const lmsReq = http.request({
@@ -367,6 +371,12 @@ const AGENT_TOOLS = [
     type: 'function' as const, function: {
       name: 'browse_page', description: 'Open a URL in Chrome and extract the full page content. Better than web_fetch for JavaScript-heavy sites.',
       parameters: { type: 'object', properties: { url: { type: 'string', description: 'URL to navigate to' } }, required: ['url'] }
+    }
+  },
+  {
+    type: 'function' as const, function: {
+      name: 'drive_list', description: 'List files in Google Drive. Returns file names, types, modified dates, and links.',
+      parameters: { type: 'object', properties: { query: { type: 'string', description: 'Optional search query (Google Drive search syntax). Leave empty for recent files.' }, max_results: { type: 'number', description: 'Max files to return (default 10)' } } }
     }
   },
   // gmail_send and gmail_reply REMOVED — email sending must go through
@@ -537,6 +547,24 @@ async function executeAgentTool(name: string, params: Record<string, unknown>): 
       }
     }
 
+    case 'drive_list': {
+      const query = params.query as string | undefined
+      const maxResults = (params.max_results as number) ?? 10
+      try {
+        const token = await getGmailAccessToken()
+        if (!token) return 'Google Drive not configured. Add Gmail credentials to ~/.jarvis/config.json'
+        const q = query ? `&q=${encodeURIComponent(query)}` : ''
+        const url = `https://www.googleapis.com/drive/v3/files?pageSize=${maxResults}&fields=files(id,name,mimeType,modifiedTime,size,webViewLink)${q}&orderBy=modifiedTime desc`
+        const resp = JSON.parse(await httpsGet(url, { Authorization: `Bearer ${token}` }))
+        if (!resp.files || resp.files.length === 0) return query ? `No Drive files found for: ${query}` : 'No files found in Drive'
+        return `Google Drive files${query ? ` (query: ${query})` : ''}:\n\n${(resp.files as Array<{ name: string; mimeType: string; modifiedTime: string; webViewLink?: string; id: string }>).map((f, i) =>
+          `${i + 1}. ${f.name}\n   Type: ${f.mimeType}\n   Modified: ${f.modifiedTime}\n   ${f.webViewLink ? `Link: ${f.webViewLink}` : `ID: ${f.id}`}`
+        ).join('\n\n')}`
+      } catch (e) {
+        return `Drive list failed: ${e instanceof Error ? e.message : String(e)}`
+      }
+    }
+
     // write_file and run_command handlers removed — privileged execution
     // must go through the runtime kernel, not chat surfaces.
     default:
@@ -639,11 +667,11 @@ ${context.slice(0, 1500)}`
         ?? ollamaModels.find(m => m.startsWith('qwen2.5:'))
         ?? ollamaModels[0]!
     } else {
-      llmBaseUrl = LMS_URL
+      llmBaseUrl = FALLBACK_LMS_URL
       llmModel = DEFAULT_MODEL
     }
   } catch {
-    llmBaseUrl = LMS_URL
+    llmBaseUrl = FALLBACK_LMS_URL
     llmModel = DEFAULT_MODEL
   }
 
@@ -694,42 +722,12 @@ ${context.slice(0, 1500)}`
   }
 })
 
-function listLocalModels(baseUrl: string): Promise<string[]> {
-  return new Promise((resolve) => {
-    const mod = baseUrl.startsWith('https') ? https : http
-    const url = new URL(`${baseUrl}/v1/models`)
-    const req = mod.get(url, (res) => {
-      let data = ''
-      res.on('data', (c: Buffer) => data += c.toString())
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data) as { data?: Array<{ id?: string }> }
-          resolve(json.data?.map(m => m.id ?? '').filter(Boolean) ?? [])
-        } catch { resolve([]) }
-      })
-    })
-    req.on('error', () => resolve([]))
-    req.setTimeout(3000, () => { req.destroy(); resolve([]) })
-  })
-}
-
-// GET /api/chat/models
-chatRouter.get('/models', (_req, res) => {
-  const lmsUrl = new URL(`${LMS_URL}/v1/models`)
-  const lmsReq = http.request({
-    hostname: lmsUrl.hostname, port: Number(lmsUrl.port) || 1234,
-    path: lmsUrl.pathname, method: 'GET'
-  }, (lmsRes) => {
-    let body = ''
-    lmsRes.on('data', (c: Buffer) => body += c.toString())
-    lmsRes.on('end', () => {
-      try {
-        const data = JSON.parse(body) as { data: Array<{ id: string }> }
-        res.json({ models: data.data.map(m => m.id), default: DEFAULT_MODEL })
-      } catch { res.json({ models: [], default: DEFAULT_MODEL }) }
-    })
-  })
-  lmsReq.on('error', () => res.json({ models: [], default: DEFAULT_MODEL, error: 'LM Studio unreachable' }))
-  lmsReq.setTimeout(30000, () => { lmsReq.destroy() })
-  lmsReq.end()
+// GET /api/chat/models — queries both Ollama and LM Studio
+chatRouter.get('/models', async (_req, res) => {
+  try {
+    const result = await listAllModels()
+    res.json({ models: result.models, default: result.models[0] ?? DEFAULT_MODEL, provider: result.provider })
+  } catch {
+    res.json({ models: [], default: DEFAULT_MODEL })
+  }
 })

--- a/packages/jarvis-dashboard/src/api/godmode.ts
+++ b/packages/jarvis-dashboard/src/api/godmode.ts
@@ -51,9 +51,11 @@ import {
   extractToolCalls,
   buildContext,
   isReadOnlyTool,
+  detectLlm,
+  listAllModels,
 } from './tool-infra.js'
 
-const LMS_URL = process.env.LMS_URL ?? 'http://localhost:1234'
+const FALLBACK_LMS_URL = process.env.LMS_URL ?? 'http://localhost:1234'
 const DEFAULT_MODEL = process.env.LMS_MODEL ?? 'qwen/qwen3.5-35b-a3b'
 
 // Verify godmode tools are a subset of the shared registry
@@ -99,13 +101,13 @@ interface IntentResult {
  * (session-chat-adapter.ts) which delegates intent classification to the
  * OpenClaw gateway.
  */
-async function classifyIntent(message: string, model: string): Promise<IntentResult> {
+async function classifyIntent(message: string, model: string, baseUrl?: string): Promise<IntentResult> {
   const fallback: IntentResult = { intent: 'chat', surfaces: ['chat'], tools: [] }
   try {
     const response = await llmChat([
       { role: 'system', content: INTENT_SYSTEM_PROMPT },
       { role: 'user', content: message }
-    ], model, 0.1, 200)
+    ], model, 0.1, 200, baseUrl)
 
     // Extract JSON from response (handle potential markdown wrapping)
     const jsonMatch = response.match(/\{[\s\S]*\}/)
@@ -241,9 +243,9 @@ function extractArtifacts(text: string): Array<{ kind: string; title: string; co
  * @deprecated Calls LM Studio directly via HTTP. Use the session-backed adapter
  * (session-chat-adapter.ts) which routes inference through the OpenClaw gateway.
  */
-function llmChat(messages: Array<{ role: string; content: string }>, model: string, temperature = 0.3, maxTokens = 2048): Promise<string> {
+function llmChat(messages: Array<{ role: string; content: string }>, model: string, temperature = 0.3, maxTokens = 2048, baseUrl?: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const lmsUrl = new URL(`${LMS_URL}/v1/chat/completions`)
+    const lmsUrl = new URL(`${baseUrl ?? FALLBACK_LMS_URL}/v1/chat/completions`)
     const body = JSON.stringify({ model, messages, stream: false, temperature, max_tokens: maxTokens })
     const req = http.request({
       hostname: lmsUrl.hostname, port: Number(lmsUrl.port) || 1234,
@@ -275,10 +277,11 @@ function streamLlm(
   res: import('express').Response,
   messages: Array<{ role: string; content: string }>,
   model: string,
-  onEvent: (type: string, data: unknown) => void
+  onEvent: (type: string, data: unknown) => void,
+  baseUrl?: string
 ): Promise<string> {
   return new Promise((resolve, reject) => {
-    const lmsUrl = new URL(`${LMS_URL}/v1/chat/completions`)
+    const lmsUrl = new URL(`${baseUrl ?? FALLBACK_LMS_URL}/v1/chat/completions`)
     const body = JSON.stringify({ model, messages, stream: true, temperature: 0.3, max_tokens: 4096 })
     const lmsReq = http.request({
       hostname: lmsUrl.hostname, port: Number(lmsUrl.port) || 1234,
@@ -349,6 +352,7 @@ godmodeRouter.post('/', async (req, res) => {
   if (!message?.trim()) { res.status(400).json({ error: 'message is required' }); return }
 
   const chosenModel = model ?? DEFAULT_MODEL
+  const detected = await detectLlm().catch(() => ({ baseUrl: FALLBACK_LMS_URL, provider: 'lmstudio' as const }))
 
   // SSE headers
   res.setHeader('Content-Type', 'text/event-stream')
@@ -359,11 +363,14 @@ godmodeRouter.post('/', async (req, res) => {
   const socket = res.socket as (NodeJS.Socket & { setNoDelay?: (v: boolean) => void }) | null
   socket?.setNoDelay?.(true)
 
+  // Notify frontend which model/provider is active
+  sendSSE(res, 'model', { model: chosenModel, provider: detected.provider, baseUrl: detected.baseUrl })
+
   let fullTextForArtifacts = ''
 
   try {
     // Step 1: Intent classification
-    const intent = await classifyIntent(message, chosenModel)
+    const intent = await classifyIntent(message, chosenModel, detected.baseUrl)
     sendSSE(res, 'surface', { surfaces: intent.surfaces })
 
     // Step 2: Build system prompt based on surfaces
@@ -394,7 +401,7 @@ Today is ${new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long
       } else if (type === 'token') {
         sendSSE(res, 'token', { content: data })
       }
-    })
+    }, detected.baseUrl)
 
     fullTextForArtifacts = fullResponse
 
@@ -466,7 +473,7 @@ Today is ${new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long
         } else if (type === 'token') {
           sendSSE(res, 'token', { content: data })
         }
-      })
+      }, detected.baseUrl)
 
       if (intent.intent === 'research') {
         sendSSE(res, 'research_step', { phase: 'done', detail: 'Research complete' })
@@ -523,22 +530,12 @@ Today is ${new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long
   res.end()
 })
 
-// GET /api/godmode/models — proxy to LM Studio
-godmodeRouter.get('/models', (_req, res) => {
-  const lmsUrl = new URL(`${LMS_URL}/v1/models`)
-  const lmsReq = http.request({
-    hostname: lmsUrl.hostname, port: Number(lmsUrl.port) || 1234,
-    path: lmsUrl.pathname, method: 'GET'
-  }, (lmsRes) => {
-    let body = ''
-    lmsRes.on('data', (c: Buffer) => body += c.toString())
-    lmsRes.on('end', () => {
-      try {
-        const data = JSON.parse(body) as { data: Array<{ id: string }> }
-        res.json({ models: data.data.map(m => m.id), default: DEFAULT_MODEL })
-      } catch { res.json({ models: [], default: DEFAULT_MODEL }) }
-    })
-  })
-  lmsReq.on('error', () => res.json({ models: [], default: DEFAULT_MODEL, error: 'LM Studio unreachable' }))
-  lmsReq.end()
+// GET /api/godmode/legacy/models — queries both Ollama and LM Studio
+godmodeRouter.get('/models', async (_req, res) => {
+  try {
+    const result = await listAllModels()
+    res.json({ models: result.models, default: result.models[0] ?? DEFAULT_MODEL, provider: result.provider })
+  } catch {
+    res.json({ models: [], default: DEFAULT_MODEL })
+  }
 })

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -18,6 +18,7 @@ import { backupRouter } from './backup.js'
 import { safemodeRouter } from './safemode.js'
 import { portalRouter } from './portal.js'
 import { godmodeRouter } from './godmode.js'
+import { listAllModels } from './tool-infra.js'
 import { createSessionChatRoute } from './session-chat-adapter.js'
 import { tasksRouter } from './tasks.js'
 import { modelsRouter } from './models.js'
@@ -126,6 +127,15 @@ app.use('/api/settings', settingsRouter)
 app.use('/api/backup', backupRouter)
 app.use('/api/safemode', safemodeRouter)
 app.use('/portal/api', portalRouter)
+// Mount models route BEFORE the session adapter to prevent shadowing
+app.get('/api/godmode/models', async (_req, res) => {
+  try {
+    const result = await listAllModels()
+    res.json({ models: result.models, default: result.models[0] ?? '', provider: result.provider })
+  } catch {
+    res.json({ models: [], default: '' })
+  }
+})
 app.use('/api/godmode', createSessionChatRoute())
 app.use('/api/godmode/legacy', godmodeRouter)
 app.use('/api/models', modelsRouter)

--- a/packages/jarvis-dashboard/src/api/session-chat-adapter.ts
+++ b/packages/jarvis-dashboard/src/api/session-chat-adapter.ts
@@ -431,6 +431,16 @@ export function mapGodmodeToolsToSessionTools(): SessionToolRegistration[] {
         required: ['query'],
       },
     },
+    drive_list: {
+      description: 'List files in Google Drive. Returns file names, types, modified dates, and links.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Optional search query (Google Drive search syntax)' },
+          max_results: { type: 'number', description: 'Max files to return (default 10)' },
+        },
+      },
+    },
   }
 
   // Build registrations only for tools in the canonical READONLY_TOOL_NAMES list

--- a/packages/jarvis-dashboard/src/api/tool-infra.ts
+++ b/packages/jarvis-dashboard/src/api/tool-infra.ts
@@ -25,7 +25,7 @@ export const READONLY_TOOL_NAMES = [
   "web_search", "web_fetch", "crm_search", "knowledge_search",
   "system_info", "list_files", "file_read", "file_list",
   "gmail_search", "gmail_read", "agent_status", "browse_page",
-  "wiki_search",
+  "wiki_search", "drive_list",
 ] as const;
 
 export type ReadOnlyToolName = (typeof READONLY_TOOL_NAMES)[number];
@@ -437,6 +437,59 @@ export function httpsGet(url: string, headers: Record<string, string> = {}): Pro
     req.setTimeout(15000, () => { req.destroy(); reject(new Error('timeout')) })
   })
 }
+
+// ─── LLM Discovery ───────────────────────────────────────────────────────────
+
+const OLLAMA_URL = 'http://localhost:11434'
+const LMSTUDIO_URL = process.env.LMS_URL ?? 'http://localhost:1234'
+
+/** Fetch model IDs from an OpenAI-compatible /v1/models endpoint. */
+export function listLocalModels(baseUrl: string): Promise<string[]> {
+  return new Promise((resolve) => {
+    const parsed = new URL(`${baseUrl}/v1/models`)
+    const transport = parsed.protocol === 'https:' ? https : http
+    const req = transport.get({ hostname: parsed.hostname, port: parsed.port, path: parsed.pathname, timeout: 3000 }, (res) => {
+      let data = ''
+      res.on('data', (c: Buffer) => data += c.toString())
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data)
+          const models = (json.data ?? json.models ?? []) as Array<{ id?: string; name?: string }>
+          resolve(models.map(m => m.id ?? m.name ?? '').filter(Boolean))
+        } catch { resolve([]) }
+      })
+      res.on('error', () => resolve([]))
+    })
+    req.on('error', () => resolve([]))
+    req.setTimeout(3000, () => { req.destroy(); resolve([]) })
+  })
+}
+
+/** Try Ollama first, fall back to LM Studio. Returns the active provider's base URL. */
+export async function detectLlm(): Promise<{ baseUrl: string; provider: 'ollama' | 'lmstudio' }> {
+  const ollamaModels = await listLocalModels(OLLAMA_URL)
+  if (ollamaModels.length > 0) return { baseUrl: OLLAMA_URL, provider: 'ollama' }
+  const lmsModels = await listLocalModels(LMSTUDIO_URL)
+  if (lmsModels.length > 0) return { baseUrl: LMSTUDIO_URL, provider: 'lmstudio' }
+  // Default to LM Studio URL even if unreachable (legacy behavior)
+  return { baseUrl: LMSTUDIO_URL, provider: 'lmstudio' }
+}
+
+/** Query both Ollama and LM Studio, merge model lists. */
+export async function listAllModels(): Promise<{ models: string[]; provider: 'ollama' | 'lmstudio' | 'mixed'; baseUrl: string }> {
+  const [ollamaModels, lmsModels] = await Promise.all([
+    listLocalModels(OLLAMA_URL),
+    listLocalModels(LMSTUDIO_URL),
+  ])
+  const all = [...new Set([...ollamaModels, ...lmsModels])]
+  const provider = ollamaModels.length > 0 && lmsModels.length > 0 ? 'mixed' as const
+    : ollamaModels.length > 0 ? 'ollama' as const
+    : 'lmstudio' as const
+  const baseUrl = ollamaModels.length > 0 ? OLLAMA_URL : LMSTUDIO_URL
+  return { models: all, provider, baseUrl }
+}
+
+// ─── Gmail Helpers ───────────────────────────────────────────────────────────
 
 export async function getGmailAccessToken(): Promise<string | null> {
   const cfg = loadGmailConfig()

--- a/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
@@ -73,7 +73,7 @@ export default function Godmode() {
 
         <div className="flex items-center gap-3">
           {/* Model selector */}
-          {models.length > 1 && (
+          {models.length >= 1 && (
             <div className="relative">
               <select
                 value={model}

--- a/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
+++ b/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
@@ -280,6 +280,11 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                 })
                 break
               }
+              case 'model': {
+                const modelId = evt.model as string
+                if (modelId) set({ model: modelId })
+                break
+              }
               case 'error': {
                 set(state => {
                   const msgs = [...state.messages]

--- a/packages/jarvis-inference/src/router.ts
+++ b/packages/jarvis-inference/src/router.ts
@@ -39,7 +39,7 @@ export function inferCapabilities(modelId: string): ModelCapability[] {
     caps.push("code");
   }
 
-  if (/vision|llava|bakllava|minicpm-v|moondream/.test(lower)) {
+  if (/vision|llava|bakllava|minicpm-v|moondream|gemma-[34]|gemma3|gemma4/.test(lower)) {
     caps.push("vision");
   }
 

--- a/packages/jarvis-runtime/src/orchestrator.ts
+++ b/packages/jarvis-runtime/src/orchestrator.ts
@@ -116,8 +116,11 @@ export async function runAgent(
   // Load plugin permissions if this is a plugin agent
   const pluginPermissions = loadPluginPermissions(agentId, runtimeDb);
 
+  // Extract goal from the command payload (Telegram free-text, API task field, etc.)
+  const goalFromPayload = (commandPayload?.task ?? commandPayload?.goal ?? (trigger as { message_preview?: string }).message_preview) as string | undefined;
+
   // 1. Start run — use the same run_id for both in-memory and durable state
-  const run = runtime.startRun(agentId, trigger);
+  const run = runtime.startRun(agentId, trigger, goalFromPayload);
   runStore?.startRun(agentId, trigger.kind, commandId, run.goal, run.run_id, owner);
 
   // Log retry relationship in the audit trail so retry runs are linked to originals

--- a/packages/jarvis-telegram/src/bot.ts
+++ b/packages/jarvis-telegram/src/bot.ts
@@ -11,6 +11,9 @@ type TelegramUpdate = {
     from?: { id: number; username?: string; first_name?: string }
     chat: { id: number }
     text?: string
+    photo?: Array<{ file_id: string; file_unique_id: string; width: number; height: number; file_size?: number }>
+    document?: { file_id: string; file_name?: string; mime_type?: string; file_size?: number }
+    caption?: string
   }
 }
 
@@ -180,6 +183,33 @@ export class JarvisBot {
           }
         } catch (e) {
           await this.send(`Error: ${String(e)}`)
+        }
+      }
+
+      // Handle photo messages
+      const photo = update.message?.photo
+      if (photo && photo.length > 0 && fromChat === this.chatId) {
+        try {
+          const { handleVisionMessage } = await import('./vision-handler.js')
+          const caption = update.message?.caption ?? 'What is in this image?'
+          const highestRes = photo[photo.length - 1]! // Telegram sends sizes ascending
+          const response = await handleVisionMessage(highestRes.file_id, caption, this.config.bot_token)
+          await this.send(response)
+        } catch (e) {
+          await this.send(`Vision processing failed: ${e instanceof Error ? e.message : String(e)}`)
+        }
+      }
+
+      // Handle image documents (files sent as attachments)
+      const doc = update.message?.document
+      if (doc && doc.mime_type?.startsWith('image/') && fromChat === this.chatId) {
+        try {
+          const { handleVisionMessage } = await import('./vision-handler.js')
+          const caption = update.message?.caption ?? 'What is in this image?'
+          const response = await handleVisionMessage(doc.file_id, caption, this.config.bot_token)
+          await this.send(response)
+        } catch (e) {
+          await this.send(`Vision processing failed: ${e instanceof Error ? e.message : String(e)}`)
         }
       }
     }

--- a/packages/jarvis-telegram/src/vision-handler.ts
+++ b/packages/jarvis-telegram/src/vision-handler.ts
@@ -1,0 +1,167 @@
+/**
+ * vision-handler.ts -- Telegram photo analysis via Ollama vision models
+ *
+ * Downloads photos from Telegram, detects a vision-capable Ollama model,
+ * and returns a multimodal analysis. Caches the detected model to avoid
+ * repeated probing across ESM reloads.
+ */
+
+import fs from 'fs'
+import { join } from 'path'
+import os from 'os'
+import http from 'http'
+
+const OLLAMA_URL = 'http://localhost:11434'
+const CACHE_PATH = join(os.homedir(), '.jarvis', '.vision-model-cache')
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+// ─── Telegram Photo Download ─────────────────────────────────────────────────
+
+async function downloadTelegramPhoto(fileId: string, botToken: string): Promise<Buffer> {
+  // Step 1: Get file path from Telegram
+  const fileRes = await fetch(`https://api.telegram.org/bot${botToken}/getFile?file_id=${fileId}`)
+  if (!fileRes.ok) throw new Error(`Telegram getFile failed: ${fileRes.statusText}`)
+  const fileData = await fileRes.json() as { ok: boolean; result?: { file_path?: string } }
+  const filePath = fileData.result?.file_path
+  if (!filePath) throw new Error('Telegram returned no file_path')
+
+  // Step 2: Download from Telegram CDN
+  const downloadRes = await fetch(`https://api.telegram.org/file/bot${botToken}/${filePath}`)
+  if (!downloadRes.ok) throw new Error(`Telegram file download failed: ${downloadRes.statusText}`)
+  const arrayBuf = await downloadRes.arrayBuffer()
+  return Buffer.from(arrayBuf)
+}
+
+// ─── Vision Model Detection ─────────────────────────────────────────────────
+
+type CacheEntry = { model: string; timestamp: number }
+
+function readCache(): string | null {
+  try {
+    const raw = fs.readFileSync(CACHE_PATH, 'utf-8')
+    const entry = JSON.parse(raw) as CacheEntry
+    if (Date.now() - entry.timestamp < CACHE_TTL_MS) return entry.model
+  } catch { /* cache miss */ }
+  return null
+}
+
+function writeCache(model: string): void {
+  try {
+    const dir = join(os.homedir(), '.jarvis')
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(CACHE_PATH, JSON.stringify({ model, timestamp: Date.now() }))
+  } catch { /* best-effort */ }
+}
+
+function ollamaGet(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${OLLAMA_URL}${path}`)
+    const req = http.get({ hostname: url.hostname, port: url.port, path: url.pathname }, (res) => {
+      let data = ''
+      res.on('data', (c: Buffer) => data += c.toString())
+      res.on('end', () => resolve(data))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.setTimeout(5000, () => { req.destroy(); reject(new Error('timeout')) })
+  })
+}
+
+function ollamaPost(path: string, body: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(`${OLLAMA_URL}${path}`)
+    const req = http.request({
+      hostname: url.hostname, port: Number(url.port),
+      path: url.pathname, method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }
+    }, (res) => {
+      let data = ''
+      res.on('data', (c: Buffer) => data += c.toString())
+      res.on('end', () => resolve(data))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.setTimeout(60000, () => { req.destroy(); reject(new Error('timeout')) })
+    req.write(body)
+    req.end()
+  })
+}
+
+/** Detect the best available vision model from Ollama. */
+async function detectVisionModel(): Promise<string> {
+  // Check cache first
+  const cached = readCache()
+  if (cached) return cached
+
+  // Candidates in priority order
+  const candidates = ['gemma3:12b', 'gemma3:4b', 'llava:13b', 'llava:7b', 'bakllava', 'moondream']
+
+  // Get available models
+  let available: string[]
+  try {
+    const resp = JSON.parse(await ollamaGet('/api/tags')) as { models?: Array<{ name: string }> }
+    available = (resp.models ?? []).map(m => m.name)
+  } catch {
+    throw new Error('Ollama is not running or unreachable at localhost:11434')
+  }
+
+  // Find first candidate that is available and has vision capability
+  for (const candidate of candidates) {
+    const match = available.find(m => m.startsWith(candidate.split(':')[0]!))
+    if (!match) continue
+
+    // Verify vision capability via /api/show
+    try {
+      const showResp = JSON.parse(await ollamaPost('/api/show', JSON.stringify({ name: match }))) as {
+        model_info?: Record<string, unknown>
+        details?: { families?: string[] }
+      }
+      // Check for vision projector in model info or families
+      const hasProjector = JSON.stringify(showResp.model_info ?? {}).includes('projector')
+      const hasVisionFamily = (showResp.details?.families ?? []).some(f => f.includes('vision') || f.includes('clip'))
+      if (hasProjector || hasVisionFamily) {
+        writeCache(match)
+        return match
+      }
+    } catch { /* skip, try next */ }
+  }
+
+  // Fallback: try any model with 'vision', 'llava', or 'gemma' in the name
+  const fallback = available.find(m => /vision|llava|gemma3|gemma4/.test(m.toLowerCase()))
+  if (fallback) {
+    writeCache(fallback)
+    return fallback
+  }
+
+  throw new Error(`No vision-capable model found in Ollama. Available: ${available.join(', ')}. Install one with: ollama pull gemma3:4b`)
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Handle a vision message from Telegram.
+ * Downloads the photo, detects a vision model, and returns the analysis.
+ */
+export async function handleVisionMessage(fileId: string, caption: string, botToken: string): Promise<string> {
+  // Download photo
+  const photoBuffer = await downloadTelegramPhoto(fileId, botToken)
+  const base64 = photoBuffer.toString('base64')
+
+  // Detect vision model
+  const model = await detectVisionModel()
+
+  // Call Ollama multimodal chat
+  const body = JSON.stringify({
+    model,
+    messages: [{ role: 'user', content: caption, images: [base64] }],
+    stream: false,
+  })
+
+  const resp = JSON.parse(await ollamaPost('/api/chat', body)) as {
+    message?: { content?: string }
+  }
+
+  const content = resp.message?.content ?? 'No response from vision model'
+  // Truncate to Telegram message limit
+  return content.length > 4096 ? content.slice(0, 4093) + '...' : content
+}


### PR DESCRIPTION
## Summary

- **P0 Boot fixes**: Add missing `AgentRuntime.listAgents()` method, pass Telegram command goal to orchestrator `startRun()`, expand vision model regex for Gemma 3/4
- **P1 Dashboard LLM detection**: Add shared `detectLlm()`/`listAllModels()` utilities — both chat and godmode surfaces auto-detect Ollama (port 11434) before falling back to LM Studio (port 1234). Fix `/api/godmode/models` route shadowed by session adapter. Show model selector with single model + SSE model event handler.
- **P2 Features**: Add `drive_list` tool to chat surface (Google Drive API v3 via existing OAuth). Add Telegram vision support — photo/document handling in bot.ts + new `vision-handler.ts` for Ollama multimodal analysis with model caching.

5 of the original 15 reported issues were already fixed on master (package exports, auth bypass, auth header dedup, rt.models null safety, trigger_agent intentional removal).

## Test plan

- [x] `npx tsc --noEmit` passes for agent-framework, inference packages
- [x] Dashboard builds with no new TS errors (pre-existing observability/tasks.ts errors unchanged)
- [x] 38 architecture boundary + governance tests pass
- [x] 1373 unit test cases pass (62/92 test files pass; 30 fail from pre-existing missing `@opentelemetry/sdk-node`)
- [ ] Manual: stop LM Studio, start Ollama — verify chat auto-detects Ollama
- [ ] Manual: `/api/godmode/models` returns model list (not 404)
- [ ] Manual: send photo to Telegram bot — verify vision analysis response

🤖 Generated with [Claude Code](https://claude.com/claude-code)