### PR TITLE
Fix LLM contention and queue cancel timestamps

### DIFF
--- a/packages/jarvis-dashboard/src/api/chat.ts
+++ b/packages/jarvis-dashboard/src/api/chat.ts
@@ -686,19 +686,33 @@ ${context.slice(0, 1500)}`
     { role: 'user', content: message }
   ]
 
-  // Use qwen3:8b (has tool support) via Ollama, fallback to LM Studio
+  // Model selection for Telegram chat — prefer fast models that don't compete
+  // with the daemon's heavier models. Try LM Studio first (separate GPU process),
+  // then small Ollama models (qwen3.5-4b loads alongside daemon models).
   let llmBaseUrl = 'http://localhost:11434'
   let llmModel = 'qwen3:8b'
   try {
-    const ollamaModels = await listLocalModels('http://localhost:11434')
-    if (ollamaModels.length > 0) {
-      // Prefer models with tool support: qwen3 > qwen2.5
-      llmModel = ollamaModels.find(m => m.startsWith('qwen3:'))
-        ?? ollamaModels.find(m => m.startsWith('qwen2.5:'))
-        ?? ollamaModels[0]!
+    // Try LM Studio first — fully parallel GPU process, no contention
+    const lmsUrl = process.env.LMS_URL ?? FALLBACK_LMS_URL
+    const lmsModels = await listLocalModels(lmsUrl).catch(() => [] as string[])
+    if (lmsModels.length > 0) {
+      llmBaseUrl = lmsUrl
+      llmModel = lmsModels.find(m => m.includes('qwen')) ?? lmsModels[0]!
     } else {
-      llmBaseUrl = FALLBACK_LMS_URL
-      llmModel = DEFAULT_MODEL
+      // Ollama: prefer small fast models to avoid contending with daemon's heavy models
+      const ollamaModels = await listLocalModels('http://localhost:11434')
+      if (ollamaModels.length > 0) {
+        // Models must support OpenAI-compatible tool calling.
+        // Prefer small models that can run alongside daemon's heavier models.
+        llmModel = ollamaModels.find(m => m === 'qwen2.5:3b')         // 3B, fast, tool support ✓
+          ?? ollamaModels.find(m => m === 'gemma-4-e4b:latest')        // 4B, tool support ✓
+          ?? ollamaModels.find(m => m.startsWith('qwen3:'))            // 8B, tool support ✓
+          ?? ollamaModels.find(m => m.startsWith('qwen2.5:'))
+          ?? ollamaModels[0]!
+      } else {
+        llmBaseUrl = FALLBACK_LMS_URL
+        llmModel = DEFAULT_MODEL
+      }
     }
   } catch {
     llmBaseUrl = FALLBACK_LMS_URL

--- a/packages/jarvis-dashboard/src/api/queue.ts
+++ b/packages/jarvis-dashboard/src/api/queue.ts
@@ -70,11 +70,12 @@ queueRouter.patch('/:commandId', (req, res) => {
   let db: DatabaseSync | undefined
   try {
     db = getRuntimeDb()
+    const now = new Date().toISOString()
     const result = db.prepare(`
       UPDATE agent_commands
-      SET status = 'cancelled', completed_at = datetime('now')
+      SET status = 'cancelled', completed_at = ?
       WHERE command_id = ? AND status IN ('queued', 'claimed')
-    `).run(commandId) as { changes: number }
+    `).run(now, commandId) as { changes: number }
 
     if (result.changes === 0) {
       res.status(404).json({ error: 'Command not found or already completed' })
@@ -83,9 +84,9 @@ queueRouter.patch('/:commandId', (req, res) => {
 
     // Also cancel any linked run
     db.prepare(`
-      UPDATE runs SET status = 'cancelled', completed_at = datetime('now')
+      UPDATE runs SET status = 'cancelled', completed_at = ?
       WHERE command_id = ? AND status NOT IN ('completed', 'failed', 'cancelled')
-    `).run(commandId)
+    `).run(now, commandId)
 
     res.json({ ok: true, command_id: commandId, status: 'cancelled' })
   } catch (e) {
@@ -100,11 +101,12 @@ queueRouter.delete('/all', (_req, res) => {
   let db: DatabaseSync | undefined
   try {
     db = getRuntimeDb()
+    const now = new Date().toISOString()
     const result = db.prepare(`
       UPDATE agent_commands
-      SET status = 'cancelled', completed_at = datetime('now')
+      SET status = 'cancelled', completed_at = ?
       WHERE status IN ('queued', 'claimed')
-    `).run() as { changes: number }
+    `).run(now) as { changes: number }
     res.json({ ok: true, cancelled: result.changes })
   } catch (e) {
     res.status(500).json({ error: `Failed to cancel: ${e instanceof Error ? e.message : String(e)}` })


### PR DESCRIPTION
## Summary
- **LLM contention fix**: Telegram chat now tries LM Studio first (separate GPU), then falls back to small Ollama models (qwen2.5:3b) that don't compete with daemon's heavy models. Tested tool support across all available models.
- **Queue cancel timestamps**: Use ISO format instead of `datetime('now')` so cancelled commands appear in history view

## Test plan
- [x] Verified qwen2.5:3b supports OpenAI tool calling
- [x] Verified qwen3.5-4b does NOT support tools (was causing "No response generated")
- [x] Telegram file read works with qwen2.5:3b while daemon runs concurrently
- [x] Queue cancel + Cancel All produce correct ISO timestamps in history

🤖 Generated with [Claude Code](https://claude.com/claude-code)