### PR TITLE
Add comprehensive project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ OpenClaw Gateway (WebSocket + HTTP, plugin host)
     '-- config.json   -- configuration
 ```
 
-## Packages (43)
+## Packages (44)
 
 ### Core & Framework
 - `@jarvis/shared` -- base types, OpenClaw SDK integration, gateway utilities
@@ -113,6 +113,7 @@ OpenClaw Gateway (WebSocket + HTTP, plugin host)
 ### Infrastructure
 - `@jarvis/jobs`, `@jarvis/dispatch`, `@jarvis/scheduler`, `@jarvis/supervisor`
 - `@jarvis/inference`, `@jarvis/interpreter`, `@jarvis/security`, `@jarvis/system`, `@jarvis/voice`, `@jarvis/device`
+- `@jarvis/observability`
 
 ### Plugins (6)
 - `@jarvis/agent-plugin`, `@jarvis/email-plugin`, `@jarvis/calendar-plugin`
@@ -138,8 +139,8 @@ OpenClaw Gateway (WebSocket + HTTP, plugin host)
 - `packages/jarvis-agents/src/legacy/prompts/` -- 14 archived prompt files
 - `packages/jarvis-agents/src/data/` -- Garden beds + planting calendar (JSON)
 - `packages/jarvis-agent-framework/src/` -- Runtime, memory, knowledge, entity graph, lesson capture
-- `contracts/jarvis/v1/` -- JSON schemas (23 families), 144 examples, job catalog (143 types), plugin surface
-- `tests/` -- 92 test files (unit + smoke + stress), 2384+ test cases
+- `contracts/jarvis/v1/` -- JSON schemas (27 families), 145 examples, job catalog (144 types), plugin surface
+- `tests/` -- 125 test files (unit + smoke + stress), 2860+ test cases
 - `scripts/` -- Setup, contract validation, DB initialization, ops (health, backup, recovery)
 - `scripts/runtime/` -- OpenClaw gateway bootstrap and smoke harness
 - `docs/` -- Architecture, usage guide, production target, release gates, specs, runbooks
@@ -149,9 +150,9 @@ OpenClaw Gateway (WebSocket + HTTP, plugin host)
 
 ```bash
 npm run check                    # Full pipeline: contracts + tests + build
-npm test                         # Tests only (92 files, 2384+ tests)
+npm test                         # Tests only (125 files, 2860+ tests)
 npm run build                    # TypeScript compilation
-npm run validate:contracts       # Schema + example validation (143 job types)
+npm run validate:contracts       # Schema + example validation (144 job types)
 npm run smoke:runtime            # OpenClaw + LM Studio integration smoke test
 ```
 
@@ -175,6 +176,6 @@ prospect -> qualified -> contacted -> meeting -> proposal -> negotiation -> won 
 - `crm.move_stage` -- requires approval (warning)
 - `document.generate_report` -- requires approval (warning)
 
-Of 143 total job types: 17 always require approval, 33 are conditional, 93 never require approval.
+Of 144 total job types: 17 always require approval, 33 are conditional, 94 never require approval.
 
 Read-only operations (search, analyze, list) never require approval.

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ The dashboard also provides two read-only copilot surfaces (`/api/chat/telegram`
 
 All job types, tool responses, and worker callbacks conform to the `jarvis.v1` contract — a frozen JSON Schema specification.
 
-- **143 job types** across **23 schema families**: agent, browser, calendar, crm, device, document, drive, email, files, inference, interpreter, office, python, scheduler, scrape, search, security, social, system, time, voice, web
-- **Schema validation** via `npm run validate:contracts` — validates all schemas and 144 example payloads against full envelope/result schemas
+- **144 job types** across **27 schema families**: agent, browser, calendar, crm, device, document, drive, email, files, inference, interpreter, office, python, scheduler, search, security, social, system, time, voice, web
+- **Schema validation** via `npm run validate:contracts` — validates all schemas and 145 example payloads against full envelope/result schemas
 - **Contract files** live in `contracts/jarvis/v1/`
 
 ### Job Lifecycle
@@ -235,13 +235,13 @@ Agent calls tool -> submitJob(type, input)
 
 ## Approval Rules
 
-High-stakes actions require human approval before execution. Of 143 job types:
+High-stakes actions require human approval before execution. Of 144 job types:
 
 | Approval | Count | Examples |
 |---|---|---|
 | **Required** (always) | 17 | `email.send`, `device.click`, `device.type_text`, `python.run`, `security.lockdown`, `calendar.create_event` |
 | **Conditional** (policy-gated) | 33 | `crm.move_stage`, `document.generate_report`, `device.open_app`, `files.write` |
-| **Not required** (read-only) | 93 | `email.search`, `crm.list_pipeline`, `device.snapshot`, `system.cpu_usage` |
+| **Not required** (read-only) | 94 | `email.search`, `crm.list_pipeline`, `device.snapshot`, `system.cpu_usage` |
 
 Agents with `high_stakes_manual_gate` maturity require approval for **every** mutating action.
 
@@ -326,9 +326,9 @@ Environment variables override config file values. See `.env.example` for all op
 
 ```bash
 npm run check              # Full pipeline: contracts + tests + build
-npm test                   # Run tests (62 files, 1411+ tests)
+npm test                   # Run tests (125 files, 2860+ tests)
 npm run build              # TypeScript compilation
-npm run validate:contracts # Schema + example validation (143 job types)
+npm run validate:contracts # Schema + example validation (144 job types)
 npm run dashboard:dev      # Dashboard dev mode (hot reload)
 npm run smoke:runtime      # OpenClaw + LM Studio integration smoke test
 ```

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -12,13 +12,13 @@ Canonical vocabulary for the Jarvis system. Every document and code comment shou
 
 **Tool** -- A function agents call via the plugin SDK; returns structured results (e.g., `email_search`). Tools are the agent-visible surface of a plugin. Each tool call produces a deterministic job spec submitted to the job queue.
 
-**Job** -- A queued unit of work with a type, input payload, and expected output (e.g., `email.send`). Jobs are the atomic unit of execution. There are 143 defined job types across 23 schema families.
+**Job** -- A queued unit of work with a type, input payload, and expected output (e.g., `email.send`). Jobs are the atomic unit of execution. There are 144 defined job types across 27 schema families.
 
 **Run** -- A single execution of an agent, tracked from planning through completion. Runs progress through a state machine (queued, planning, executing, awaiting_approval, completed, failed, cancelled) and emit events to the `run_events` table for audit.
 
 **Command** -- An operator instruction to start an agent run, stored in the `agent_commands` table. Commands flow from channels (Telegram, dashboard, CLI) into the runtime kernel, which creates a run.
 
-**Approval** -- A human-gated decision point for high-stakes actions. Approvals are created in `pending` state and transition to `approved`, `rejected`, `expired`, or `cancelled`. Of 143 job types, 17 always require approval and 33 are conditionally gated.
+**Approval** -- A human-gated decision point for high-stakes actions. Approvals are created in `pending` state and transition to `approved`, `rejected`, `expired`, or `cancelled`. Of 144 job types, 17 always require approval and 33 are conditionally gated.
 
 ## Outputs and Delivery
 

--- a/docs/JARVIS.md
+++ b/docs/JARVIS.md
@@ -1,0 +1,1277 @@
+# Jarvis -- Comprehensive Reference
+
+> Generated from source: 2026-04-10 | Contract version: `jarvis.v1` | OpenClaw: `^2026.4.8`
+
+### Reference Documents
+
+This is the main reference. Detailed sub-references:
+
+- **[Tool Reference](reference/tool-reference.md)** -- Full parameter documentation for all 100+ tools across 19 plugins
+- **[Database Schema](reference/database-schema.md)** -- Column-level schema for all 3 SQLite databases (runtime.db, crm.db, knowledge.db)
+- **[State Machines & Workflows](reference/state-machines.md)** -- All state transitions (run, approval, job, command, subgoal) and 9 workflow definitions
+
+---
+
+## 1. Overview
+
+Jarvis is an autonomous agent system for **Thinking in Code**, an automotive safety consulting firm (ISO 26262, ASPICE, AUTOSAR, cybersecurity). It runs 8 production agents that handle regulatory watch, proposal generation, contract review, evidence auditing, staffing optimization, knowledge curation, self-reflection, and multi-agent orchestration. The system operates as a plugin pack on top of OpenClaw and persists all state in three SQLite databases under `~/.jarvis/`.
+
+**Who it's for:** A single operator (Daniel) managing a 23-engineer consulting practice. All irreversible actions require human approval.
+
+---
+
+## 2. Architecture
+
+### 2.1 High-Level Diagram
+
+```mermaid
+graph TB
+    subgraph Channels
+        TG[Telegram Bot]
+        DASH[Dashboard :4242]
+        CLI[Claude Code / CLI]
+    end
+
+    subgraph OpenClaw Gateway
+        GW[Gateway :18789<br/>WebSocket + HTTP]
+        SESS[Session Router]
+        HOOKS[Hook Engine]
+        GW --> SESS
+        GW --> HOOKS
+    end
+
+    subgraph Jarvis Plugins x19
+        CORE["@jarvis/core<br/>planning, approvals, model selection"]
+        JOBS["@jarvis/jobs<br/>submit / claim / heartbeat / callback"]
+        DISPATCH["@jarvis/dispatch<br/>cross-session messaging"]
+        SCHED["@jarvis/scheduler<br/>cron + alerts + workflows"]
+        AGENT_P["@jarvis/agent<br/>agent lifecycle"]
+        EMAIL_P["@jarvis/email<br/>Gmail facade"]
+        CAL_P["@jarvis/calendar<br/>Calendar facade"]
+        CRM_P["@jarvis/crm<br/>pipeline management"]
+        WEB_P["@jarvis/web<br/>web intelligence"]
+        DOC_P["@jarvis/document<br/>document analysis"]
+        BROWSER_P["@jarvis/browser<br/>browser facade"]
+        OFFICE_P["@jarvis/office<br/>Excel/Word/PPT"]
+        FILES_P["@jarvis/files<br/>safe file broker"]
+        DEVICE_P["@jarvis/device<br/>desktop automation"]
+        SYSTEM_P["@jarvis/system<br/>monitoring"]
+        INF_P["@jarvis/inference<br/>local LLM routing"]
+        INTERP_P["@jarvis/interpreter<br/>code execution"]
+        SEC_P["@jarvis/security<br/>audit + lockdown"]
+        VOICE_P["@jarvis/voice<br/>STT / TTS"]
+    end
+
+    subgraph Workers x17
+        W_AGENT[agent-worker]
+        W_EMAIL[email-worker]
+        W_CAL[calendar-worker]
+        W_CRM[crm-worker]
+        W_WEB[web-worker]
+        W_DOC[document-worker]
+        W_BROWSER[browser-worker]
+        W_OFFICE[office-worker]
+        W_INF[inference-worker]
+        W_INTERP[interpreter-worker]
+        W_SEC[security-worker]
+        W_SYS[system-worker]
+        W_VOICE[voice-worker]
+        W_SOCIAL[social-worker]
+        W_TIME[time-worker]
+        W_DRIVE[drive-worker]
+        W_DESKTOP[desktop-host-worker]
+    end
+
+    subgraph Runtime Daemon
+        QUEUE[Agent Queue<br/>max_concurrent: 1-16]
+        PLANNER[Planner<br/>single / critic / multi]
+        RAG[RAG Pipeline<br/>dense + BM25 hybrid]
+        STATUS[Status Writer<br/>heartbeat 10s]
+        HEALTH[Health / Readiness]
+        ORCH[Orchestrator<br/>goal decomposition + DAG]
+    end
+
+    subgraph State Layer
+        RDB[(runtime.db<br/>runs, approvals, jobs,<br/>models, schedules, memory)]
+        CDB[(crm.db<br/>contacts, pipeline)]
+        KDB[(knowledge.db<br/>docs, playbooks,<br/>entities, RAG index)]
+    end
+
+    subgraph External Services
+        LMS[LM Studio :1234]
+        OLLAMA[Ollama :11434]
+        GMAIL[Gmail API]
+        GCAL[Google Calendar API]
+        GDRIVE[Google Drive API]
+        TOGGL[Toggl API]
+    end
+
+    TG --> GW
+    DASH --> GW
+    CLI --> GW
+
+    GW --> CORE & JOBS & DISPATCH & SCHED
+    GW --> AGENT_P & EMAIL_P & CAL_P & CRM_P
+    GW --> WEB_P & DOC_P & BROWSER_P & OFFICE_P
+    GW --> FILES_P & DEVICE_P & SYSTEM_P & INF_P
+    GW --> INTERP_P & SEC_P & VOICE_P
+
+    JOBS -- "claim/heartbeat/callback" --> W_AGENT & W_EMAIL & W_CAL & W_CRM
+    JOBS --> W_WEB & W_DOC & W_BROWSER & W_OFFICE
+    JOBS --> W_INF & W_INTERP & W_SEC & W_SYS
+    JOBS --> W_VOICE & W_SOCIAL & W_TIME & W_DRIVE & W_DESKTOP
+
+    W_EMAIL --> GMAIL
+    W_CAL --> GCAL
+    W_DRIVE --> GDRIVE
+    W_TIME --> TOGGL
+    W_INF --> LMS & OLLAMA
+
+    QUEUE --> PLANNER --> RAG
+    QUEUE --> ORCH
+    STATUS --> RDB
+    HEALTH --> RDB & CDB & KDB
+
+    CORE --> RDB
+    JOBS --> RDB
+    CRM_P --> CDB
+    DOC_P --> KDB
+    AGENT_P --> RDB
+```
+
+### 2.2 Data Flow
+
+1. **Inbound:** Operator messages arrive via Telegram (session mode), Dashboard WebSocket, or Claude Code MCP.
+2. **Routing:** OpenClaw gateway routes messages to sessions. Jarvis plugins register tools, commands, and hooks with the gateway.
+3. **Job lifecycle:** Tools create `JobEnvelope` objects (contract version `jarvis.v1`) and submit them to the queue. Workers claim jobs via HTTP (`POST /jarvis/jobs/claim`), send heartbeats every 10s, and return results via callback (`POST /jarvis/jobs/callback`).
+4. **Approval gates:** Mutating operations (email send, CRM stage move, file write) pass through hook-based approval. The hook engine checks severity (critical/warning/info) and blocks until operator approves or timeout expires.
+5. **Agent execution:** The runtime daemon dequeues agent commands, selects a planner mode (single/critic/multi-viewpoint), generates a step plan via LLM inference, and executes steps sequentially. Each step may submit jobs, query knowledge (RAG), or request approval.
+6. **Persistence:** All state lives in three SQLite databases. `runtime.db` holds the control plane. `crm.db` holds contacts and pipeline. `knowledge.db` holds documents, playbooks, entities, and the RAG index.
+
+### 2.3 Execution Planes
+
+| Plane | Components | Responsibility |
+|-------|-----------|---------------|
+| **Operator** | Telegram, Dashboard, CLI | Human interface, approval resolution |
+| **Control** | Core plugin, scheduler, dispatch | Policy, planning, coordination |
+| **Execution** | Agent queue, supervisor, 17 workers | Job claim, execution, callback |
+| **Inference** | Inference plugin + worker, LM Studio, Ollama | LLM chat, embeddings, RAG |
+| **Knowledge** | Agent framework, knowledge store, entity graph | Memory, lessons, document retrieval |
+
+---
+
+## 3. Prerequisites & Installation
+
+### 3.1 Requirements
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Node.js | >= 22.5.0 | Required for OpenClaw SDK |
+| npm | >= 10 | Workspace support |
+| TypeScript | ^6.0.2 | Dev dependency, installed automatically |
+| OpenClaw | ^2026.4.8 | Platform SDK, installed automatically |
+| Windows 11 | 10.0+ | Desktop automation uses PowerShell |
+| LM Studio | latest | Local inference backend (default `:1234`) |
+| SQLite | bundled | Via better-sqlite3 |
+
+**Optional:**
+
+| Service | Purpose |
+|---------|---------|
+| Ollama (`:11434`) | Alternative inference backend |
+| Gmail OAuth | Email agent capabilities |
+| Google Calendar OAuth | Calendar agent capabilities |
+| Google Drive OAuth | Drive worker |
+| Telegram Bot Token | Telegram channel |
+| Toggl API Token | Time tracking |
+| Chrome (debugging port) | Browser automation |
+
+### 3.2 Installation
+
+```bash
+git clone https://github.com/dturcu/jarvis.git
+cd jarvis
+npm install
+```
+
+### 3.3 First-Time Setup
+
+**Interactive wizard:**
+
+```bash
+npm run setup
+```
+
+The wizard creates `~/.jarvis/`, initializes all three SQLite databases, and prompts for optional credentials (Telegram, Gmail OAuth, Chrome debugging URL, LM Studio URL).
+
+**Non-interactive (CI / scripted):**
+
+```bash
+npx tsx scripts/init-jarvis.ts
+```
+
+Creates databases and runs migrations without prompting.
+
+### 3.4 Verify Installation
+
+```bash
+npm run check    # validate contracts + run tests + build
+```
+
+This runs:
+1. `npm run validate:contracts` -- validates 144 job types against JSON schemas and 145 example payloads
+2. `npm test` -- 125 test files, 2860+ test cases
+3. `npm run build` -- TypeScript compilation
+
+---
+
+## 4. Configuration
+
+### 4.1 Config File
+
+**Path:** `~/.jarvis/config.json`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `lmstudio_url` | string | `"http://localhost:1234"` | LM Studio inference endpoint |
+| `default_model` | string | `"auto"` | Model ID or `"auto"` for router selection |
+| `adapter_mode` | `"mock"` \| `"real"` | `"mock"` | Worker adapter mode (mock for testing) |
+| `poll_interval_ms` | number (1000+) | 2500 | Job queue polling interval |
+| `trigger_poll_ms` | number (1000+) | 5000 | Schedule trigger polling interval |
+| `max_concurrent` | number (1-16) | 2 | Maximum concurrent agent runs |
+| `log_level` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | `"info"` | Log verbosity |
+| `mode` | `"dev"` \| `"production"` | `"dev"` | Production enables auth enforcement |
+| `appliance_mode` | boolean | false | Production appliance mode |
+| `bind_host` | string | `"127.0.0.1"` | Dashboard bind address |
+| `trust_proxy` | boolean | false | Trust X-Forwarded-For headers |
+| `project_root` | string | (cwd) | Root for file operations |
+| `webhook_secret` | string | (empty) | HMAC secret for webhook verification |
+| `anthropic_api_key` | string | (empty) | Anthropic API key |
+| `api_token` | string | (empty) | Dashboard auth token |
+| `api_tokens` | string[] | [] | Additional API tokens |
+| `gmail` | object | (empty) | `{ client_id, client_secret, refresh_token }` |
+| `calendar` | object | (empty) | `{ client_id, client_secret, refresh_token }` |
+| `drive` | object | (empty) | `{ client_id, client_secret, refresh_token }` |
+| `chrome` | object | (empty) | `{ debugging_url }` |
+| `telegram` | object | (empty) | `{ bot_token, chat_id }` |
+| `toggl` | object | (empty) | `{ api_token, workspace_id }` |
+
+### 4.2 Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `4242` | Dashboard HTTP port |
+| `LMS_URL` | `http://localhost:1234` | LM Studio base URL (overrides config) |
+| `LMS_MODEL` | `auto` | Default model (overrides config) |
+| `JARVIS_PROJECT_ROOT` | (cwd) | File operations root |
+| `JARVIS_CORS_ORIGIN` | `http://localhost:4242` | Dashboard CORS origin |
+| `JARVIS_API_TOKEN` | (empty) | Dashboard auth token (empty = dev mode) |
+| `JARVIS_BIND_HOST` | `127.0.0.1` | Dashboard bind host |
+| `JARVIS_MODE` | `development` | `"production"` enforces auth |
+| `JARVIS_WEBHOOK_SECRET` | (empty) | Webhook HMAC secret |
+| `ANTHROPIC_API_KEY` | (empty) | Anthropic API key |
+| `JARVIS_TELEGRAM_BOT_TOKEN` | (empty) | Telegram bot token |
+| `JARVIS_TELEGRAM_CHAT_ID` | (empty) | Telegram destination chat |
+| `JARVIS_TELEGRAM_MODE` | (default) | `"legacy"` for old polling bot |
+| `JARVIS_TELEGRAM_SESSION_KEY` | `telegram:main` | OpenClaw session key for Telegram |
+| `JARVIS_BROWSER_MODE` | (default) | `"legacy"` for old chrome-adapter |
+| `JARVIS_FILES_ROOT` | (cwd) | Single root for file operations |
+| `JARVIS_FILES_ALLOWED_ROOTS` | (empty) | Semicolon-separated allowed file dirs |
+| `JARVIS_APPLIANCE_MODE` | (empty) | `"true"` enables appliance mode |
+| `JARVIS_SMOKE_PROFILE` | (empty) | Smoke test profile (CI only) |
+| `JARVIS_SMOKE_AGENT_ID` | (empty) | Smoke test agent (CI only) |
+| `JARVIS_SMOKE_GATEWAY_PORT` | (empty) | Smoke test gateway port (CI only) |
+| `JARVIS_SMOKE_LMSTUDIO_PORT` | (empty) | Smoke test LM Studio port (CI only) |
+| `JARVIS_SMOKE_MODEL_KEY` | (empty) | Smoke test model key (CI only) |
+
+### 4.3 Worker Credential Scoping
+
+Workers receive only the credentials they need, scoped by worker type:
+
+| Worker | Credential Scope |
+|--------|-----------------|
+| email | `gmail` |
+| calendar | `calendar` |
+| drive | `drive` |
+| browser, social | `chrome` |
+| time | `toggl` |
+| All others | (none) |
+
+---
+
+## 5. Usage
+
+### 5.1 CLI Commands
+
+```bash
+npm run jarvis <command>
+```
+
+| Command | Description |
+|---------|-------------|
+| `setup` | Interactive setup wizard |
+| `doctor` | Verify installation health |
+| `config` | Show/edit config |
+| `init` | Initialize databases |
+| `start` | Start daemon + dashboard |
+| `stop` | Stop daemon |
+| `status` | Show daemon status |
+| `dashboard` | Start dashboard only |
+| `logs` | Show recent logs |
+| `health` | Run health check |
+| `backup` | Create runtime backup |
+| `restore` | Restore from backup |
+| `migrate` | Run database migrations |
+| `benchmark-models` | Benchmark local models |
+| `demo` | Seed demo data |
+
+### 5.2 NPM Scripts
+
+```bash
+npm start                    # Daemon + dashboard together
+npm run daemon               # Daemon only
+npm run dashboard            # Dashboard production mode (:4242)
+npm run dashboard:dev        # Dashboard dev mode (hot reload)
+npm run telegram-bot         # Telegram bot service
+
+npm run check                # Full pipeline: contracts + tests + build
+npm test                     # Tests only (125 files, 2860+ tests)
+npm run test:stress          # Stress tests (separate config)
+npm run build                # TypeScript compilation
+npm run validate:contracts   # Schema + example validation (144 job types)
+npm run check:architecture   # Boundary tests
+npm run check:convergence    # Full convergence gate tests
+npm run smoke:runtime        # OpenClaw + LM Studio smoke test
+
+npm run ops:health           # Health check
+npm run ops:backup           # Create backup
+npm run ops:recover          # Restore from backup
+
+npm run plugin:install       # Install plugin
+npm run plugin:list          # List installed plugins
+npm run plugin:remove        # Remove plugin
+```
+
+### 5.3 Agent Invocation
+
+In Claude Code mode, agents are invoked as slash commands:
+
+```
+/orchestrator    -- Decompose goals, coordinate multi-agent workflows
+/self-reflection -- Weekly system health analysis
+/regulatory-watch -- Track ISO/ASPICE/EU regulatory changes
+/knowledge-curator -- Ingest docs, maintain knowledge store
+/proposal-engine -- Analyze RFQs, build quotes, generate proposals
+/evidence-auditor -- Audit ISO 26262 / ASPICE evidence
+/contract-reviewer -- Analyze NDA/MSA clauses
+/staffing-monitor -- Track utilization, forecast gaps
+```
+
+In OpenClaw mode, agents run via schedules or commands:
+
+```bash
+# Manual trigger via dashboard API
+curl -X POST http://localhost:4242/api/agents/orchestrator/run \
+  -H "Authorization: Bearer $JARVIS_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"goal": "Generate Q2 staffing report"}'
+```
+
+### 5.4 Approval Flow
+
+Mutating operations block until approved:
+
+1. Agent requests approval (tool call triggers hook)
+2. Notification sent to Telegram / Dashboard
+3. Operator approves via `/approve <id> approved` (Telegram) or Dashboard button
+4. Agent resumes execution
+
+Timeouts: 5 minutes for built-in tools (exec, apply_patch, browser), 10 minutes for domain tools (email_send, crm_move_stage). Timeout behavior: deny.
+
+---
+
+## 6. Features
+
+### 6.1 Agents (8 Active)
+
+#### Orchestrator
+- **ID:** `orchestrator`
+- **Maturity:** high_stakes_manual_gate
+- **Triggers:** manual, event (`workflow.start`)
+- **Planner:** multi-viewpoint (3 perspectives: pragmatic, thorough, creative)
+- **Max steps:** 20
+- **Capabilities:** inference, crm, email, document, web, device
+- **Behavior:** Decomposes goals into agent DAGs, presents execution plan for approval, dispatches agents in topological order, validates outputs, merges deliverables.
+- **Approval gates:** `workflow.execute_multi` (warning), `email.send` (critical)
+- **Output channels:** telegram:daniel
+
+#### Self-Reflection
+- **ID:** `self-reflection`
+- **Maturity:** trusted_with_review
+- **Triggers:** schedule (Sunday 06:00), manual
+- **Planner:** critic (plan + critique + optional revision)
+- **Max steps:** 6
+- **Behavior:** Queries 7-day decision logs, approvals, and lessons. Produces `review_report` with health score (0-100) and 5+ ranked improvement proposals. Categories: prompt_change, schema_enhancement, knowledge_gap, retrieval_miss, approval_friction, workflow_optimization.
+- **Constraint:** Read-only. Never self-modifies.
+
+#### Regulatory-Watch
+- **ID:** `regulatory-watch`
+- **Maturity:** operational
+- **Triggers:** schedule (Mon/Thu 07:00), manual
+- **Planner:** single
+- **Max steps:** 8
+- **Behavior:** Searches news/RSS for ISO 26262, ISO 21434, ASPICE, UN R155/R156, ISO/PAS 8800, SOTIF, EU CRA, UNECE WP.29. Classifies findings (CRITICAL/HIGH/MEDIUM/LOW). Stores in `regulatory` knowledge collection. Only Telegram-notifies CRITICAL/HIGH.
+
+#### Knowledge-Curator
+- **ID:** `knowledge-curator`
+- **Maturity:** operational
+- **Triggers:** schedule (weekdays 06:00), manual, event (`document.received`)
+- **Planner:** single
+- **Max steps:** 10
+- **Behavior:** Ingests documents and meetings. Parses, extracts entities, checks duplicates (>0.85 similarity threshold), stores with metadata, links entities to CRM. For meetings: extracts attendees, decisions, action items, risks. Runs collection health check (flags if no docs in 90+ days).
+- **Approval gates:** `knowledge.delete` (critical), `entity.merge` (warning)
+- **Knowledge collections:** proposals, case-studies, contracts, playbooks, iso26262, regulatory, meetings, lessons
+
+#### Proposal-Engine
+- **ID:** `proposal-engine`
+- **Maturity:** high_stakes_manual_gate
+- **Triggers:** manual, event (`email.received.rfq`)
+- **Planner:** multi-viewpoint
+- **Max steps:** 10
+- **Behavior:** Ingests RFQ, extracts work packages, identifies risks, queries past proposals + case-studies + regulatory knowledge, queries CRM for client history, builds defensible quote. Generates DOCX proposal, drafts cover email, logs to CRM, builds invoice structure.
+- **Quote rules:** Phase 1 always 2-4 weeks EUR 5-15k. No T&M for safety-critical. Rates: ASIL-D EUR 130-180/h, standard EUR 85-120/h.
+- **Approval gates:** `email.send` (critical), `document.generate_report` (warning)
+- **Artifacts:** proposal_document, cover_email, risk_summary, crm_note, invoice_structure
+
+#### Evidence-Auditor
+- **ID:** `evidence-auditor`
+- **Maturity:** trusted_with_review
+- **Triggers:** schedule (Monday 09:00), manual
+- **Planner:** critic
+- **Max steps:** 8
+- **Behavior:** Scans project directory, parses work products, extracts ASIL level / revision / review status. Checks against ISO 26262 Part 6 checklist. Verifies traceability chains (HSR-FSR-TSR-SSR, SSR-Arch-Unit, SSR-Tests). Assesses DIA coverage. Generates gap matrix and gate-readiness summary (RED/YELLOW/GREEN).
+- **Multimodal:** Accepts scanned PDFs, screenshots, images with OCR.
+- **Approval gates:** `document.generate_report` (warning)
+
+#### Contract-Reviewer
+- **ID:** `contract-reviewer`
+- **Maturity:** high_stakes_manual_gate
+- **Triggers:** manual, event (`email.received.nda`)
+- **Planner:** multi-viewpoint
+- **Max steps:** 7
+- **Behavior:** Ingests contract, extracts clauses by category (jurisdiction, confidentiality, IP, indemnity, liability, non-compete, termination, payment). Classifies each (OK/FLAG/RED FLAG). Queries past contracts with counterparty, EU legislation. Synthesizes recommendation: SIGN/NEGOTIATE/ESCALATE with risk score (0-100).
+- **Baseline:** EU/Romanian law preferred, 3yr confidentiality, mutual indemnity, capped liability, 6mo non-compete, Net 30.
+- **Multimodal:** Accepts scanned contracts with OCR.
+
+#### Staffing-Monitor
+- **ID:** `staffing-monitor`
+- **Maturity:** operational
+- **Triggers:** schedule (Monday 09:00), manual
+- **Planner:** single
+- **Max steps:** 8
+- **Behavior:** Tracks 23-engineer team utilization (Romania + EU: 8 AUTOSAR, 6 Safety, 3 Cybersecurity, 4 Timing/MPU, 2 ASPICE). Target: 85% utilization (~160h/month). Warns at <70% or >95%. Forecasts gaps 4-6 weeks ahead. Matches skills to CRM pipeline.
+- **Artifacts:** utilization_report, pipeline_gaps, staffing_recommendations, overall_health (GREEN/YELLOW/RED)
+- **Approval gates:** `email.send` (critical)
+
+### 6.2 Planning System
+
+Three planner modes, selectable per agent via `planner_mode`:
+
+| Mode | Process | Best for |
+|------|---------|----------|
+| `single` | LLM generates plan directly | Routine tasks, operational agents |
+| `critic` | Plan -> Critique -> Optional revision | Quality-sensitive tasks |
+| `multi` | N viewpoints (pragmatic/thorough/creative) -> Score -> Rank -> Optional critic on winner | High-stakes decisions |
+
+**Plan scoring** (deterministic, no LLM):
+- Capability coverage: 35% weight
+- Step efficiency: 25% (sweet spot 40-80% of max_steps)
+- Action diversity: 20%
+- Reasoning quality: 20% (steps with reasoning > 20 chars)
+
+**Disagreement detection:** Flags when step counts differ by >50% or >30% of actions are unique to a single plan.
+
+### 6.3 Job Queue
+
+**Lifecycle:** submit -> claim -> heartbeat -> callback
+
+| Phase | Mechanism |
+|-------|-----------|
+| Submit | Plugin creates `JobEnvelope` via `submitJob()` |
+| Claim | Worker polls `POST /jarvis/jobs/claim` with worker_id and routes |
+| Heartbeat | Worker sends `POST /jarvis/jobs/heartbeat` every 10s |
+| Callback | Worker returns result via `POST /jarvis/jobs/callback` |
+| Requeue | Expired leases requeued after 15s |
+
+**144 job types** across 27 schema families. Each envelope includes: contract_version, job_id (UUID), type, session_key, requested_by, priority, approval_state, timeout_seconds, attempt, input, artifacts_in, retry_policy, metadata.
+
+### 6.4 Approval System
+
+**Hook-based enforcement** (registered with OpenClaw `before_tool_call`):
+
+| Hook | Priority | Targets | Severity | Timeout |
+|------|----------|---------|----------|---------|
+| Built-in approval | 0 | exec, apply_patch, browser | critical (exec), warning (others) | 300s |
+| Domain approval | 10 | email_send, email_draft, crm_move_stage, crm_update_contact | critical (email), warning (CRM) | 600s |
+| Capability boundary | -10 | All non-read-only tools | deny if context.readOnly | immediate |
+
+**Additional hooks** (defined, awaiting OpenClaw hook point registration):
+- `createProvenanceHook()` -- after_tool_call: records tool_name, duration_ms, timestamp
+- `createReplyGuardrailHook()` -- before_reply: redacts API keys, credit cards, GitHub tokens, Telegram bot tokens
+- `createErrorPolicyHook()` -- on_error: retryable errors (ECONNREFUSED, ETIMEDOUT, ENOTFOUND, WORKER_UNAVAILABLE) get 3 retries with exponential backoff (1s, 2s, 4s)
+
+**Approval rules summary** (of 144 job types):
+- 17 always require approval (email.send, device.click, device.type, system.kill_process, security.audit, social.*, etc.)
+- 33 conditional (crm.move_stage, document.generate_report, device.open_app, files.write, etc.)
+- 94 never require approval (all read-only: search, list, inspect, status, monitor)
+
+### 6.5 Knowledge System
+
+**9 collections:** lessons, playbooks, case-studies, contracts, proposals, iso26262, regulatory, meetings, garden
+
+**Components:**
+- **KnowledgeStore** -- Document CRUD, playbook management, search
+- **EntityGraph** -- Entity types: contact, company, document, project, engagement. Relations: works_at, reports_to, related_to, authored, referenced_in. Traversal via `neighborhood()`.
+- **LessonCapture** -- Post-run extraction. Each agent maps to a default collection (e.g., orchestrator->playbooks, evidence-auditor->iso26262).
+- **RAG Pipeline** -- Hybrid search: dense (cosine similarity on embeddings) + sparse (BM25). Fusion via reciprocal rank fusion (k=60).
+
+**Seed playbooks:** ASIL-D staffing, fixed-price conditions, objection handling, delivery gate, RFQ email template.
+
+### 6.6 Memory System
+
+**Per-agent memory:**
+- **Short-term** -- Per-run context, cleared on run completion
+- **Long-term** -- Persistent across runs, capped at 500 entries per agent
+- **Decision log** -- Step-level action/reasoning/outcome audit trail
+
+**Backing:** SQLite `agent_memory` table in `runtime.db` (via `SqliteMemoryStore`).
+
+### 6.7 Inference Routing
+
+**Supported backends:**
+- LM Studio (`localhost:1234`, `/v1/models`)
+- Ollama (`localhost:11434`, `/api/tags`)
+- OpenClaw (via gateway adapter)
+
+**Runtime detection:** Probes backends on startup (3s timeout). Uses the first available.
+
+**Model registry:** SQLite-backed in `runtime.db`. Models tagged by `size_class` and `capabilities`.
+
+**Task-profile-based routing:** Agent definitions declare a `TaskProfile` with objective, constraints, and preferences. The router selects the best available model.
+
+### 6.8 Observability
+
+Package: `@jarvis/observability`
+
+**Metrics tracked:** job duration, queue depth, worker health, model latency, RAG retrieval time, approval funnel, provenance records, webhook ingress, session mode distribution, browser bridge calls, inference cost.
+
+**Telemetry:** OpenTelemetry setup (`initTelemetry`, `shutdownTelemetry`), tracer/meter access.
+
+**Provenance:** Content hashing, signature generation, artifact-level provenance records.
+
+### 6.9 Dashboard
+
+**Port:** 4242 (configurable via `PORT`)
+
+**32 API modules** covering:
+
+| Category | Endpoints |
+|----------|-----------|
+| Agents | List, run, configure agents |
+| Approvals | List pending, approve/reject |
+| Runs | History, details, cancel |
+| Queue | Job queue status, job list |
+| Knowledge | Search, ingest |
+| Entities | Entity graph queries |
+| CRM | Contacts, pipeline, notes |
+| Models | Registry, benchmark, selection |
+| Settings | Config read/write, mode |
+| Daemon | Status, restart, stop |
+| Backup | Create, restore, status |
+| Health | System health report |
+| Workflows | Definitions, execution |
+| Plugins | List, surface inspection |
+| Godmode | Operator chat (session-backed) |
+| Chat | Chat interface with WebSocket streaming |
+
+**Auth:** Bearer token validation. Rate limiting: 10 failed attempts -> 5-min block. Dev mode (empty token) allows unauthenticated access. `/api/health` is always unauthenticated.
+
+### 6.10 Telegram Bot
+
+**Session mode (default):** Messages delivered via OpenClaw session system. Bot is stateless receiver.
+
+**Legacy mode:** Direct Telegram Bot API polling. Enable with `JARVIS_TELEGRAM_MODE=legacy`.
+
+**Commands:** `/help`, `/status`, `/approve`, `/reject`, `/start`, `/stop`, `/logs`
+
+**Behavior:**
+- Rate limiting: 20 messages/minute per chat
+- Retry: 3 attempts with exponential backoff (1s, 2s, 4s)
+- Message truncation: 4096-char Telegram limit
+- Approval polling: every 15s against `runtime.db`
+- Agent notification relay: every 30s
+
+### 6.11 Security
+
+**Network:**
+- Dashboard binds to `127.0.0.1` by default
+- Auth required in production mode
+- Webhook HMAC verification
+
+**Tools:**
+- Process scanning against whitelist
+- Network connection auditing
+- File integrity (SHA-256 baseline + check)
+- Windows Firewall rule management
+- Lockdown mode (standard/maximum)
+
+**Hooks:**
+- PII redaction in replies (API keys, credit cards, GitHub tokens)
+- Capability boundary enforcement (read-only contexts blocked from mutations)
+- Credential scoping per worker type
+
+**Files:**
+- Path allowlist enforcement via `JARVIS_FILES_ALLOWED_ROOTS`
+- Write/patch/copy/move require approval
+
+### 6.12 Office Automation
+
+**Excel:** inspect, transform (column selection/rename/sheet selection), merge (union/append/by-sheet with dedup), extract tables (JSON/CSV/XLSX)
+
+**Word:** inspect, template fill (strict variable checking)
+
+**PowerPoint:** build (4 themes: corporate_clean, minimal_light, minimal_dark, executive_brief), inspect
+
+**Output:** PNG/PDF/HTML/text preview
+
+### 6.13 Desktop Automation
+
+**Windows-specific** via PowerShell:
+- Screenshot (desktop/active_window/window/display/region)
+- Mouse click injection (left/right/middle, screen/window coordinates)
+- Text input (insert/replace/paste mode)
+- Keyboard shortcuts
+- Clipboard read/write
+- Window management (list, focus, layout)
+- Virtual desktops
+- Desktop notifications
+- System metrics (CPU, memory, disk, network, battery, processes)
+- Audio volume control
+- Display settings
+- Power actions
+- Focus mode
+
+---
+
+## 7. Project Structure
+
+```
+jarvis/
+|-- package.json                    # Workspace root, 44 packages, all npm scripts
+|-- tsconfig.json                   # Composite TypeScript build
+|-- tsconfig.base.json              # Shared compiler options + 44 path aliases
+|-- vitest.config.ts                # Unit/integration test config
+|-- vitest.stress.config.ts         # Stress test config (separate)
+|-- .env                            # PORT, LMS_URL, LMS_MODEL
+|-- .env.example                    # Full env var reference
+|-- Dockerfile                      # Container build
+|-- docker-compose.yml              # Multi-service compose
+|-- CLAUDE.md                       # Project instructions for Claude Code
+|-- README.md                       # Project README
+|
+|-- contracts/jarvis/v1/            # jarvis.v1 contract specification
+|   |-- job-catalog.json            # 144 job type definitions
+|   |-- plugin-surface.json         # 19 plugin registrations
+|   |-- common.schema.json          # Shared types (uuid, channel, approval_state, ...)
+|   |-- job-envelope.schema.json    # Job request format
+|   |-- job-result.schema.json      # Job response format
+|   |-- worker-callback.schema.json # Worker callback format
+|   |-- tool-response.schema.json   # Tool response wrapper
+|   |-- review-report.schema.json   # Audit report format
+|   |-- *-job-types.schema.json     # 21 domain-specific job schemas
+|   '-- examples/                   # 145 example job payloads
+|
+|-- packages/
+|   |-- jarvis-shared/              # Base types, OpenClaw SDK, gateway utilities
+|   |-- jarvis-core/                # Policy engine: hooks, approvals, model selection
+|   |-- jarvis-agent-framework/     # Agent runtime, memory, knowledge, entity graph
+|   |-- jarvis-agents/              # 8 active + 15 legacy agent definitions
+|   |   |-- src/definitions/        # Active agent TypeScript definitions
+|   |   |-- src/prompts/            # Active agent system prompts (Markdown)
+|   |   |-- src/legacy/             # 15 archived agents
+|   |   '-- src/data/               # Garden beds + planting calendar (JSON)
+|   |-- jarvis-runtime/             # Daemon, planners, RAG, health, migrations
+|   |-- jarvis-jobs/                # Job queue (submit/claim/heartbeat/callback)
+|   |-- jarvis-dispatch/            # Cross-session messaging
+|   |-- jarvis-scheduler/           # Cron, alerts, workflows, habits
+|   |-- jarvis-supervisor/          # Worker process supervision
+|   |-- jarvis-inference/           # LM Studio / Ollama / OpenClaw routing
+|   |-- jarvis-interpreter/         # Code execution (Python/JS/shell)
+|   |-- jarvis-security/            # Audit, scanning, lockdown
+|   |-- jarvis-system/              # System monitoring
+|   |-- jarvis-voice/               # STT / TTS / wake word
+|   |-- jarvis-device/              # Desktop automation broker
+|   |-- jarvis-observability/       # Metrics, tracing, provenance
+|   |-- jarvis-browser/             # Browser facade + OpenClaw bridge
+|   |-- jarvis-office/              # Office facade (Excel/Word/PPT)
+|   |-- jarvis-files/               # Safe file broker with allowlists
+|   |-- jarvis-agent-plugin/        # Agent lifecycle plugin
+|   |-- jarvis-email-plugin/        # Gmail plugin
+|   |-- jarvis-calendar-plugin/     # Calendar plugin
+|   |-- jarvis-crm-plugin/          # CRM plugin
+|   |-- jarvis-web-plugin/          # Web intelligence plugin
+|   |-- jarvis-document-plugin/     # Document analysis plugin
+|   |-- jarvis-*-worker/ (x17)     # Worker implementations (see sec. 6.3)
+|   |-- jarvis-dashboard/           # React dashboard (Vite, port 4242)
+|   '-- jarvis-telegram/            # Telegram bot service
+|
+|-- tests/                          # 125 test files
+|   |-- *.test.ts                   # Unit + integration tests (71 files)
+|   |-- smoke/                      # Smoke tests (18 files)
+|   '-- stress/                     # Stress tests (40+ files)
+|
+|-- scripts/
+|   |-- jarvis.mjs                  # CLI entrypoint
+|   |-- start.mjs                   # Daemon + dashboard launcher
+|   |-- setup-wizard.mjs            # Interactive setup
+|   |-- setup-jarvis.ts             # TypeScript setup
+|   |-- init-jarvis.ts              # Minimal DB init (CI)
+|   |-- validate-contracts.mjs      # Contract validation
+|   |-- seed-demo.ts                # Demo data seeder
+|   |-- plugin-manager.ts           # Plugin install/list/remove
+|   |-- runtime/                    # OpenClaw bootstrap + smoke harness
+|   '-- ops/                        # Health check, backup, recovery
+|
+|-- docs/                           # 25 markdown files
+|   |-- ARCHITECTURE.md             # System shape + execution planes
+|   |-- CONVERGENCE-ROADMAP.md      # 12 epics, Waves 1-8 complete
+|   |-- RELEASE-GATES.md            # 5 gates (A-E) with pass criteria
+|   |-- ROADMAP.md                  # 3-year quarterly plan
+|   |-- USAGE.md                    # User guide
+|   |-- GLOSSARY.md                 # Canonical vocabulary
+|   |-- THREAT-MODEL.md             # Trust boundaries, attack vectors
+|   |-- OPERATOR-RUNBOOK.md         # Day-to-day operations
+|   |-- specs/                      # Plugin API, device agent, model strategy, workflows
+|   |-- runbooks/                   # Recovery, smoke test procedures
+|   '-- quarters/                   # Quarterly release notes + migration plans
+|
+|-- .claude/
+|   |-- skills/                     # 6 active Claude Code skill files
+|   '-- skills/legacy/              # 8 archived skill files
+|
+'-- ~/.jarvis/                      # Runtime state (created by setup)
+    |-- runtime.db                  # Control plane: runs, approvals, jobs, models, schedules
+    |-- crm.db                      # CRM: contacts, notes, pipeline
+    |-- knowledge.db                # Knowledge: docs, playbooks, entities, RAG index
+    '-- config.json                 # Configuration
+```
+
+---
+
+## 8. API / Integration Reference
+
+### 8.1 Job Queue HTTP Routes
+
+All routes served by the OpenClaw gateway (default `:18789`).
+
+#### POST /jarvis/jobs/claim
+
+Claim the next available job for a worker.
+
+```json
+// Request
+{
+  "worker_id": "email-worker-01",
+  "routes": ["email"],
+  "max_jobs": 1,
+  "lease_duration_seconds": 60
+}
+
+// Response (200)
+{
+  "claim_id": "uuid",
+  "job": { /* JobEnvelope */ }
+}
+
+// Response (204) -- no jobs available
+```
+
+#### POST /jarvis/jobs/heartbeat
+
+Keep-alive for an active job claim.
+
+```json
+// Request
+{
+  "claim_id": "uuid",
+  "worker_id": "email-worker-01",
+  "progress": { "step": 2, "total": 5 }
+}
+
+// Response (200)
+{ "ok": true }
+```
+
+#### POST /jarvis/jobs/callback
+
+Return completed job result.
+
+```json
+// Request (WorkerCallback)
+{
+  "contract_version": "jarvis.v1",
+  "job_id": "uuid",
+  "job_type": "email.send",
+  "attempt": 1,
+  "status": "completed",
+  "summary": "Email sent to client@example.com",
+  "worker_id": "email-worker-01",
+  "structured_output": { /* domain-specific */ },
+  "metrics": {
+    "queued_at": "2026-04-10T09:00:00Z",
+    "started_at": "2026-04-10T09:00:01Z",
+    "finished_at": "2026-04-10T09:00:03Z",
+    "queue_seconds": 1,
+    "run_seconds": 2,
+    "attempt": 1,
+    "worker_id": "email-worker-01"
+  }
+}
+```
+
+### 8.2 Dashboard API
+
+**Base URL:** `http://localhost:4242/api`
+
+**Auth:** `Authorization: Bearer <JARVIS_API_TOKEN>` (not required in dev mode)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/agents` | List all agents with status |
+| POST | `/agents/{id}/run` | Trigger agent run |
+| PATCH | `/agents/{id}` | Update agent config |
+| GET | `/approvals` | List pending approvals |
+| POST | `/approvals/{id}/approve` | Approve action |
+| POST | `/approvals/{id}/reject` | Reject action |
+| GET | `/runs` | List run history |
+| GET | `/runs/{id}` | Run details |
+| POST | `/runs/{id}/cancel` | Cancel run |
+| GET | `/queue/status` | Queue status summary |
+| GET | `/queue/jobs` | List queued jobs |
+| GET | `/knowledge/search?q=...` | Search knowledge base |
+| POST | `/knowledge/ingest` | Ingest document |
+| GET | `/entities` | List entities |
+| GET | `/entities/{id}` | Entity details + neighborhood |
+| GET | `/crm/contacts` | List CRM contacts |
+| POST | `/crm/contacts` | Add contact |
+| GET | `/models` | List registered models |
+| GET | `/health` | Health report (unauthenticated) |
+| GET | `/daemon/status` | Daemon status |
+| POST | `/daemon/restart` | Restart daemon |
+| GET | `/settings` | Get config |
+| PATCH | `/settings` | Update config |
+| POST | `/backup/create` | Create backup |
+| POST | `/backup/restore` | Restore from backup |
+| GET | `/tools` | List registered tools |
+| GET | `/plugins` | List plugins |
+| GET | `/workflows` | List workflow definitions |
+| POST | `/chat` | Chat message |
+| WS | `/chat/stream` | Chat WebSocket stream |
+| POST | `/godmode/chat` | Operator chat (session-backed) |
+
+### 8.3 Plugin Tool Surface
+
+19 plugins expose 100+ tools. Key tools by domain:
+
+| Plugin | Tools |
+|--------|-------|
+| `@jarvis/core` | jarvis_plan, jarvis_run_job, jarvis_get_job, jarvis_list_artifacts, jarvis_request_approval |
+| `@jarvis/jobs` | job_submit, job_status, job_cancel, job_artifacts, job_retry |
+| `@jarvis/dispatch` | dispatch_to_session, dispatch_followup, dispatch_broadcast, dispatch_notify_completion, dispatch_spawn_worker_agent |
+| `@jarvis/email` | email_search, email_read, email_draft, email_send, email_archive, email_trash, email_label, email_forward |
+| `@jarvis/calendar` | calendar_brief, calendar_list_events, calendar_create_event, calendar_find_free, calendar_update_event |
+| `@jarvis/crm` | crm_digest, crm_list_pipeline, crm_search, crm_add_contact, crm_update_contact, crm_add_note, crm_move_stage |
+| `@jarvis/browser` | browser_run_task, browser_extract, browser_capture, browser_download |
+| `@jarvis/office` | office_inspect, office_transform, office_merge_excel, office_fill_docx, office_build_pptx, office_extract_tables, office_preview |
+| `@jarvis/files` | files_inspect, files_read, files_search, files_write, files_patch, files_copy, files_move, files_preview |
+| `@jarvis/device` | device_snapshot, device_screenshot, device_click, device_type, device_hotkey, device_clipboard_get, device_clipboard_set, device_notify, +15 more |
+| `@jarvis/system` | system_monitor_cpu, system_monitor_memory, system_monitor_disk, system_monitor_network, system_monitor_battery, system_list_processes, system_kill_process, system_hardware_info |
+| `@jarvis/inference` | inference_chat, inference_embed, inference_list_models, inference_rag_index, inference_rag_query, inference_batch_submit, inference_batch_status |
+| `@jarvis/scheduler` | scheduler_create_schedule, scheduler_list_schedules, scheduler_delete_schedule, scheduler_create_alert, scheduler_create_workflow, scheduler_run_workflow, scheduler_habit_track, scheduler_habit_status |
+| `@jarvis/interpreter` | interpreter_run_task, interpreter_run_code, interpreter_status |
+| `@jarvis/security` | security_scan_processes, security_whitelist_update, security_network_audit, security_file_integrity_check, security_file_integrity_baseline, security_firewall_rule, security_lockdown |
+| `@jarvis/voice` | voice_listen, voice_transcribe, voice_speak, voice_wake_word_start, voice_wake_word_stop |
+| `@jarvis/web` | web_search_news, web_scrape_profile, web_monitor_page, web_enrich_contact, web_track_jobs, web_competitive_intel |
+| `@jarvis/document` | document_extract, document_classify, document_summarize, document_find_entities, document_compare, document_index, document_batch_process |
+| `@jarvis/agent` | agent_start, agent_step, agent_status, agent_pause, agent_resume, agent_configure |
+
+### 8.4 Slash Commands (OpenClaw)
+
+| Command | Plugin | Description |
+|---------|--------|-------------|
+| `/approve <id> <action>` | @jarvis/core | Resolve approval (approved/rejected/expired/cancelled) |
+| `/dispatch` | @jarvis/dispatch | Send cross-session message |
+| `/followup` | @jarvis/dispatch | Follow up on existing job |
+| `/broadcast` | @jarvis/dispatch | Broadcast to multiple sessions |
+| `/sendto` | @jarvis/dispatch | Send to specific session |
+| `/excel` | @jarvis/office | Excel operations |
+| `/word` | @jarvis/office | Word operations |
+| `/ppt` | @jarvis/office | PowerPoint operations |
+| `/office-status` | @jarvis/office | Office automation status |
+| `/files` | @jarvis/files | File operations |
+| `/browser` | @jarvis/browser | Browser automation |
+| `/device` | @jarvis/device | Desktop automation |
+| `/windows` | @jarvis/device | Window management |
+| `/clipboard` | @jarvis/device | Clipboard operations |
+| `/notify` | @jarvis/device | Desktop notifications |
+| `/system` | @jarvis/system | System monitoring |
+| `/processes` | @jarvis/system | Process management |
+| `/hardware` | @jarvis/system | Hardware info |
+| `/models` | @jarvis/inference | Model listing |
+| `/benchmark` | @jarvis/inference | Model benchmarking |
+| `/schedule` | @jarvis/scheduler | Schedule management |
+| `/interpret` | @jarvis/interpreter | Run automation |
+| `/run-code` | @jarvis/interpreter | Execute code |
+| `/security` | @jarvis/security | Security audit |
+| `/lockdown` | @jarvis/security | System lockdown |
+| `/audit` | @jarvis/security | Run audit |
+| `/voice` | @jarvis/voice | Voice I/O |
+| `/listen` | @jarvis/voice | Capture audio |
+| `/speak` | @jarvis/voice | Text to speech |
+| `/email` | @jarvis/email | Email operations |
+| `/inbox` | @jarvis/email | Inbox overview |
+| `/calendar` | @jarvis/calendar | Calendar operations |
+| `/crm` | @jarvis/crm | CRM operations |
+| `/web` | @jarvis/web | Web intelligence |
+| `/intel` | @jarvis/web | Competitive intelligence |
+| `/document` | @jarvis/document | Document analysis |
+| `/agent` | @jarvis/agent | Agent management |
+
+### 8.5 Contract Schema (jarvis.v1)
+
+**Job Envelope** (simplified):
+
+```typescript
+interface JobEnvelope {
+  contract_version: "jarvis.v1";
+  job_id: string;           // UUID v4
+  type: string;             // e.g., "email.send"
+  session_key: string;
+  requested_by: {
+    channel: Channel;       // telegram | web | cli | api | ...
+    user_id?: string;
+    username?: string;
+  };
+  priority: "low" | "normal" | "high" | "urgent";
+  approval_state: "pending" | "approved" | "rejected" | "expired" | "cancelled" | "not_required";
+  timeout_seconds: number;
+  attempt: number;
+  input: Record<string, unknown>;  // Domain-specific
+  artifacts_in?: ArtifactRef[];
+  retry_policy?: { mode: "never" | "manual" | "exponential"; max_attempts: number; backoff_seconds: number };
+  metadata?: Record<string, unknown>;
+}
+```
+
+**Job Result** (simplified):
+
+```typescript
+interface JobResult {
+  status: "completed" | "failed" | "cancelled";
+  summary: string;
+  structured_output?: Record<string, unknown>;
+  error?: { code: string; message: string; retryable: boolean; field?: string; details?: unknown };
+  logs?: LogEntry[];
+  metrics: Metrics;
+}
+```
+
+### 8.6 External Integrations
+
+| Service | Auth Method | Used By |
+|---------|------------|---------|
+| Gmail API | OAuth2 (client_id, client_secret, refresh_token) | email-worker |
+| Google Calendar API | OAuth2 | calendar-worker |
+| Google Drive API | OAuth2 | drive-worker |
+| Toggl API | API token + workspace ID | time-worker |
+| LM Studio | No auth (localhost) | inference-worker |
+| Ollama | No auth (localhost) | inference-worker |
+| Telegram Bot API | Bot token | jarvis-telegram |
+| Chrome DevTools | Debugging URL (localhost) | browser-worker |
+
+### 8.7 Webhook Ingress
+
+> Webhook ingress (`webhooks.ts`) was eliminated in Wave 1 of convergence. Inbound events now route through the OpenClaw gateway session system.
+
+---
+
+## 9. Troubleshooting
+
+### 9.1 Health Check
+
+```bash
+npm run ops:health
+# or
+curl http://localhost:4242/api/health
+```
+
+Returns `healthy`, `degraded`, or `unhealthy` based on:
+- Database availability (runtime.db, crm.db, knowledge.db)
+- Daemon heartbeat freshness (stale if >30s since last write)
+- Pending approvals and commands
+- Disk free space
+
+### 9.2 Readiness Check
+
+`getReadinessReport()` verifies:
+- `~/.jarvis/` directory exists
+- All three databases exist and are accessible
+- Config is valid
+- Daemon is running (heartbeat fresh)
+- Migrations are current
+- No stale job claims (>10 minutes)
+- No overdue schedules
+
+### 9.3 Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `ECONNREFUSED :1234` | LM Studio not running | Start LM Studio, verify `LMS_URL` |
+| `ECONNREFUSED :11434` | Ollama not running | Start Ollama or remove from config |
+| `ECONNREFUSED :18789` | OpenClaw gateway not running | Start gateway via `npm run runtime:bootstrap` |
+| Daemon shows `unhealthy` | Stale heartbeat (>30s) | Check if daemon process is alive: `npm run jarvis status` |
+| Approval timeout | No operator response within timeout | Increase timeout in hook or respond faster |
+| `PATH_NOT_ALLOWED` | File operation outside allowed roots | Set `JARVIS_FILES_ALLOWED_ROOTS` |
+| `CAPABILITY_BOUNDARY` | Mutating tool called in read-only context | Check context.readOnly flag; use appropriate tool |
+| Job stuck in `running` | Worker crashed without callback | Requeue via expired lease mechanism (15s) or manual `job_retry` |
+| Auth failures on dashboard | Missing or wrong `JARVIS_API_TOKEN` | Set token in env or config; empty = dev mode |
+| Rate limit on Telegram | >20 messages/minute per chat | Reduce message frequency |
+| SQLite `SQLITE_BUSY` | Concurrent writes | WAL mode is enabled; ensure single daemon instance |
+| Stale claims in readiness | Worker claimed but never completed | Claims auto-expire; check worker health |
+| Safe mode active | `StatusWriter.setSafeMode(true)` was called | Investigate reason; restart daemon to exit |
+
+### 9.4 Error Codes
+
+Standardized across all workers:
+
+| Code | Meaning |
+|------|---------|
+| `INVALID_INPUT` | Job input failed schema validation |
+| `PATH_NOT_ALLOWED` | File path outside allowed roots |
+| `FILE_NOT_FOUND` | Target file does not exist |
+| `TIMEOUT` | Job exceeded timeout_seconds |
+| `WORKER_UNAVAILABLE` | No worker registered for route |
+| `APPROVAL_DENIED` | Operator rejected the action |
+| `APPROVAL_TIMEOUT` | Approval window expired |
+| `CAPABILITY_BOUNDARY` | Tool blocked by read-only context |
+| `ECONNREFUSED` | Backend service unreachable |
+| `ETIMEDOUT` | Network timeout |
+| `ENOTFOUND` | DNS resolution failed |
+
+### 9.5 Backup & Recovery
+
+```bash
+# Create backup (databases + config + manifests)
+npm run ops:backup
+
+# Restore (transactional, all-or-nothing)
+npm run ops:recover
+```
+
+Backups are timestamp-named, validated on creation and before restore.
+
+---
+
+## 10. Development
+
+### 10.1 Build & Test
+
+```bash
+npm install                  # Install all workspace dependencies
+npm run build                # TypeScript compilation (tsc -b)
+npm test                     # All tests (vitest, 125 files)
+npm run test:stress          # Stress tests (separate vitest config)
+npm run validate:contracts   # JSON schema validation
+npm run check                # Full pipeline: contracts + tests + build
+npm run check:architecture   # Boundary + hook + credential + convergence tests
+```
+
+### 10.2 Architecture Boundary Tests
+
+`tests/architecture-boundary.test.ts` enforces forbidden import patterns:
+- Plugins must not import from workers directly
+- Workers must not import from plugins
+- Shared layer must not import from runtime
+- No circular dependencies between packages
+
+Run: `npm run check:architecture`
+
+### 10.3 Test Categories
+
+| Category | Count | Config | What it validates |
+|----------|-------|--------|-------------------|
+| Unit + integration | 71 | `vitest.config.ts` | Individual functions, state machines, policies |
+| Smoke | 18 | `vitest.config.ts` | End-to-end lifecycle, approval channels, restart recovery |
+| Stress | 40+ | `vitest.stress.config.ts` | Concurrency, memory pressure, exhaustive input coverage |
+| Architecture | 4 | `vitest.config.ts` | Import boundaries, hook catalog, credential scoping |
+
+### 10.4 Adding a New Job Type
+
+1. Add the type to the appropriate `*-job-types.schema.json` in `contracts/jarvis/v1/`
+2. Add an entry to `job-catalog.json`
+3. Add example payloads in `contracts/jarvis/v1/examples/`
+4. Implement the handler in the appropriate worker's `execute.ts`
+5. Register the tool in the plugin's `index.ts`
+6. Update `JOB_TYPE_NAMES` in `packages/jarvis-shared/src/contracts.ts`
+7. Run `npm run validate:contracts` to verify schema alignment
+8. Run `npm run check` for full validation
+
+### 10.5 Adding a New Agent
+
+1. Create definition in `packages/jarvis-agents/src/definitions/<agent-id>.ts`
+2. Create system prompt in `packages/jarvis-agents/src/prompts/<agent-id>.md`
+3. Register in `ALL_AGENTS` array in `packages/jarvis-agents/src/registry.ts`
+4. Create Claude Code skill file in `.claude/skills/<agent-id>.md`
+5. Map to default knowledge collection in `AGENT_DEFAULT_COLLECTION` (`packages/jarvis-agent-framework/src/lesson-capture.ts`)
+
+### 10.6 Branch & PR Conventions
+
+- Branch from `master`
+- Create PR before merging (never merge directly to master)
+- PR title: short descriptive summary
+- CI runs: `npm run check` (contracts + tests + build)
+
+### 10.7 Docker
+
+```bash
+docker compose up          # Start all services
+docker compose up dashboard # Dashboard only
+```
+
+Dockerfile and docker-compose.yml are present at the project root.
+
+---
+
+## 11. Changelog (Documentation Update)
+
+**2026-04-10:** Generated comprehensive reference from source audit.
+
+### Counts verified against codebase:
+
+| Metric | Value |
+|--------|-------|
+| Packages | 44 |
+| Job types | 144 |
+| Schema families | 27 (21 domain + 6 shared) |
+| Contract examples | 145 |
+| Plugins | 19 |
+| Workers | 17 |
+| Active agents | 8 |
+| Legacy agents | 15 |
+| Test files | 125 |
+| Test cases | 2860+ |
+| Dashboard API modules | 32 |
+| Slash commands | 35+ |
+| Tools | 100+ |
+| SQLite databases | 3 |
+
+### Discrepancies found and corrected in other docs:
+
+| File | Old | New | Field |
+|------|-----|-----|-------|
+| `CLAUDE.md` | 43 packages | 44 | Added @jarvis/observability |
+| `CLAUDE.md` | 92 test files, 2384+ tests | 125 files, 2860+ tests | Test counts |
+| `CLAUDE.md` | 23 schema families | 27 | Schema count |
+| `CLAUDE.md` | 144 examples | 145 | Example count |
+| `CLAUDE.md`, `README.md`, `GLOSSARY.md`, `THREAT-MODEL.md`, `WHAT-JARVIS-IS-NOT.md`, `RELEASE-GATES.md` | 143 job types | 144 | Job type count |
+
+---
+
+## Appendix A: Database Schema Summary
+
+### runtime.db
+
+| Table | Purpose |
+|-------|---------|
+| `agent_commands` | Durable command queue (webhook/manual/schedule triggers) |
+| `approvals` | Approval state machine (pending -> approved/rejected/expired/cancelled) |
+| `run_events` | Immutable run event audit trail |
+| `daemon_heartbeats` | Daemon liveness (UPSERT every 10s) |
+| `notifications` | Outbound notification queue |
+| `schedules` | Durable cron schedules (survives restart) |
+| `agent_memory` | Short-term and persistent agent memory |
+| `audit_log` | Security-sensitive action trail |
+| `settings` | Runtime-configurable settings |
+| `plugin_installs` | Plugin lifecycle tracking |
+| `model_registry` | Discovered local models with capabilities |
+| `model_benchmarks` | Cached benchmark results |
+| `channel_messages` | Message history (best-effort) |
+
+### crm.db
+
+| Table | Purpose |
+|-------|---------|
+| `contacts` | Contact records |
+| `notes` | Contact notes |
+| `stages` | Pipeline stage history |
+| `deals` | Deal pipeline |
+
+**Pipeline stages:** prospect -> qualified -> contacted -> meeting -> proposal -> negotiation -> won | lost | parked
+
+### knowledge.db
+
+| Table | Purpose |
+|-------|---------|
+| `documents` | Knowledge documents across 9 collections |
+| `playbooks` | Reusable playbooks with use_count tracking |
+| `entities` | Entity records (contact, company, document, project, engagement) |
+| `relations` | Entity relationships (works_at, reports_to, authored, ...) |
+| `decisions` | Agent decision logs |
+| `rag_chunks` | RAG vector index chunks |
+
+---
+
+## Appendix B: Agent Schedule Summary
+
+| Agent | Schedule | Cron |
+|-------|----------|------|
+| self-reflection | Sunday 06:00 | `0 6 * * 0` |
+| regulatory-watch | Monday + Thursday 07:00 | `0 7 * * 1,4` |
+| knowledge-curator | Weekdays 06:00 | `0 6 * * 1-5` |
+| evidence-auditor | Monday 09:00 | `0 9 * * 1` |
+| staffing-monitor | Monday 09:00 | `0 9 * * 1` |
+| orchestrator | Manual / event only | -- |
+| proposal-engine | Manual / event only | -- |
+| contract-reviewer | Manual / event only | -- |
+
+---
+
+## Appendix C: Convergence Status
+
+All four primary-path duplication targets from Year 1 are addressed (Waves 1-8 complete):
+
+| Target | Status | Legacy Fallback |
+|--------|--------|-----------------|
+| Webhook ingress | **Eliminated** | `webhooks.ts` deleted |
+| Telegram transport | **Session default** | `JARVIS_TELEGRAM_MODE=legacy` |
+| Operator chat (godmode) | **Session default** | `/api/godmode/legacy` |
+| Browser runtime | **OpenClaw default** | `JARVIS_BROWSER_MODE=legacy` |
+
+See `docs/CONVERGENCE-ROADMAP.md` for the full 12-epic map and `docs/RELEASE-GATES.md` for gate criteria.
+
+---
+
+## Appendix D: Known Gaps
+
+> These are documented limitations, not bugs. See `docs/KNOWN-TRUST-GAPS.md` and `docs/ARCHITECTURE-STATUS.md` for details.
+
+| Gap | Impact | Tracking |
+|-----|--------|----------|
+| Encrypted credentials not implemented | Plaintext in `~/.jarvis/config.json` | Blocks Gate C |
+| Hook registration incomplete | `after_tool_call`, `before_reply`, `on_error` hooks defined but not registered | Awaiting OpenClaw support (Epic 8) |
+| Agent roster empty in ALL_AGENTS | Agent definitions exist but roster wiring TBD | Platform Adoption Roadmap |
+| `check:convergence` not in CI | Convergence tests not automated | Platform Adoption Roadmap |
+| Entity graph canonical_key format unspecified | No validation on key format | -- |
+| Memory long-term cap hardcoded | 500 entries per agent, no config option | -- |
+| RAG chunk size hardcoded | No configurable chunk size parameter | -- |
+| Safe mode exit mechanism undocumented | `setSafeMode(true)` exists but no documented exit path | -- |

--- a/docs/RELEASE-GATES.md
+++ b/docs/RELEASE-GATES.md
@@ -88,7 +88,7 @@ Each gate has objective pass criteria. A gate is either passed or not -- no part
 
 **Pass criteria**:
 
-- [ ] Contract validation passes for all 143 job types (`npm run validate:contracts`).
+- [ ] Contract validation passes for all 144 job types (`npm run validate:contracts`).
 - [ ] Security posture smoke tests pass (`tests/smoke/security-posture.test.ts`).
 - [ ] No `run_command` or `write_file` tool handlers exist in chat surfaces (`packages/jarvis-dashboard/src/api/chat.ts`, `packages/jarvis-telegram/src/`). Grep CI step confirms zero matches.
 - [ ] Auth middleware rate limiting is exercised: IP blocked after 10 failed auth attempts within 5 minutes.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -66,7 +66,7 @@ approval before execution.
 
 **Approval bypass.** Defense-in-depth: the orchestrator enforces approval checks
 before dispatching jobs, and the worker registry has a secondary approval guard
-that rejects unapproved envelopes for critical job types. Of 143 job types, 17
+that rejects unapproved envelopes for critical job types. Of 144 job types, 17
 always require approval and 33 are conditionally gated.
 
 **Action classification.** The action classifier defaults unknown action suffixes

--- a/docs/WHAT-JARVIS-IS-NOT.md
+++ b/docs/WHAT-JARVIS-IS-NOT.md
@@ -16,7 +16,7 @@ Jarvis is domain-focused for automotive safety consulting (ISO 26262, ASPICE, AU
 
 ## Not a Replacement for Human Judgment
 
-High-stakes decisions are approval-gated. Jarvis will not send an email, publish a post, execute a trade, or move a CRM stage without human approval. Of 143 job types, 17 always require approval and 33 are conditionally gated. The system is designed to surface recommendations, not to act unilaterally on consequential actions.
+High-stakes decisions are approval-gated. Jarvis will not send an email, publish a post, execute a trade, or move a CRM stage without human approval. Of 144 job types, 17 always require approval and 33 are conditionally gated. The system is designed to surface recommendations, not to act unilaterally on consequential actions.
 
 ## Not a Distributed System
 

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -1,0 +1,623 @@
+# Jarvis Database Schema Reference
+
+> Full column-level schema for all three SQLite databases.
+> Generated from migration source files: 2026-04-10
+
+All databases use WAL mode and 5s busy timeout:
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA busy_timeout = 5000;
+```
+
+---
+
+## runtime.db (Control Plane)
+
+**Path:** `~/.jarvis/runtime.db`
+**Migrations:** 11 (0001-0011)
+
+### runs
+
+Authoritative current state of agent runs.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `run_id` | TEXT | PRIMARY KEY | UUID |
+| `agent_id` | TEXT | NOT NULL | Agent definition ID |
+| `status` | TEXT | NOT NULL DEFAULT 'queued', CHECK IN (queued, planning, executing, awaiting_approval, completed, failed, cancelled) | Run state |
+| `trigger_kind` | TEXT | | Trigger type (manual, schedule, event, threshold) |
+| `command_id` | TEXT | | Source command |
+| `goal` | TEXT | | Run goal description |
+| `total_steps` | INTEGER | | Plan step count |
+| `current_step` | INTEGER | DEFAULT 0 | Current execution step |
+| `error` | TEXT | | Error message if failed |
+| `started_at` | TEXT | NOT NULL | ISO timestamp |
+| `completed_at` | TEXT | | ISO timestamp |
+| `owner` | TEXT | | Delegating operator |
+| `assignee` | TEXT | | Assigned operator |
+
+**Indexes:** `idx_runs_agent_id`, `idx_runs_status`, `idx_runs_owner`, `idx_runs_assignee`
+
+### approvals
+
+Approval state machine for gated actions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `approval_id` | TEXT | PRIMARY KEY | UUID |
+| `run_id` | TEXT | | Associated run |
+| `agent_id` | TEXT | | Agent requesting approval |
+| `step_no` | INTEGER | | Step number in plan |
+| `action` | TEXT | NOT NULL | Action being approved (e.g., "email.send") |
+| `severity` | TEXT | NOT NULL, CHECK IN (info, warning, critical) | Risk level |
+| `payload_json` | TEXT | | Action payload |
+| `status` | TEXT | NOT NULL DEFAULT 'pending', CHECK IN (pending, approved, rejected, expired) | Approval state |
+| `requested_at` | TEXT | NOT NULL | ISO timestamp |
+| `resolved_at` | TEXT | | Resolution time |
+| `resolved_by` | TEXT | | Resolver identity |
+| `resolution_note` | TEXT | | Resolution comment |
+| `assignee` | TEXT | | Delegated operator |
+| `delegated_by` | TEXT | | Who delegated |
+| `delegation_note` | TEXT | | Delegation reason |
+
+**Indexes:** `idx_approvals_run_id`, `idx_approvals_status`, `idx_approvals_assignee`
+
+### agent_commands
+
+Durable command queue for agent triggers.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `command_id` | TEXT | PRIMARY KEY | UUID |
+| `command_type` | TEXT | NOT NULL | Command type |
+| `target_agent_id` | TEXT | | Target agent |
+| `target_run_id` | TEXT | | Target run |
+| `payload_json` | TEXT | | Command payload |
+| `status` | TEXT | NOT NULL DEFAULT 'queued', CHECK IN (queued, claimed, completed, failed, cancelled) | State |
+| `priority` | INTEGER | NOT NULL DEFAULT 0 | Priority (higher = first) |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `claimed_at` | TEXT | | Claim time |
+| `completed_at` | TEXT | | Completion time |
+| `created_by` | TEXT | | Source identity |
+| `idempotency_key` | TEXT | UNIQUE | Dedup key |
+
+**Indexes:** `idx_agent_commands_status_priority (status, priority DESC)`
+
+### run_events
+
+Immutable audit trail for run execution.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `event_id` | TEXT | PRIMARY KEY | UUID |
+| `run_id` | TEXT | NOT NULL | Parent run |
+| `agent_id` | TEXT | | Agent ID |
+| `event_type` | TEXT | NOT NULL | Event type |
+| `step_no` | INTEGER | | Plan step |
+| `action` | TEXT | | Action name |
+| `payload_json` | TEXT | | Event data |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_run_events_run_id`
+
+### daemon_heartbeats
+
+Daemon liveness tracking (UPSERT every 10s).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `daemon_id` | TEXT | PRIMARY KEY | Daemon instance ID |
+| `pid` | INTEGER | | Process ID |
+| `host` | TEXT | | Hostname |
+| `version` | TEXT | | Jarvis version |
+| `status` | TEXT | | Daemon status |
+| `last_seen_at` | TEXT | NOT NULL | Last heartbeat time |
+| `current_run_id` | TEXT | | Active run |
+| `current_agent_id` | TEXT | | Active agent |
+| `details_json` | TEXT | | StatusWriter payload |
+
+### notifications
+
+Outbound notification queue.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `notification_id` | TEXT | PRIMARY KEY | UUID |
+| `channel` | TEXT | NOT NULL | Target channel (telegram, dashboard) |
+| `kind` | TEXT | | Notification type |
+| `payload_json` | TEXT | | Content |
+| `status` | TEXT | NOT NULL DEFAULT 'pending', CHECK IN (pending, sent, failed) | State |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `delivered_at` | TEXT | | Delivery time |
+
+**Indexes:** `idx_notifications_status`
+
+### schedules
+
+Durable cron schedules (survives restart).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `schedule_id` | TEXT | PRIMARY KEY | UUID |
+| `job_type` | TEXT | NOT NULL | Job to fire |
+| `input_json` | TEXT | | Job input |
+| `cron_expression` | TEXT | | 5-field cron |
+| `next_fire_at` | TEXT | | Next fire time |
+| `enabled` | INTEGER | NOT NULL DEFAULT 1 | Active flag |
+| `scope_group` | TEXT | | Schedule group |
+| `label` | TEXT | | Human label |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `last_fired_at` | TEXT | | Last fire time |
+
+**Indexes:** `idx_schedules_next_fire (next_fire_at, enabled)`
+
+### agent_memory
+
+Per-agent persistent memory.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `memory_id` | TEXT | PRIMARY KEY | UUID |
+| `agent_id` | TEXT | NOT NULL | Owner agent |
+| `memory_type` | TEXT | NOT NULL, CHECK IN (short_term, long_term) | Memory kind |
+| `key` | TEXT | NOT NULL | Memory key |
+| `value_json` | TEXT | | Memory value |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `expires_at` | TEXT | | Expiry (short_term) |
+
+**Indexes:** `idx_agent_memory_agent_type (agent_id, memory_type)`
+
+### audit_log
+
+Security-sensitive action trail.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `audit_id` | TEXT | PRIMARY KEY | UUID |
+| `actor_type` | TEXT | NOT NULL | "dashboard", "webhook", "telegram" |
+| `actor_id` | TEXT | | e.g., "admin:abcd" |
+| `action` | TEXT | NOT NULL | e.g., "approval.approved" |
+| `target_type` | TEXT | | Resource type |
+| `target_id` | TEXT | | Resource ID |
+| `payload_json` | TEXT | | Context data |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_audit_log_created_at`
+
+### settings
+
+Runtime-configurable key-value settings.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `key` | TEXT | PRIMARY KEY | Setting key |
+| `value_json` | TEXT | | JSON value |
+| `updated_at` | TEXT | NOT NULL | Last update |
+
+### plugin_installs
+
+Plugin lifecycle tracking.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `plugin_id` | TEXT | PRIMARY KEY | Plugin identifier |
+| `version` | TEXT | | Installed version |
+| `install_path` | TEXT | | Filesystem path |
+| `installed_at` | TEXT | NOT NULL | Install time |
+| `installed_by` | TEXT | | Installer identity |
+| `status` | TEXT | NOT NULL DEFAULT 'active', CHECK IN (active, disabled, failed, uninstalled) | State |
+| `manifest_json` | TEXT | | Plugin manifest |
+
+### model_registry
+
+Discovered local LLM models.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `model_id` | TEXT | NOT NULL | Model identifier |
+| `runtime` | TEXT | NOT NULL | Runtime (lmstudio, ollama, openclaw) |
+| `capabilities_json` | TEXT | | Model capabilities |
+| `limits_json` | TEXT | | Model limits |
+| `tags_json` | TEXT | | Tags |
+| `discovered_at` | TEXT | | First discovery |
+| `last_seen_at` | TEXT | | Last seen |
+| `enabled` | INTEGER | NOT NULL DEFAULT 1 | Active flag |
+
+**Primary Key:** `(runtime, model_id)` composite
+
+### model_benchmarks
+
+Cached benchmark results.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `benchmark_id` | TEXT | PRIMARY KEY | UUID |
+| `model_id` | TEXT | NOT NULL | Model tested |
+| `runtime` | TEXT | | Runtime |
+| `benchmark_type` | TEXT | | Benchmark type |
+| `latency_ms` | REAL | | Response latency |
+| `tokens_per_sec` | REAL | | Generation speed |
+| `json_success` | REAL | | JSON output success rate |
+| `tool_call_success` | REAL | | Tool call success rate |
+| `notes_json` | TEXT | | Additional notes |
+| `measured_at` | TEXT | NOT NULL | Measurement time |
+
+### channel_threads
+
+Message thread tracking for multi-platform communication.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `thread_id` | TEXT | PRIMARY KEY | UUID |
+| `channel` | TEXT | NOT NULL | Channel (telegram, web, api) |
+| `external_id` | TEXT | | Platform thread ID |
+| `subject` | TEXT | | Thread subject |
+| `metadata_json` | TEXT | | Additional metadata |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `updated_at` | TEXT | NOT NULL | ISO timestamp |
+| `status` | TEXT | NOT NULL DEFAULT 'active', CHECK IN (active, resolved, archived) | Thread state |
+
+**Indexes:** `idx_channel_threads_channel`, `idx_channel_threads_ext (channel, external_id) UNIQUE`, `idx_channel_threads_status`, `idx_channel_threads_channel_status`
+
+### channel_messages
+
+Individual messages within threads.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `message_id` | TEXT | PRIMARY KEY | UUID |
+| `thread_id` | TEXT | NOT NULL, FK channel_threads | Parent thread |
+| `channel` | TEXT | NOT NULL | Channel |
+| `external_id` | TEXT | | Platform message ID |
+| `direction` | TEXT | NOT NULL, CHECK IN (inbound, outbound) | Message direction |
+| `content_preview` | TEXT | | Truncated preview |
+| `content_full` | TEXT | | Full message content |
+| `sender` | TEXT | | Sender identity |
+| `command_id` | TEXT | | Linked command |
+| `run_id` | TEXT | | Linked run |
+| `approval_id` | TEXT | | Linked approval |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_channel_messages_thread`, `idx_channel_messages_command`, `idx_channel_messages_run`, `idx_channel_messages_approval`
+
+### artifact_deliveries
+
+Track artifact delivery to channels.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `delivery_id` | TEXT | PRIMARY KEY | UUID |
+| `run_id` | TEXT | NOT NULL | Source run |
+| `thread_id` | TEXT | FK channel_threads | Target thread |
+| `message_id` | TEXT | FK channel_messages | Delivery message |
+| `channel` | TEXT | NOT NULL | Channel |
+| `artifact_type` | TEXT | | Artifact type |
+| `content_preview` | TEXT | | Preview |
+| `status` | TEXT | NOT NULL DEFAULT 'pending', CHECK IN (pending, delivered, failed) | State |
+| `delivered_at` | TEXT | | Delivery time |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_artifact_deliveries_run`, `idx_artifact_deliveries_thread`
+
+### delivery_attempts
+
+Retry tracking for artifact deliveries.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `attempt_id` | TEXT | PRIMARY KEY | UUID |
+| `delivery_id` | TEXT | NOT NULL, FK artifact_deliveries | Parent delivery |
+| `attempted_at` | TEXT | NOT NULL | Attempt time |
+| `success` | INTEGER | NOT NULL DEFAULT 0 | Success flag |
+| `error` | TEXT | | Error message |
+
+**Indexes:** `idx_delivery_attempts_delivery`
+
+### provenance_traces
+
+Regulated audit compliance with HMAC signatures.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `record_id` | TEXT | PRIMARY KEY | UUID |
+| `job_id` | TEXT | NOT NULL | Job |
+| `job_type` | TEXT | NOT NULL | Job type |
+| `agent_id` | TEXT | | Agent |
+| `run_id` | TEXT | | Run |
+| `input_hash` | TEXT | NOT NULL | SHA-256 of input |
+| `output_hash` | TEXT | NOT NULL | SHA-256 of output |
+| `trace_id` | TEXT | | Correlation trace |
+| `sequence` | INTEGER | NOT NULL | Order in chain |
+| `prev_signature` | TEXT | | Previous signature |
+| `signature` | TEXT | NOT NULL | HMAC-SHA256 |
+| `signed_at` | TEXT | NOT NULL | Signature time |
+
+**Indexes:** `idx_prov_job`, `idx_prov_agent`, `idx_prov_run`, `idx_prov_sequence (run_id, sequence)`, `idx_prov_trace`
+
+### jobs
+
+Job execution tracking.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `job_id` | TEXT | PRIMARY KEY | UUID |
+| `run_id` | TEXT | FK runs | Parent run |
+| `job_type` | TEXT | NOT NULL | Job type |
+| `status` | TEXT | NOT NULL DEFAULT 'queued' | Job state |
+| `priority` | INTEGER | NOT NULL DEFAULT 0 | Priority |
+| `input_json` | TEXT | | Job input |
+| `output_json` | TEXT | | Job result |
+| `error_json` | TEXT | | Error details |
+| `worker_id` | TEXT | | Executing worker |
+| `created_at` | TEXT | NOT NULL DEFAULT datetime('now') | Creation time |
+| `claimed_at` | TEXT | | Claim time |
+| `completed_at` | TEXT | | Completion time |
+
+**Indexes:** `idx_jobs_run_id`, `idx_jobs_status`
+
+### decision_entity_links
+
+Links decisions to entities for knowledge graph.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `link_id` | TEXT | PRIMARY KEY | UUID |
+| `decision_id` | TEXT | NOT NULL | Decision |
+| `entity_id` | TEXT | NOT NULL | Entity |
+| `link_type` | TEXT | NOT NULL | Relationship type |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_del_decision`, `idx_del_entity`
+
+### canonical_aliases
+
+Entity name aliases for deduplication.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `alias_id` | TEXT | PRIMARY KEY | UUID |
+| `canonical_key` | TEXT | NOT NULL | Canonical entity key |
+| `alias_key` | TEXT | NOT NULL | Alternative name |
+| `entity_type` | TEXT | NOT NULL | Entity type |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_ca_canonical`, `idx_ca_alias`
+
+---
+
+## crm.db (CRM Pipeline)
+
+**Path:** `~/.jarvis/crm.db`
+**Migrations:** 1 (crm_0001)
+
+### contacts
+
+Sales pipeline contacts.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | TEXT | PRIMARY KEY | UUID |
+| `name` | TEXT | NOT NULL | Full name |
+| `company` | TEXT | NOT NULL | Company name |
+| `role` | TEXT | | Job title |
+| `email` | TEXT | | Email address |
+| `linkedin_url` | TEXT | | LinkedIn URL |
+| `source` | TEXT | | Lead source |
+| `score` | INTEGER | DEFAULT 0 | Engagement score (0-100) |
+| `stage` | TEXT | DEFAULT 'prospect' | Pipeline stage |
+| `tags` | TEXT | | JSON array of tags |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `updated_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Valid stages:** prospect, qualified, contacted, meeting, proposal, negotiation, won, lost, parked
+
+### notes
+
+Contact interaction notes.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | TEXT | PRIMARY KEY | UUID |
+| `contact_id` | TEXT | FK contacts | Parent contact |
+| `note` | TEXT | | Note content |
+| `note_type` | TEXT | DEFAULT 'general' | call, email, meeting, observation, proposal, general |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+### stage_history
+
+Pipeline stage transitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | TEXT | PRIMARY KEY | UUID |
+| `contact_id` | TEXT | FK contacts | Contact |
+| `from_stage` | TEXT | | Previous stage |
+| `to_stage` | TEXT | | New stage |
+| `moved_at` | TEXT | NOT NULL | Transition time |
+| `note` | TEXT | | Reason for move |
+
+### campaigns
+
+Email campaign definitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | TEXT | PRIMARY KEY | UUID |
+| `name` | TEXT | NOT NULL | Campaign name |
+| `type` | TEXT | NOT NULL DEFAULT 'cold_outreach' | Campaign type |
+| `status` | TEXT | NOT NULL DEFAULT 'draft' | State |
+| `sequence_count` | INTEGER | NOT NULL DEFAULT 3 | Email count in sequence |
+| `delay_days` | INTEGER | NOT NULL DEFAULT 4 | Days between emails |
+| `subject_template` | TEXT | NOT NULL DEFAULT '' | Subject template |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `updated_at` | TEXT | NOT NULL | ISO timestamp |
+
+### campaign_recipients
+
+Campaign enrollment tracking.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `campaign_id` | TEXT | NOT NULL, FK campaigns | Campaign |
+| `contact_id` | TEXT | NOT NULL | Contact |
+| `email` | TEXT | NOT NULL | Recipient email |
+| `current_step` | INTEGER | NOT NULL DEFAULT 0 | Current sequence step |
+| `status` | TEXT | NOT NULL DEFAULT 'enrolled' | enrolled, completed, unsubscribed, bounced |
+| `enrolled_at` | TEXT | NOT NULL | Enrollment time |
+| `last_sent_at` | TEXT | | Last email sent |
+| `last_status_at` | TEXT | NOT NULL | Last status change |
+
+**Primary Key:** `(campaign_id, contact_id)` composite
+**Indexes:** `idx_recipients_campaign`, `idx_recipients_status`
+
+---
+
+## knowledge.db (Knowledge Store)
+
+**Path:** `~/.jarvis/knowledge.db`
+**Migrations:** 1 (knowledge_0001)
+
+### documents
+
+Knowledge documents across 9 collections.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `doc_id` | TEXT | PRIMARY KEY | UUID |
+| `collection` | TEXT | NOT NULL | lessons, playbooks, case-studies, contracts, proposals, iso26262, regulatory, meetings, garden |
+| `title` | TEXT | NOT NULL | Document title |
+| `content` | TEXT | NOT NULL | Full content |
+| `tags` | TEXT | | JSON array of tags |
+| `source_agent_id` | TEXT | | Creating agent |
+| `source_run_id` | TEXT | | Creating run |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `updated_at` | TEXT | NOT NULL | ISO timestamp |
+
+### playbooks
+
+Reusable process playbooks.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `playbook_id` | TEXT | PRIMARY KEY | UUID |
+| `title` | TEXT | NOT NULL | Playbook title |
+| `category` | TEXT | NOT NULL | proposal, objection, delivery, sales, engagement |
+| `body` | TEXT | NOT NULL | Playbook content |
+| `tags` | TEXT | | JSON array of tags |
+| `use_count` | INTEGER | DEFAULT 0 | Usage counter |
+| `last_used_at` | TEXT | | Last usage time |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+### entities
+
+Named entities in the knowledge graph.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `entity_id` | TEXT | PRIMARY KEY | UUID |
+| `entity_type` | TEXT | NOT NULL | contact, company, document, project, engagement, other |
+| `name` | TEXT | NOT NULL | Entity name |
+| `canonical_key` | TEXT | UNIQUE | Dedup key |
+| `attributes` | TEXT | | JSON attributes |
+| `seen_by` | TEXT | | JSON array of agent IDs |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+| `updated_at` | TEXT | NOT NULL | ISO timestamp |
+
+### relations
+
+Entity relationships.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `relation_id` | TEXT | PRIMARY KEY | UUID |
+| `from_entity_id` | TEXT | NOT NULL | Source entity |
+| `to_entity_id` | TEXT | NOT NULL | Target entity |
+| `kind` | TEXT | NOT NULL | works_at, reports_to, related_to, authored, referenced_in, etc. |
+| `attributes` | TEXT | | JSON attributes |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+### decisions
+
+Agent decision audit log.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `decision_id` | TEXT | PRIMARY KEY | UUID |
+| `agent_id` | TEXT | NOT NULL | Deciding agent |
+| `run_id` | TEXT | NOT NULL | Parent run |
+| `step` | INTEGER | NOT NULL | Plan step |
+| `action` | TEXT | NOT NULL | Action taken |
+| `reasoning` | TEXT | NOT NULL | Decision reasoning |
+| `outcome` | TEXT | NOT NULL | Result |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_decisions_agent`, `idx_decisions_run (agent_id, run_id)`
+
+### entity_provenance
+
+Entity change tracking.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `provenance_id` | TEXT | PRIMARY KEY | UUID |
+| `entity_id` | TEXT | NOT NULL | Entity |
+| `change_type` | TEXT | NOT NULL | created, updated, merged, deleted |
+| `agent_id` | TEXT | NOT NULL | Acting agent |
+| `run_id` | TEXT | | Source run |
+| `step_no` | INTEGER | | Plan step |
+| `action` | TEXT | | Action |
+| `changed_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_prov_entity`, `idx_prov_agent`
+
+### memory
+
+Agent memory entries (knowledge.db copy).
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `entry_id` | TEXT | PRIMARY KEY | UUID |
+| `agent_id` | TEXT | NOT NULL | Agent |
+| `run_id` | TEXT | NOT NULL | Run |
+| `kind` | TEXT | NOT NULL, CHECK IN (short_term, long_term) | Memory kind |
+| `content` | TEXT | NOT NULL | Memory content |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_memory_agent (agent_id, kind)`
+
+### embedding_chunks
+
+RAG vector index chunks.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `chunk_id` | TEXT | PRIMARY KEY | UUID |
+| `doc_id` | TEXT | NOT NULL | Parent document |
+| `chunk_text` | TEXT | NOT NULL | Text chunk |
+| `embedding` | BLOB | NOT NULL | Vector embedding |
+| `chunk_index` | INTEGER | NOT NULL | Chunk position |
+| `created_at` | TEXT | NOT NULL | ISO timestamp |
+
+**Indexes:** `idx_chunks_doc`
+
+### agent_runs (legacy)
+
+Legacy run tracking, kept for backward compatibility.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `run_id` | TEXT | PRIMARY KEY | UUID |
+| `agent_id` | TEXT | NOT NULL | Agent |
+| `trigger_kind` | TEXT | NOT NULL | Trigger type |
+| `trigger_data` | TEXT | | Trigger payload |
+| `goal` | TEXT | NOT NULL | Run goal |
+| `status` | TEXT | NOT NULL | Run state |
+| `current_step` | INTEGER | DEFAULT 0 | Current step |
+| `total_steps` | INTEGER | DEFAULT 0 | Total steps |
+| `plan_json` | TEXT | | Plan JSON |
+| `started_at` | TEXT | NOT NULL | Start time |
+| `updated_at` | TEXT | NOT NULL | Last update |
+| `completed_at` | TEXT | | Completion time |
+| `error` | TEXT | | Error message |
+
+**Indexes:** `idx_runs_agent`

--- a/docs/reference/state-machines.md
+++ b/docs/reference/state-machines.md
@@ -1,0 +1,359 @@
+# Jarvis State Machines & Workflows Reference
+
+> All state transitions and workflow definitions.
+> Generated from source: 2026-04-10
+
+---
+
+## 1. Run State Machine
+
+**Enforced by:** `RunStore` in `packages/jarvis-runtime/src/run-store.ts`
+**Table:** `runs` in `runtime.db`
+
+```
+                    +-----------+
+                    |  queued   |
+                    +-----+-----+
+                          |
+                    +-----v-----+
+              +---->| planning  |<----+
+              |     +-----+-----+    |
+              |           |          |
+              |     +-----v--------+ |
+              |     | executing    |-+
+              |     +-----+--------+
+              |           |
+              |     +-----v-----------+
+              +---->|awaiting_approval|
+                    +-----+-----------+
+                          |
+                +---------+---------+
+                |         |         |
+          +-----v-+ +----v---+ +---v------+
+          |completed| | failed | |cancelled |
+          +--------+ +--------+ +----------+
+```
+
+### Valid Transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| `queued` | `planning` | Agent dequeued, planner starts |
+| `queued` | `cancelled` | Manual cancel before start |
+| `planning` | `executing` | Plan approved or auto-approved |
+| `planning` | `awaiting_approval` | Plan requires operator approval |
+| `planning` | `failed` | Planner error |
+| `planning` | `cancelled` | Manual cancel |
+| `executing` | `awaiting_approval` | Step requires approval |
+| `executing` | `completed` | All steps finished |
+| `executing` | `failed` | Step error, no retries |
+| `executing` | `cancelled` | Manual cancel |
+| `awaiting_approval` | `executing` | Approval granted |
+| `awaiting_approval` | `failed` | Approval rejected or timeout |
+| `awaiting_approval` | `cancelled` | Manual cancel |
+
+**Terminal states:** `completed`, `failed`, `cancelled`
+
+### Run Events Emitted
+
+Each transition writes to `run_events` table:
+- `run.queued` -- Run created
+- `run.planning_started` -- Planner invoked
+- `run.plan_ready` -- Plan generated
+- `run.step_started` -- Step execution begins
+- `run.step_completed` -- Step finished
+- `run.approval_requested` -- Waiting for approval
+- `run.approval_resolved` -- Approval received
+- `run.completed` -- All steps done
+- `run.failed` -- Error occurred
+- `run.cancelled` -- Manual cancellation
+
+---
+
+## 2. Approval State Machine
+
+**Enforced by:** approval logic in `packages/jarvis-runtime/src/`
+**Table:** `approvals` in `runtime.db`
+
+```
+              +----------+
+              |  pending |
+              +----+-----+
+                   |
+          +--------+--------+
+          |        |        |
+    +-----v--+ +---v----+ +-v-------+
+    |approved | |rejected| |expired  |
+    +---------+ +--------+ +---------+
+```
+
+### Valid Transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| `pending` | `approved` | Operator approves via Telegram, Dashboard, or API |
+| `pending` | `rejected` | Operator rejects |
+| `pending` | `expired` | Timeout reached (default 4h, configurable per hook) |
+
+**Terminal states:** `approved`, `rejected`, `expired`
+
+### Operations
+
+| Operation | Function | Description |
+|-----------|----------|-------------|
+| Request | `requestApproval()` | Creates approval in `pending` state |
+| Resolve | `resolveApproval(id, status, resolvedBy)` | Transitions to approved/rejected/expired |
+| Delegate | `delegateApproval(id, assignee, delegatedBy, note)` | Assigns to different operator |
+| Wait | `waitForApproval(id, timeoutMs)` | Polls until resolved or timeout |
+
+### Timeout Behavior
+
+| Hook | Timeout | On Expire |
+|------|---------|-----------|
+| Built-in approval (exec, apply_patch, browser) | 300s (5m) | deny |
+| Domain approval (email_send, crm_move_stage) | 600s (10m) | deny |
+| Dashboard approvals | 14400s (4h) | fail run immediately |
+
+### Approval Metrics
+
+`getApprovalMetrics()` returns:
+- `total`, `approved`, `rejected`, `expired`, `pending` counts
+- `rejection_rate` -- percentage of rejections
+- `avg_latency_ms` -- average time to resolve
+- `by_action` -- rejection rate per action type
+- `by_severity` -- breakdown by severity level
+
+---
+
+## 3. Job Status Machine
+
+**Table:** `jobs` in `runtime.db` (migration 0011)
+
+```
+           +--------+
+           | queued |
+           +---+----+
+               |
+           +---v-----+
+           | running  |
+           +---+------+
+               |
+     +---------+----------+
+     |         |          |
++----v----+ +--v------+ +-v-----------+
+|completed| | failed  | |awaiting_    |
++---------+ +---------+ |approval     |
+                         +------+------+
+                                |
+                      +---------+--------+
+                      |         |        |
+                +-----v-+ +----v---+ +--v-------+
+                |completed| | failed | |cancelled |
+                +---------+ +--------+ +----------+
+```
+
+### Valid Transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| `queued` | `running` | Worker claims job |
+| `queued` | `completed` | Instant completion (mock) |
+| `queued` | `failed` | Claim error |
+| `queued` | `cancelled` | Manual cancel |
+| `running` | `completed` | Worker callback (success) |
+| `running` | `failed` | Worker callback (error) |
+| `running` | `cancelled` | Manual cancel |
+| `running` | `awaiting_approval` | Action needs approval |
+| `awaiting_approval` | `completed` | Approved + executed |
+| `awaiting_approval` | `failed` | Rejected |
+| `awaiting_approval` | `cancelled` | Cancel |
+
+**Terminal states:** `completed`, `failed`, `cancelled`
+
+---
+
+## 4. Command Status Machine
+
+**Table:** `agent_commands` in `runtime.db`
+
+```
+         +--------+
+         | queued |
+         +---+----+
+             |
+         +---v-----+
+         | claimed  |
+         +---+------+
+             |
+     +-------+-------+
+     |               |
++----v-----+   +----v---+
+| completed|   | failed |
++----------+   +--------+
+```
+
+### Valid Transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| `queued` | `claimed` | Daemon picks up command |
+| `queued` | `cancelled` | Manual cancel |
+| `claimed` | `completed` | Run finished |
+| `claimed` | `failed` | Run error |
+
+**Terminal states:** `completed`, `failed`, `cancelled`
+
+---
+
+## 5. SubGoal State Machine (Orchestrator DAG)
+
+**Defined in:** `packages/jarvis-runtime/src/orchestration-types.ts`
+
+```
+         +---------+
+         | pending |
+         +----+----+
+              |
+     +--------+--------+
+     |                  |
++----v----+       +----v----+
+| running |       | skipped |
++----+----+       +---------+
+     |
++----+--------+
+|             |
++--v------+ +-v------+
+|completed| | failed |
++---------+ +--------+
+```
+
+### Valid Transitions
+
+| From | To | Trigger |
+|------|----|---------|
+| `pending` | `running` | All dependencies completed |
+| `pending` | `skipped` | Dependency failed (cascade) |
+| `running` | `completed` | Agent run succeeded |
+| `running` | `failed` | Agent run failed |
+
+**Terminal states:** `completed`, `failed`, `skipped`
+
+**JobGraph status:** `planning` -> `executing` -> `completed` | `failed`
+
+---
+
+## 6. Notification Status Machine
+
+```
++--------+     +------+
+| pending | --> | sent |
++----+----+     +------+
+     |
++----v----+
+| failed  |
++---------+
+```
+
+---
+
+## 7. Channel Thread Lifecycle
+
+```
++--------+     +----------+     +----------+
+| active | --> | resolved | --> | archived |
++--------+     +----------+     +----------+
+```
+
+---
+
+## 8. Plugin Lifecycle
+
+```
++--------+  <-->  +----------+
+| active |        | disabled |
++---+----+        +----+-----+
+    |                  |
+    +------+  +--------+
+           |  |
+      +----v--v-+     +-------------+
+      | failed  |     | uninstalled |
+      +---------+     +-------------+
+```
+
+---
+
+## 9. V1 Workflow Definitions
+
+**Source:** `packages/jarvis-runtime/src/workflows.ts`
+
+### contract-review
+
+- **Agents:** contract-reviewer
+- **Inputs:** document (file), jurisdiction (select: EU|US|UK|Other)
+- **Outputs:** recommendation, risks (list), clause_analysis (table), next_actions (list)
+- **Safety:** outbound_default=draft, preview_recommended=true, retry_safe=true
+
+### rfq-analysis
+
+- **Agents:** evidence-auditor, proposal-engine
+- **Inputs:** document (file), scope (select: Full audit|Gap analysis only|Quote only)
+- **Outputs:** summary, gap_matrix (table), recommendations (list)
+- **Safety:** outbound_default=draft, preview_recommended=true, retry_safe=true
+
+### staffing-check
+
+- **Agents:** staffing-monitor
+- **Inputs:** period (select: This week|Next 2 weeks|This month|This quarter)
+- **Outputs:** utilization, gaps (list)
+- **Safety:** outbound_default=blocked, retry_safe=true
+
+### weekly-report
+
+- **Agents:** evidence-auditor, staffing-monitor, regulatory-watch
+- **Inputs:** week (date, defaults to current week)
+- **Outputs:** summary, action_items (list)
+- **Safety:** outbound_default=draft, retry_safe=true
+
+### meeting-ingestion
+
+- **Agents:** knowledge-curator
+- **Inputs:** recording (file), engagement (text, optional)
+- **Outputs:** minutes (document), action_items (list), attendees (list)
+- **Safety:** outbound_default=blocked, retry_safe=true
+
+### invoice-generation
+
+- **Agents:** proposal-engine
+- **Inputs:** engagement (text), milestone (text, optional)
+- **Outputs:** invoice (document), cover_email (text)
+- **Safety:** outbound_default=draft, preview_recommended=true, retry_safe=true
+
+### document-ingestion
+
+- **Agents:** knowledge-curator
+- **Inputs:** document (file), collection (select: proposals|case-studies|contracts|playbooks|iso26262|regulatory|meetings)
+- **Outputs:** ingestion_log, entities (list, optional)
+- **Safety:** outbound_default=blocked, retry_safe=true
+
+### regulatory-scan
+
+- **Agents:** regulatory-watch
+- **Inputs:** standards (text, optional, defaults to all)
+- **Outputs:** findings (list), digest (document, optional)
+- **Safety:** outbound_default=blocked, retry_safe=true
+
+### self-review
+
+- **Agents:** self-reflection
+- **Inputs:** period_days (text, defaults to "7")
+- **Outputs:** health_score (0-100), proposals (list), report (document)
+- **Safety:** outbound_default=blocked, retry_safe=true
+
+### Workflow Safety Rules
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outbound_default` | `"draft"` \| `"blocked"` | Default outbound action |
+| `preview_recommended` | boolean | Show preview before delivery |
+| `retry_safe` | boolean | Safe to retry without side effects |
+| `retry_requires_approval` | boolean | Re-run needs approval |

--- a/docs/reference/tool-reference.md
+++ b/docs/reference/tool-reference.md
@@ -1,0 +1,1518 @@
+# Jarvis Tool Reference
+
+> Complete parameter documentation for all 100+ tools across 19 plugins.
+> Generated from source: 2026-04-10 | Contract version: `jarvis.v1`
+
+---
+
+## @jarvis/core
+
+### jarvis_plan
+
+Summarize the recommended Jarvis execution path for a goal.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `goal` | string | yes | -- | Goal to plan for (min length 1) |
+| `preferredCapabilities` | string[] | no | -- | Preferred capabilities |
+| `mustUseApprovals` | boolean | no | -- | Whether approvals are mandatory |
+
+**Approval:** No
+
+### jarvis_run_job
+
+Queue a typed Jarvis worker job against the shared broker.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `type` | string (job type literal) | yes | -- | e.g., `"email.send"`, `"system.monitor_cpu"` |
+| `input` | Record<string, unknown> | yes | -- | Job input payload |
+| `artifactIds` | string[] | no | -- | Input artifact IDs |
+| `priority` | `"low"` \| `"normal"` \| `"high"` \| `"urgent"` | no | `"normal"` | Job priority |
+| `approvalId` | string | no | -- | Associated approval ID |
+
+**Approval:** Conditional (if approvalId present)
+
+### jarvis_get_job
+
+Return a Jarvis job summary and current state.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobId` | string (UUID) | yes | -- | Job ID to query |
+
+**Approval:** No
+
+### jarvis_list_artifacts
+
+List artifacts for a job or across all tracked jobs.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobId` | string (UUID) | no | -- | Filter by job ID |
+
+**Approval:** No
+
+### jarvis_request_approval
+
+Create a Jarvis-managed approval request.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `title` | string | yes | -- | Approval title (min length 1) |
+| `description` | string | yes | -- | Approval description (min length 1) |
+| `severity` | `"info"` \| `"warning"` \| `"critical"` | no | `"warning"` | Severity level |
+| `scopes` | string[] | no | -- | Approval scope tags |
+
+**Approval:** No
+
+---
+
+## @jarvis/jobs
+
+### job_submit
+
+Submit a Jarvis worker job into the shared broker.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `type` | string (job type literal) | yes | -- | Job type |
+| `input` | Record<string, unknown> | yes | -- | Job input data |
+| `artifactIds` | string[] | no | -- | Input artifact IDs |
+| `artifactsIn` | ArtifactRef[] | no | -- | Full artifact objects (`{artifact_id, name?, kind?, path?, path_context?, path_style?, checksum_sha256?, size_bytes?}`) |
+| `priority` | `"low"` \| `"normal"` \| `"high"` \| `"urgent"` | no | `"normal"` | Priority |
+| `approvalId` | string | no | -- | Associated approval |
+| `requestedCommand` | string | no | -- | Specific command route |
+| `capabilityRoute` | string | no | -- | Capability route hint |
+
+**Approval:** Conditional
+
+### job_status
+
+Fetch current state for a queued or completed job.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobId` | string (UUID) | yes | -- | Job ID |
+
+**Approval:** No
+
+### job_cancel
+
+Cancel a job that is still in flight.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobId` | string (UUID) | yes | -- | Job ID |
+| `reason` | string | no | -- | Cancellation reason |
+
+**Approval:** No
+
+### job_artifacts
+
+List artifacts for a specific job or all tracked jobs.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobId` | string (UUID) | no | -- | Filter by job |
+
+**Approval:** No
+
+### job_retry
+
+Retry a completed, failed, or cancelled job.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobId` | string (UUID) | yes | -- | Job to retry |
+| `approvalId` | string | no | -- | Associated approval |
+
+**Approval:** Conditional
+
+---
+
+## @jarvis/dispatch
+
+### dispatch_to_session
+
+Send message to a single OpenClaw session.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_key` | string | yes | -- | Target session key |
+| `text` | string | yes | -- | Message content |
+| `job_id` | string | no | -- | Associated job |
+
+**Approval:** Yes
+
+### dispatch_followup
+
+Send follow-up message tied to an existing job.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `job_id` | string | yes | -- | Job to follow up on |
+| `text` | string | yes | -- | Follow-up content |
+
+**Approval:** No
+
+### dispatch_broadcast
+
+Broadcast message to multiple sessions.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_keys` | string[] | yes | -- | Target sessions |
+| `text` | string | yes | -- | Broadcast content |
+
+**Approval:** Yes
+
+### dispatch_notify_completion
+
+Auto-notify session when job completes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `job_id` | string | yes | -- | Job to watch |
+| `session_key` | string | yes | -- | Session to notify |
+
+**Approval:** No
+
+### dispatch_spawn_worker_agent
+
+Spawn a subagent in a target session.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_key` | string | yes | -- | Target session |
+| `worker_type` | string | yes | -- | Worker type to spawn |
+| `goal` | string | yes | -- | Agent goal |
+
+**Approval:** Yes
+
+---
+
+## @jarvis/email
+
+### email_search
+
+Search inbox using Gmail query syntax.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | -- | Gmail search syntax (from:, subject:, label:, etc.) |
+| `max_results` | integer | no | 20 | 1-500 |
+| `page_token` | string | no | -- | Pagination token |
+
+**Approval:** No
+
+### email_read
+
+Read a specific email message by ID.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `message_id` | string | yes | -- | Message ID |
+| `include_raw` | boolean | no | false | Include raw MIME source |
+
+**Approval:** No
+
+### email_draft
+
+Create a new draft email without sending.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `to` | string[] | yes | -- | Recipients (min 1) |
+| `subject` | string | yes | -- | Subject line |
+| `body` | string | yes | -- | Plain-text body |
+| `cc` | string[] | no | -- | CC recipients |
+| `reply_to_message_id` | string | no | -- | Reply-to message ID |
+
+**Approval:** No
+
+### email_send
+
+Send an existing draft or compose and send a new email.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `draft_id` | string | no | -- | Draft ID to send |
+| `to` | string[] | no | -- | Recipients for inline compose |
+| `subject` | string | no | -- | Subject for inline compose |
+| `body` | string | no | -- | Body for inline compose |
+| `cc` | string[] | no | -- | CC recipients |
+| `reply_to_message_id` | string | no | -- | Reply-to message ID |
+
+**Approval:** Yes (always)
+
+### email_label
+
+Apply or remove Gmail labels from a message.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `message_id` | string | yes | -- | Message ID |
+| `action` | `"add"` \| `"remove"` | yes | -- | Label action |
+| `labels` | string[] | yes | -- | Label names (min 1) |
+
+**Approval:** No
+
+### email_list_threads
+
+List email threads, optionally filtered.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | no | -- | Filter query |
+| `max_results` | integer | no | 20 | 1-500 |
+
+**Approval:** No
+
+---
+
+## @jarvis/calendar
+
+### calendar_list_events
+
+List events in a date range with optional search.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `calendar_id` | string | no | `"primary"` | Calendar ID |
+| `start_date` | string (ISO) | yes | -- | Range start |
+| `end_date` | string (ISO) | yes | -- | Range end |
+| `max_results` | integer | no | 50 | 1-500 |
+| `query` | string | no | -- | Text search filter |
+
+**Approval:** No
+
+### calendar_create_event
+
+Create a new calendar event.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `title` | string | yes | -- | Event title |
+| `start` | string (ISO) | yes | -- | Start time |
+| `end` | string (ISO) | yes | -- | End time |
+| `description` | string | no | -- | Description/agenda |
+| `location` | string | no | -- | Location or meeting link |
+| `attendees` | string[] | no | -- | Attendee emails |
+| `calendar_id` | string | no | `"primary"` | Target calendar |
+| `send_invites` | boolean | no | -- | Send invites |
+
+**Approval:** Yes (if sending invites)
+
+### calendar_update_event
+
+Modify an existing calendar event.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `event_id` | string | yes | -- | Event ID |
+| `calendar_id` | string | no | -- | Calendar ID |
+| `title` | string | no | -- | New title |
+| `start` | string (ISO) | no | -- | New start |
+| `end` | string (ISO) | no | -- | New end |
+| `description` | string | no | -- | New description |
+| `location` | string | no | -- | New location |
+| `send_updates` | boolean | no | -- | Notify attendees |
+
+**Approval:** Conditional
+
+### calendar_find_free
+
+Find available meeting slots for all attendees.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `attendees` | string[] | yes | -- | Attendee emails |
+| `duration_minutes` | integer | yes | -- | Slot duration (min 5) |
+| `start_search` | string (ISO) | yes | -- | Search window start |
+| `end_search` | string (ISO) | yes | -- | Search window end |
+| `working_hours_only` | boolean | no | -- | Restrict to 9am-6pm |
+
+**Approval:** No
+
+### calendar_brief
+
+Generate a meeting preparation brief.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `event_id` | string | yes | -- | Event to brief |
+| `calendar_id` | string | no | -- | Calendar ID |
+| `include_history` | boolean | no | -- | Past interaction history |
+
+**Approval:** No
+
+---
+
+## @jarvis/crm
+
+### crm_add_contact
+
+Add a new contact to the CRM pipeline.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | yes | -- | Full name |
+| `company` | string | yes | -- | Company |
+| `role` | string | no | -- | Job role/title |
+| `email` | string | no | -- | Email address |
+| `linkedin_url` | string | no | -- | LinkedIn URL |
+| `source` | string | no | -- | Contact source (linkedin_scrape, web_intel, referral, direct) |
+| `tags` | string[] | no | -- | Categorization tags |
+| `notes` | string | no | -- | Initial notes |
+| `stage` | enum | no | `"prospect"` | Pipeline stage |
+
+**Approval:** No
+
+### crm_update_contact
+
+Update fields on an existing CRM contact.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `contact_id` | string | yes | -- | Contact ID |
+| `name` | string | no | -- | New name |
+| `company` | string | no | -- | New company |
+| `role` | string | no | -- | New role |
+| `email` | string | no | -- | New email |
+| `tags` | string[] | no | -- | New tags |
+| `score` | integer | no | -- | Engagement score (0-100) |
+| `last_contact_at` | string (ISO) | no | -- | Last contact date |
+
+**Approval:** No
+
+### crm_list_pipeline
+
+List contacts filtered by stage, tags, or score.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `stage` | enum | no | -- | Stage filter |
+| `tags` | string[] | no | -- | Tag filters |
+| `min_score` | integer | no | -- | Minimum score (0-100) |
+| `limit` | integer | no | -- | Max results |
+
+**Approval:** No
+
+### crm_move_stage
+
+Move a contact to a different pipeline stage.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `contact_id` | string | yes | -- | Contact ID |
+| `new_stage` | enum | yes | -- | Target stage |
+| `reason` | string | no | -- | Move reason |
+
+**Approval:** No
+
+### crm_add_note
+
+Add an interaction note to a contact.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `contact_id` | string | yes | -- | Contact ID |
+| `content` | string | yes | -- | Note content |
+| `note_type` | `"call"` \| `"email"` \| `"meeting"` \| `"observation"` \| `"proposal"` \| `"general"` | no | `"general"` | Note type |
+
+**Approval:** No
+
+### crm_search
+
+Full-text search across CRM contacts.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | -- | Search query |
+| `fields` | (`"name"` \| `"company"` \| `"notes"` \| `"tags"`)[] | no | all | Fields to search |
+| `stage` | enum | no | -- | Stage filter |
+
+**Approval:** No
+
+### crm_digest
+
+Generate a summary digest of the CRM pipeline.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `include_parked` | boolean | no | false | Include parked contacts |
+| `days_since_contact` | integer | no | -- | Flag stale contacts (days) |
+
+**Approval:** No
+
+---
+
+## @jarvis/web
+
+### web_search_news
+
+Search news and web for a company or topic.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | -- | Search query |
+| `max_results` | integer | no | 10 | 1-100 |
+| `date_from` | string (ISO date) | no | -- | Filter by publish date |
+| `sources` | string[] | no | -- | Preferred sources |
+
+**Approval:** No
+
+### web_scrape_profile
+
+Extract profile data from a URL.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | URL to scrape |
+| `profile_type` | `"company"` \| `"person"` \| `"job_posting"` | yes | -- | Profile type |
+| `extract_fields` | string[] | no | -- | Specific fields |
+
+**Approval:** No
+
+### web_monitor_page
+
+Check a web page for changes since last run.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | URL to monitor |
+| `page_id` | string | yes | -- | Stable tracking ID |
+| `selector` | string | no | -- | CSS selector to limit scope |
+
+**Approval:** No
+
+### web_enrich_contact
+
+Enrich a contact record with web data.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | yes | -- | Full name |
+| `company` | string | no | -- | Company |
+| `email` | string | no | -- | Email |
+| `linkedin_url` | string | no | -- | LinkedIn URL |
+
+**Approval:** No
+
+### web_track_jobs
+
+Monitor job postings at target companies.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `company_names` | string[] | yes | -- | Companies to monitor (min 1) |
+| `keywords` | string[] | yes | -- | Match keywords (min 1) |
+| `max_per_company` | integer | no | -- | Max per company |
+
+**Approval:** No
+
+### web_competitive_intel
+
+Gather competitive intelligence on a company.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `company_name` | string | yes | -- | Company to research |
+| `aspects` | (`"products"` \| `"pricing"` \| `"team"` \| `"news"` \| `"customers"`)[] | no | all | Aspects to research |
+
+**Approval:** No
+
+---
+
+## @jarvis/document
+
+### document_ingest
+
+Parse PDF, DOCX, TXT, or MD files and extract text.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | yes | -- | Path to document |
+| `extract_structure` | boolean | no | false | Extract headings/sections |
+| `extract_tables` | boolean | no | false | Extract tables |
+| `max_pages` | integer | no | -- | Max pages to process |
+
+**Approval:** No
+
+### document_extract_clauses
+
+Extract and classify clauses from contracts.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | no | -- | Path to document |
+| `text` | string | no | -- | Raw text (requires file_path OR text) |
+| `document_type` | `"nda"` \| `"msa"` \| `"sow"` \| `"contract"` \| `"agreement"` | no | -- | Document type |
+
+**Approval:** No
+
+### document_analyze_compliance
+
+Analyze document compliance against safety standards.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | no | -- | Path to document |
+| `text` | string | no | -- | Raw text (requires file_path OR text) |
+| `framework` | `"iso_26262"` \| `"aspice"` \| `"iec_61508"` \| `"iso_21434"` | yes | -- | Compliance framework |
+| `project_asil` | `"A"` \| `"B"` \| `"C"` \| `"D"` | no | -- | ASIL level |
+| `work_product_type` | string | no | -- | e.g., "software_plan", "dv_report", "tsr", "dia" |
+
+**Approval:** No
+
+### document_compare
+
+Compare two document versions.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path_a` | string | yes | -- | First document |
+| `file_path_b` | string | yes | -- | Second document |
+| `compare_mode` | `"full"` \| `"sections"` \| `"clauses"` | no | `"full"` | Comparison mode |
+
+**Approval:** No
+
+### document_generate_report
+
+Generate a structured report from a template.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `template` | `"proposal"` \| `"evidence_gap"` \| `"compliance_summary"` \| `"nda_analysis"` \| `"custom"` | yes | -- | Template type |
+| `data` | Record<string, unknown> | yes | -- | Template data |
+| `output_format` | `"docx"` \| `"pdf"` \| `"markdown"` | yes | -- | Output format |
+| `output_path` | string | yes | -- | Output file path |
+| `title` | string | no | -- | Report title |
+
+**Approval:** No
+
+---
+
+## @jarvis/device
+
+### device_snapshot
+
+Capture structured snapshot of current device state.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `includeWindows` | boolean | no | -- | Include window list |
+| `includeDisplays` | boolean | no | -- | Include display info |
+| `includeClipboard` | boolean | no | -- | Include clipboard |
+| `includeActiveWindow` | boolean | no | -- | Include active window detail |
+| `captureScreenshot` | boolean | no | -- | Take screenshot |
+| `outputName` | string | no | -- | Screenshot artifact name |
+
+**Approval:** No
+
+### device_list_windows
+
+List visible desktop windows.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `includeMinimized` | boolean | no | false | Include minimized |
+| `titleContains` | string | no | -- | Title filter |
+| `appId` | string | no | -- | App ID filter |
+
+**Approval:** No
+
+### device_open_app
+
+Launch a desktop application.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `appId` | string | no | -- | App identifier |
+| `executable` | string | no | -- | Executable path |
+| `displayName` | string | no | -- | Display name |
+| `arguments` | string[] | no | -- | Launch arguments |
+| `waitForWindow` | boolean | no | -- | Wait for window to appear |
+
+**Approval:** No
+
+### device_focus_window
+
+Bring a window to foreground.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `windowId` | string | no | -- | Window ID |
+| `titleContains` | string | no | -- | Title match |
+| `appId` | string | no | -- | App ID match |
+| `strictMatch` | boolean | no | false | Exact match |
+
+**Approval:** No
+
+### device_screenshot
+
+Capture screenshot.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `target` | `"desktop"` \| `"active_window"` \| `"window"` \| `"display"` \| `"region"` | no | `"desktop"` | Capture target |
+| `windowId` | string | no | -- | Window to capture |
+| `displayId` | string | no | -- | Display to capture |
+| `region` | `{x, y, width, height}` | no | -- | Pixel region |
+| `format` | `"png"` \| `"jpeg"` | no | `"png"` | Image format |
+| `outputName` | string | yes | -- | Artifact name |
+
+**Approval:** No
+
+### device_click
+
+Inject mouse click at coordinates.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `x` | number | yes | -- | X coordinate |
+| `y` | number | yes | -- | Y coordinate |
+| `coordinateSpace` | `"screen"` \| `"window"` | no | `"screen"` | Coordinate space |
+| `windowId` | string | no | -- | Target window |
+| `button` | `"left"` \| `"right"` \| `"middle"` | no | `"left"` | Mouse button |
+| `clickCount` | integer | no | 1 | Click count (1-5) |
+
+**Approval:** No
+
+### device_type
+
+Type text into current device.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `text` | string | yes | -- | Text to type |
+| `mode` | `"insert"` \| `"replace"` \| `"paste"` | no | `"insert"` | Input mode |
+| `submit` | boolean | no | false | Auto-submit (Enter) |
+| `windowId` | string | no | -- | Target window |
+
+**Approval:** No
+
+### device_hotkey
+
+Send keyboard shortcut.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `keys` | string[] | yes | -- | Key sequence (min 1) |
+| `windowId` | string | no | -- | Target window |
+
+**Approval:** No
+
+### device_clipboard_get
+
+Read current clipboard.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `format` | `"text"` \| `"html"` \| `"files"` \| `"image"` | no | `"text"` | Clipboard format |
+
+**Approval:** No
+
+### device_clipboard_set
+
+Write to device clipboard.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `text` | string | no | -- | Text content |
+| `artifactIds` | string[] | no | -- | Artifact references |
+| `mode` | `"replace"` | no | `"replace"` | Write mode |
+
+**Approval:** No
+
+### device_notify
+
+Send desktop notification.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `title` | string | yes | -- | Notification title |
+| `body` | string | yes | -- | Notification body |
+| `urgency` | `"low"` \| `"normal"` \| `"high"` | no | `"normal"` | Urgency level |
+
+**Approval:** No
+
+---
+
+## @jarvis/files
+
+### files_inspect
+
+Inspect files or directories under an approved root.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `paths` | string[] | yes | -- | Paths to inspect (min 1) |
+| `recursive` | boolean | no | false | Recurse directories |
+| `includeStats` | boolean | no | false | Include file stats |
+| `previewLines` | integer | no | -- | Preview first N lines (1-100) |
+
+**Approval:** No
+
+### files_read
+
+Read a file under an approved root.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `path` | string | yes | -- | File path |
+| `encoding` | `"utf8"` \| `"base64"` | no | `"utf8"` | Encoding |
+
+**Approval:** No
+
+### files_search
+
+Search file names and content.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `query` | string | yes | -- | Search query |
+| `caseSensitive` | boolean | no | false | Case sensitive |
+| `includeContents` | boolean | no | false | Search file contents |
+| `maxResults` | integer | no | -- | Max results (1-500) |
+
+**Approval:** No
+
+### files_write
+
+Write a file under an approved root.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `path` | string | yes | -- | File path |
+| `content` | string | yes | -- | File content |
+| `encoding` | `"utf8"` \| `"base64"` | no | `"utf8"` | Encoding |
+| `createDirectories` | boolean | no | false | Auto-create parent dirs |
+| `overwrite` | boolean | no | false | Overwrite existing |
+| `approvalId` | string | no | -- | Required approval ID |
+
+**Approval:** Yes
+
+### files_patch
+
+Apply text replacements to a file.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `path` | string | yes | -- | File path |
+| `operations` | `{find, replace, all?}[]` | yes | -- | Replacement ops (min 1) |
+| `encoding` | `"utf8"` \| `"base64"` | no | `"utf8"` | Encoding |
+| `createDirectories` | boolean | no | false | Auto-create dirs |
+| `approvalId` | string | no | -- | Required approval ID |
+
+**Approval:** Yes
+
+### files_copy
+
+Copy a file within an approved root.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `sourcePath` | string | yes | -- | Source path |
+| `destinationPath` | string | yes | -- | Destination path |
+| `createDirectories` | boolean | no | false | Auto-create dirs |
+| `approvalId` | string | no | -- | Required approval ID |
+
+**Approval:** Yes
+
+### files_move
+
+Move a file within an approved root.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `sourcePath` | string | yes | -- | Source path |
+| `destinationPath` | string | yes | -- | Destination path |
+| `createDirectories` | boolean | no | false | Auto-create dirs |
+| `approvalId` | string | no | -- | Required approval ID |
+
+**Approval:** Yes
+
+### files_preview
+
+Preview first N lines of a file.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rootPath` | string | no | config root | Approved root |
+| `path` | string | yes | -- | File path |
+| `lines` | integer | no | 12 | Lines to preview (max 200) |
+
+**Approval:** No
+
+---
+
+## @jarvis/office
+
+### office_inspect
+
+Analyze Excel, Word, or PowerPoint file.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | yes | -- | Path to office file |
+| `output_format` | `"summary"` \| `"json"` | no | `"summary"` | Output format |
+
+**Approval:** No
+
+### office_transform
+
+Normalize spreadsheet (column select, rename, sheet).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | yes | -- | Input file |
+| `output_path` | string | yes | -- | Output file |
+| `sheet` | string \| integer | no | -- | Sheet name or index |
+| `columns` | string[] | no | -- | Column selection |
+| `rename` | Record<string, string> | no | -- | Column renames |
+| `approvalId` | string | no | -- | Required approval |
+
+**Approval:** Yes
+
+### office_merge_excel
+
+Combine multiple Excel files.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_paths` | string[] | yes | -- | Files to merge (min 2) |
+| `output_path` | string | yes | -- | Output file |
+| `mode` | `"union"` \| `"append"` \| `"by_sheet"` | no | `"union"` | Merge mode |
+| `deduplicate` | boolean | no | false | Remove duplicates |
+| `approvalId` | string | no | -- | Required approval |
+
+**Approval:** Yes
+
+### office_fill_docx
+
+Template substitution in Word document.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `template_path` | string | yes | -- | Template file |
+| `output_path` | string | yes | -- | Output file |
+| `variables` | Record<string, string> | yes | -- | Substitution variables |
+| `strict` | boolean | no | true | Error on missing variables |
+| `approvalId` | string | no | -- | Required approval |
+
+**Approval:** Yes
+
+### office_build_pptx
+
+Generate PowerPoint presentation.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `output_path` | string | yes | -- | Output file |
+| `title` | string | yes | -- | Presentation title |
+| `slides` | SlideSpec[] | yes | -- | Slide specifications |
+| `theme` | `"corporate_clean"` \| `"minimal_light"` \| `"minimal_dark"` \| `"executive_brief"` | no | `"corporate_clean"` | Visual theme |
+| `approvalId` | string | no | -- | Required approval |
+
+**Approval:** Yes
+
+### office_extract_tables
+
+Export tables from office files.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | yes | -- | Input file |
+| `output_format` | `"json"` \| `"csv"` \| `"xlsx"` | no | `"json"` | Output format |
+| `output_path` | string | no | -- | Output file (if csv/xlsx) |
+| `sheet` | string \| integer | no | -- | Sheet selector |
+
+**Approval:** No
+
+### office_preview
+
+Render preview of office file.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `file_path` | string | yes | -- | Input file |
+| `format` | `"png"` \| `"pdf"` \| `"html"` \| `"text"` | no | `"text"` | Preview format |
+| `output_path` | string | no | -- | Output file |
+
+**Approval:** No
+
+---
+
+## @jarvis/system
+
+### system_monitor_cpu
+
+Current CPU utilization.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `per_core` | boolean | no | false | Per-core breakdown |
+
+**Approval:** No
+
+### system_monitor_memory
+
+Memory usage and top consumers.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `top_n` | integer | no | 10 | Top N consumers |
+
+**Approval:** No
+
+### system_monitor_disk
+
+Disk usage by path or all volumes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `path` | string | no | -- | Specific path to check |
+
+**Approval:** No
+
+### system_monitor_network
+
+Network interface statistics.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Returns all interfaces |
+
+**Approval:** No
+
+### system_monitor_battery
+
+Battery status, charge, and time remaining.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Returns battery info |
+
+**Approval:** No
+
+### system_list_processes
+
+List running processes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sort_by` | `"cpu"` \| `"memory"` \| `"name"` | no | `"cpu"` | Sort order |
+| `filter` | string | no | -- | Name filter |
+| `top_n` | integer | no | -- | Limit results |
+
+**Approval:** No
+
+### system_kill_process
+
+Kill a running process.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pid` | integer | no | -- | Process ID |
+| `name` | string | no | -- | Process name (requires pid OR name) |
+| `force` | boolean | no | false | Force kill |
+
+**Approval:** Yes
+
+### system_hardware_info
+
+Full hardware information.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Returns CPU, GPU, memory, disk, network, display, battery |
+
+**Approval:** No
+
+---
+
+## @jarvis/inference
+
+### inference_chat
+
+Route-based chat completion.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `messages` | `{role, content}[]` | yes | -- | Chat messages |
+| `model` | string | no | config default | Model ID |
+| `temperature` | number | no | -- | Sampling temperature |
+| `maxTokens` | integer | no | -- | Max output tokens |
+
+**Approval:** No
+
+### inference_embed
+
+Vector embeddings for text.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `texts` | string[] | yes | -- | Texts to embed |
+| `model` | string | no | -- | Embedding model |
+
+**Approval:** No
+
+### inference_list_models
+
+List available models across runtimes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Probes LM Studio + Ollama |
+
+**Approval:** No
+
+### inference_rag_index
+
+Index documents into a RAG collection.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `paths` | string[] | yes | -- | File paths to index |
+| `collection` | string | yes | -- | Collection name |
+
+**Approval:** No
+
+### inference_rag_query
+
+Retrieve top-K chunks from a RAG collection.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | -- | Search query |
+| `collection` | string | no | -- | Collection filter |
+| `topK` | integer | no | 5 | Results to return |
+
+**Approval:** No
+
+### inference_batch_submit
+
+Submit async batch job.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `jobs` | BatchJob[] | yes | -- | Batch job specifications |
+
+**Approval:** No
+
+### inference_batch_status
+
+Query batch completion.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `batch_id` | string | yes | -- | Batch ID |
+
+**Approval:** No
+
+---
+
+## @jarvis/scheduler
+
+### scheduler_create_schedule
+
+Create a recurring job on a cron expression or fixed interval.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `job_type` | string | yes | -- | Job type to schedule |
+| `input` | Record<string, unknown> | yes | -- | Job input |
+| `cron_expression` | string | no | -- | 5-field cron (minute hour dom month dow) |
+| `interval_seconds` | integer | no | -- | Fixed interval (requires cron OR interval) |
+| `scope_group` | string | no | -- | Schedule group |
+| `label` | string | no | -- | Human label |
+
+**Approval:** No
+
+### scheduler_list_schedules
+
+List schedules with optional filters.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `scope_group` | string | no | -- | Filter by group |
+| `enabled` | boolean | no | -- | Filter by enabled state |
+
+**Approval:** No
+
+### scheduler_delete_schedule
+
+Delete a schedule.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `schedule_id` | string | yes | -- | Schedule ID |
+
+**Approval:** No
+
+### scheduler_create_alert
+
+Create threshold-based alert on job metrics.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `job_type` | string | yes | -- | Job type to monitor |
+| `metric_path` | string | yes | -- | Dot-path metric (e.g., "cpu_percent") |
+| `operator` | `"gt"` \| `"lt"` \| `"eq"` \| `"gte"` \| `"lte"` | yes | -- | Comparison |
+| `threshold` | number | yes | -- | Threshold value |
+| `label` | string | no | -- | Alert label |
+
+**Approval:** No
+
+### scheduler_create_workflow
+
+Create multi-step job automation.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | yes | -- | Workflow name |
+| `steps` | WorkflowStep[] | yes | -- | Step definitions |
+| `label` | string | no | -- | Description |
+
+**Approval:** No
+
+### scheduler_run_workflow
+
+Execute a workflow.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `workflow_id` | string | yes | -- | Workflow ID |
+
+**Approval:** No
+
+### scheduler_habit_track
+
+Create, log, or delete habit entries.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | `"create"` \| `"log"` \| `"delete"` | yes | -- | Habit action |
+| `habit_id` | string | no | -- | Habit ID (required for log/delete) |
+| `name` | string | no | -- | Habit name (required for create) |
+| `frequency` | string | no | -- | Frequency (e.g., "daily") |
+
+**Approval:** No
+
+### scheduler_habit_status
+
+Get habit completion stats.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `habit_id` | string | no | -- | Filter by habit |
+| `days` | integer | no | 30 | Lookback window |
+
+**Approval:** No
+
+---
+
+## @jarvis/security
+
+### security_scan_processes
+
+Scan running processes against whitelist.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Scans all processes |
+
+**Approval:** No
+
+### security_whitelist_update
+
+Update process whitelist.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | `"add"` \| `"remove"` | yes | -- | Whitelist action |
+| `entries` | string[] | yes | -- | Process names or SHA-256 hashes |
+
+**Approval:** No
+
+### security_network_audit
+
+Audit network connections.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Audits listening + established connections |
+
+**Approval:** No
+
+### security_file_integrity_check
+
+Verify file hashes against baseline.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `paths` | string[] | yes | -- | Files to check |
+
+**Approval:** No
+
+### security_file_integrity_baseline
+
+Record current file hashes as baseline.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `paths` | string[] | yes | -- | Files to baseline |
+
+**Approval:** No
+
+### security_firewall_rule
+
+Manage Windows Firewall rules.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | `"add"` \| `"remove"` \| `"list"` | yes | -- | Rule action |
+| `name` | string | no | -- | Rule name (required for add/remove) |
+| `direction` | `"inbound"` \| `"outbound"` | no | -- | Traffic direction |
+| `protocol` | `"tcp"` \| `"udp"` | no | -- | Protocol |
+| `port` | integer | no | -- | Port number |
+| `action_type` | `"allow"` \| `"block"` | no | -- | Rule action type |
+
+**Approval:** No
+
+### security_lockdown
+
+Emergency lockdown mode.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `level` | `"standard"` \| `"maximum"` | no | `"standard"` | Lockdown level |
+
+**Approval:** Yes
+
+---
+
+## @jarvis/voice
+
+### voice_listen
+
+Capture microphone audio.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `duration_seconds` | integer | yes | -- | Duration (1-300) |
+| `device` | string | no | -- | Audio device |
+
+**Approval:** No
+
+### voice_transcribe
+
+Speech-to-text via Whisper.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `artifact_id` | string | yes | -- | Audio artifact |
+| `language` | string | no | auto-detect | Language code |
+| `model` | string | no | -- | Whisper model |
+
+**Approval:** No
+
+### voice_speak
+
+Text-to-speech via Piper or SAPI.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `text` | string | yes | -- | Text to speak |
+| `voice` | string | no | -- | Voice model |
+| `speed` | number | no | 1.0 | Speed (0.5-3.0) |
+
+**Approval:** No
+
+### voice_wake_word_start
+
+Start wake word detection.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `keyword` | string | yes | -- | Wake word |
+| `sensitivity` | number | no | 0.5 | Detection sensitivity (0-1) |
+
+**Approval:** No
+
+### voice_wake_word_stop
+
+Stop active wake word session.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Stops current session |
+
+**Approval:** No
+
+---
+
+## @jarvis/browser
+
+### browser_run_task
+
+Execute Playwright automation task on target URL.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Target URL |
+| `task` | string | yes | -- | Task description |
+| `approvalId` | string | no | -- | Approval ID |
+
+**Approval:** Conditional
+
+### browser_extract
+
+Extract content from web page.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Target URL |
+| `format` | `"json"` \| `"markdown"` \| `"text"` \| `"html"` | no | `"text"` | Output format |
+| `selector` | string | no | -- | CSS selector |
+| `approvalId` | string | no | -- | Approval ID |
+
+**Approval:** Conditional
+
+### browser_capture
+
+Screenshot or PDF of web page.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Target URL |
+| `format` | `"png"` \| `"pdf"` | no | `"png"` | Capture format |
+| `fullPage` | boolean | no | false | Full page capture |
+| `approvalId` | string | no | -- | Approval ID |
+
+**Approval:** Conditional
+
+### browser_download
+
+Download file from URL.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | string | yes | -- | Download URL |
+| `outputPath` | string | no | -- | Save location |
+
+**Approval:** No
+
+---
+
+## @jarvis/interpreter
+
+### interpreter_run_task
+
+High-level multi-step automation via Open Interpreter.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `task` | string | yes | -- | Task description |
+
+**Approval:** No
+
+### interpreter_run_code
+
+Execute code with timeout.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `language` | `"python"` \| `"javascript"` \| `"shell"` | yes | -- | Language |
+| `code` | string | yes | -- | Code to execute |
+| `timeout_seconds` | integer | no | 30 | Execution timeout |
+
+**Approval:** No
+
+### interpreter_status
+
+List active sessions.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| (none) | | | | Returns active sessions |
+
+**Approval:** No
+
+---
+
+## @jarvis/agent
+
+### agent_start
+
+Start an agent run.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `agent_id` | string | yes | -- | Agent to start |
+| `goal` | string | no | -- | Optional goal override |
+| `trigger` | string | no | `"manual"` | Trigger type |
+
+**Approval:** No
+
+### agent_step
+
+Advance agent by one step.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `run_id` | string | yes | -- | Run to advance |
+
+**Approval:** No
+
+### agent_status
+
+Get agent run status.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `run_id` | string | no | -- | Specific run |
+| `agent_id` | string | no | -- | Filter by agent |
+
+**Approval:** No
+
+### agent_pause
+
+Pause an executing agent.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `run_id` | string | yes | -- | Run to pause |
+
+**Approval:** No
+
+### agent_resume
+
+Resume a paused agent.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `run_id` | string | yes | -- | Run to resume |
+
+**Approval:** No
+
+### agent_configure
+
+Update agent runtime configuration.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `agent_id` | string | yes | -- | Agent to configure |
+| `max_steps` | integer | no | -- | New max steps |
+| `planner_mode` | `"single"` \| `"critic"` \| `"multi"` | no | -- | Planner mode |
+
+**Approval:** No


### PR DESCRIPTION
## Summary
- Add `docs/JARVIS.md` (1,277 lines): main reference covering architecture (Mermaid diagram), all 8 agents in detail, config tables, usage, features, project structure, API reference, troubleshooting, development guide
- Add `docs/reference/tool-reference.md` (1,518 lines): full parameter documentation for all 100+ tools across 19 plugins
- Add `docs/reference/database-schema.md` (623 lines): column-level schema for all 3 SQLite databases (30+ tables, every index)
- Add `docs/reference/state-machines.md` (359 lines): 8 state machine diagrams with transition tables, 9 V1 workflow definitions
- Fix stale counts across 6 existing docs (packages 43→44, test files 92→125, job types 143→144, schema families 23→27, examples 144→145)

## Test plan
- [ ] Verify all cross-links between docs resolve
- [ ] Spot-check 5+ tool parameter tables against source index.ts files
- [ ] Spot-check database schema columns against migration files
- [ ] Confirm no stale "143" or "92 test" counts remain in tracked .md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)