### PR TITLE
Fix chat history persistence for Ask Jarvis and Godmode

### DIFF
--- a/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
+++ b/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, type MutableRefObject } from 'react'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -135,14 +135,21 @@ export default function JarvisChat() {
   const [models, setModels] = useState<string[]>([])
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const sessionsRef = useRef(sessions) as MutableRefObject<ChatSession[]>
+  sessionsRef.current = sessions
 
   const activeSession = sessions.find(s => s.id === activeId) ?? null
   const messages = activeSession?.messages ?? []
 
-  // Persist
+  // Persist on every change (including mid-stream — partial messages beat lost messages)
   useEffect(() => {
-    if (!streaming) saveSessions(sessions)
-  }, [sessions, streaming])
+    saveSessions(sessions)
+  }, [sessions])
+
+  // Safety: persist on unmount via ref to avoid stale closure
+  useEffect(() => {
+    return () => { saveSessions(sessionsRef.current) }
+  }, [])
 
   useEffect(() => {
     if (activeId) saveActiveId(activeId)

--- a/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
@@ -7,16 +7,34 @@ import CodePanel from '../components/godmode/CodePanel.tsx'
 import CoworkPanel from '../components/godmode/CoworkPanel.tsx'
 import { SurfaceBadge, ResizeHandle } from '../components/godmode/shared.tsx'
 
+function timeLabel(iso: string): string {
+  const d = new Date(iso)
+  const now = new Date()
+  const diff = now.getTime() - d.getTime()
+  if (diff < 60_000) return 'Just now'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+  if (diff < 172_800_000) return 'Yesterday'
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
 export default function Godmode() {
   const activeSurfaces = useGodmodeStore(s => s.activeSurfaces)
   const model = useGodmodeStore(s => s.model)
   const models = useGodmodeStore(s => s.models)
   const setModel = useGodmodeStore(s => s.setModel)
   const setModels = useGodmodeStore(s => s.setModels)
-  const clearSession = useGodmodeStore(s => s.clearSession)
   const streaming = useGodmodeStore(s => s.streaming)
 
+  // Conversation management
+  const conversations = useGodmodeStore(s => s.conversations)
+  const currentConversationId = useGodmodeStore(s => s.currentConversationId)
+  const newConversation = useGodmodeStore(s => s.newConversation)
+  const switchConversation = useGodmodeStore(s => s.switchConversation)
+  const deleteConversation = useGodmodeStore(s => s.deleteConversation)
+
   const [rightPanelWidth, setRightPanelWidth] = useState(45) // percentage
+  const [sidebarOpen, setSidebarOpen] = useState(true)
 
   // Fetch available models
   useEffect(() => {
@@ -51,6 +69,16 @@ export default function Godmode() {
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between px-5 py-3 border-b border-white/5 bg-[#030712]">
         <div className="flex items-center gap-3">
+          {/* Sidebar toggle */}
+          <button
+            onClick={() => setSidebarOpen(v => !v)}
+            className="w-8 h-8 rounded-xl bg-slate-800/50 border border-white/5 flex items-center justify-center hover:bg-slate-700/50 transition-colors cursor-pointer"
+            title={sidebarOpen ? 'Hide conversations' : 'Show conversations'}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" className="text-slate-400">
+              <path d="M2 3.5h10M2 7h10M2 10.5h10" />
+            </svg>
+          </button>
           <div className="w-8 h-8 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center">
             <svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-indigo-400">
               <path d="M10 2L3 7v6l7 5 7-5V7z" />
@@ -90,26 +118,73 @@ export default function Godmode() {
             </div>
           )}
 
-          {/* New session button */}
+          {/* New chat button */}
           <div
-            onClick={() => !streaming && clearSession()}
+            onClick={() => !streaming && newConversation()}
             className={`px-3 py-1.5 text-xs rounded-lg border transition-all cursor-pointer ${
               streaming
                 ? 'border-white/5 text-slate-600 cursor-not-allowed'
                 : 'border-white/10 text-slate-400 hover:text-slate-200 hover:border-white/20'
             }`}
           >
-            New session
+            New chat
           </div>
         </div>
       </div>
 
       {/* Main content area */}
       <div className="flex flex-1 overflow-hidden">
+        {/* Conversation sidebar */}
+        <div className={`${sidebarOpen ? 'w-56' : 'w-0'} shrink-0 transition-all duration-200 overflow-hidden border-r border-white/5 bg-[#0a0f1a]`}>
+          <div className="w-56 h-full flex flex-col">
+            <div className="flex items-center justify-between px-3 py-3 border-b border-white/5">
+              <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Conversations</span>
+              <span className="text-[10px] text-slate-600">{conversations.length}</span>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {conversations.length === 0 ? (
+                <p className="text-xs text-slate-600 px-3 py-4 text-center">No conversations yet</p>
+              ) : (
+                conversations.map(c => (
+                  <div
+                    key={c.id}
+                    onClick={() => switchConversation(c.id)}
+                    className={`group px-3 py-2.5 cursor-pointer border-b border-white/[0.03] transition-colors ${
+                      c.id === currentConversationId
+                        ? 'bg-indigo-500/10 border-l-2 border-l-indigo-500'
+                        : 'hover:bg-slate-800/50 border-l-2 border-l-transparent'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-1.5">
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-xs font-medium truncate ${
+                          c.id === currentConversationId ? 'text-indigo-300' : 'text-slate-300'
+                        }`}>
+                          {c.title}
+                        </p>
+                        <p className="text-[10px] text-slate-600 mt-0.5">
+                          {c.messageCount} msg{c.messageCount !== 1 ? 's' : ''} · {timeLabel(c.updatedAt)}
+                        </p>
+                      </div>
+                      <button
+                        onClick={e => { e.stopPropagation(); deleteConversation(c.id) }}
+                        className="text-slate-700 hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 text-xs cursor-pointer shrink-0 mt-0.5"
+                        title="Delete conversation"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
         {/* Chat panel (always visible) */}
         <div
           className="flex flex-col overflow-hidden bg-[#030712]"
-          style={{ width: hasRightPanel ? `${100 - rightPanelWidth}%` : '100%' }}
+          style={{ width: hasRightPanel ? `${100 - rightPanelWidth}%` : '100%', flex: hasRightPanel ? undefined : 1 }}
         >
           <ChatPanel />
         </div>

--- a/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
+++ b/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
@@ -1,11 +1,10 @@
 import JarvisChat from '../components/JarvisChat.tsx'
 
 export default function AssistantRail({ open, onClose }: { open: boolean; onClose: () => void }) {
-  if (!open) return null
-
   return (
     <aside
       className="w-[340px] shrink-0 bg-j-surface border-l border-j-border flex flex-col h-full animate-j-slide-in"
+      style={{ display: open ? undefined : 'none' }}
       aria-label="Jarvis assistant"
     >
       {/* Header */}

--- a/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
+++ b/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
@@ -1,28 +1,86 @@
 import { create } from 'zustand'
 
-// ─── Session Persistence ────────────────────────────────────────────────────
+// ─── Multi-Conversation Persistence (localStorage) ─────────────────────────
 
-const STORAGE_KEY = 'godmode-session'
+const CONVERSATIONS_KEY = 'godmode-conversations'
+const ACTIVE_CONV_KEY = 'godmode-active'
+const CONV_PREFIX = 'godmode-conv-'
 
-interface PersistedState {
+interface ConversationMeta {
+  id: string
+  title: string
+  updatedAt: string
+  messageCount: number
+}
+
+interface ConversationData {
   messages: GodmodeMessage[]
   artifactHistory: Artifact[]
   currentArtifact: Artifact | null
   model: string
 }
 
-function loadSession(): Partial<PersistedState> {
-  try {
-    const raw = sessionStorage.getItem(STORAGE_KEY)
-    if (raw) return JSON.parse(raw)
-  } catch {}
-  return {}
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6)
 }
 
-function saveSession(state: PersistedState) {
+function deriveTitle(messages: GodmodeMessage[]): string {
+  const first = messages.find(m => m.role === 'user')
+  if (!first) return 'New chat'
+  const text = first.content.trim()
+  return text.length > 50 ? text.slice(0, 47) + '...' : text
+}
+
+function loadConversationList(): ConversationMeta[] {
   try {
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    const raw = localStorage.getItem(CONVERSATIONS_KEY)
+    if (raw) return JSON.parse(raw) as ConversationMeta[]
+  } catch { /* ignore */ }
+  return []
+}
+
+function saveConversationList(list: ConversationMeta[]): void {
+  try { localStorage.setItem(CONVERSATIONS_KEY, JSON.stringify(list)) } catch {}
+}
+
+function loadActiveConversationId(): string | null {
+  try { return localStorage.getItem(ACTIVE_CONV_KEY) } catch { return null }
+}
+
+function saveActiveConversationId(id: string | null): void {
+  try {
+    if (id) localStorage.setItem(ACTIVE_CONV_KEY, id)
+    else localStorage.removeItem(ACTIVE_CONV_KEY)
   } catch {}
+}
+
+function loadConversationData(id: string): ConversationData | null {
+  try {
+    const raw = localStorage.getItem(CONV_PREFIX + id)
+    if (raw) return JSON.parse(raw) as ConversationData
+  } catch {}
+  return null
+}
+
+function saveConversationData(id: string, data: ConversationData): void {
+  try { localStorage.setItem(CONV_PREFIX + id, JSON.stringify(data)) } catch {}
+}
+
+function removeConversationData(id: string): void {
+  try { localStorage.removeItem(CONV_PREFIX + id) } catch {}
+}
+
+// Migrate legacy sessionStorage data → new localStorage model (one-time)
+function migrateLegacySession(): { id: string; data: ConversationData } | null {
+  try {
+    const raw = sessionStorage.getItem('godmode-session')
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as ConversationData
+    if (!parsed.messages?.length) return null
+    sessionStorage.removeItem('godmode-session')
+    const id = generateId()
+    return { id, data: parsed }
+  } catch { return null }
 }
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -68,6 +126,11 @@ export type SurfaceId = 'chat' | 'artifact' | 'research' | 'code' | 'cowork'
 // ─── Store ──────────────────────────────────────────────────────────────────
 
 interface GodmodeState {
+  // Conversation management
+  conversations: ConversationMeta[]
+  currentConversationId: string | null
+
+  // Current conversation state
   messages: GodmodeMessage[]
   streaming: boolean
   activeSurfaces: SurfaceId[]
@@ -82,34 +145,216 @@ interface GodmodeState {
   model: string
   models: string[]
 
+  // Actions
   sendMessage: (text: string) => Promise<void>
-  clearSession: () => void
+  newConversation: () => void
+  switchConversation: (id: string) => void
+  deleteConversation: (id: string) => void
+  clearSession: () => void // backward-compat alias for newConversation
   setArtifactViewMode: (mode: 'preview' | 'code') => void
   setModel: (model: string) => void
   setModels: (models: string[]) => void
   closeSurface: (id: SurfaceId) => void
 }
 
-export const useGodmodeStore = create<GodmodeState>((set, get) => {
-  const persisted = loadSession()
+function initState(): {
+  conversations: ConversationMeta[]
+  currentConversationId: string | null
+  messages: GodmodeMessage[]
+  currentArtifact: Artifact | null
+  artifactHistory: Artifact[]
+  model: string
+} {
+  let conversations = loadConversationList()
+  let activeId = loadActiveConversationId()
+
+  // One-time migration from legacy sessionStorage
+  const legacy = migrateLegacySession()
+  if (legacy) {
+    const meta: ConversationMeta = {
+      id: legacy.id,
+      title: deriveTitle(legacy.data.messages),
+      updatedAt: new Date().toISOString(),
+      messageCount: legacy.data.messages.length,
+    }
+    conversations = [meta, ...conversations]
+    saveConversationList(conversations)
+    saveConversationData(legacy.id, legacy.data)
+    activeId = legacy.id
+    saveActiveConversationId(activeId)
+  }
+
+  // Load active conversation data
+  const data = activeId ? loadConversationData(activeId) : null
+
+  // Validate activeId still exists in list
+  if (activeId && !conversations.find(c => c.id === activeId)) {
+    activeId = conversations.length > 0 ? conversations[0].id : null
+    saveActiveConversationId(activeId)
+  }
+
+  const activeData = activeId ? (data ?? loadConversationData(activeId)) : null
+
   return {
-  messages: persisted.messages ?? [],
+    conversations,
+    currentConversationId: activeId,
+    messages: activeData?.messages ?? [],
+    currentArtifact: activeData?.currentArtifact ?? null,
+    artifactHistory: activeData?.artifactHistory ?? [],
+    model: activeData?.model ?? '',
+  }
+}
+
+function persistCurrentConversation(state: GodmodeState): void {
+  const { currentConversationId, messages, artifactHistory, currentArtifact, model, conversations } = state
+  if (!currentConversationId) return
+
+  // Save conversation data
+  saveConversationData(currentConversationId, { messages, artifactHistory, currentArtifact, model })
+
+  // Update metadata in list
+  const updated = conversations.map(c =>
+    c.id === currentConversationId
+      ? { ...c, title: deriveTitle(messages), updatedAt: new Date().toISOString(), messageCount: messages.length }
+      : c
+  )
+  saveConversationList(updated)
+}
+
+export const useGodmodeStore = create<GodmodeState>((set, get) => {
+  const init = initState()
+  return {
+  conversations: init.conversations,
+  currentConversationId: init.currentConversationId,
+  messages: init.messages,
   streaming: false,
   activeSurfaces: ['chat'],
-  currentArtifact: persisted.currentArtifact ?? null,
-  artifactHistory: persisted.artifactHistory ?? [],
+  currentArtifact: init.currentArtifact,
+  artifactHistory: init.artifactHistory,
   artifactViewMode: 'preview',
   researchPhase: 'idle',
   researchSources: [],
   coworkSteps: [],
   codeContent: '',
   toolLog: [],
-  model: persisted.model ?? '',
+  model: init.model,
   models: [],
 
+  // ─── Conversation Management ─────────────────────────────────
+
+  newConversation: () => {
+    const state = get()
+    if (state.streaming) return
+
+    // Persist current conversation first
+    persistCurrentConversation(state)
+
+    // Create new empty conversation
+    const id = generateId()
+    const meta: ConversationMeta = {
+      id,
+      title: 'New chat',
+      updatedAt: new Date().toISOString(),
+      messageCount: 0,
+    }
+    const updated = [meta, ...state.conversations]
+    saveConversationList(updated)
+    saveActiveConversationId(id)
+
+    set({
+      conversations: updated,
+      currentConversationId: id,
+      messages: [],
+      streaming: false,
+      activeSurfaces: ['chat'],
+      currentArtifact: null,
+      artifactHistory: [],
+      artifactViewMode: 'preview',
+      researchPhase: 'idle',
+      researchSources: [],
+      coworkSteps: [],
+      codeContent: '',
+      toolLog: [],
+    })
+  },
+
+  switchConversation: (id: string) => {
+    const state = get()
+    if (state.streaming || id === state.currentConversationId) return
+
+    // Persist current first
+    persistCurrentConversation(state)
+
+    // Load target
+    const data = loadConversationData(id)
+    saveActiveConversationId(id)
+
+    set({
+      currentConversationId: id,
+      messages: data?.messages ?? [],
+      currentArtifact: data?.currentArtifact ?? null,
+      artifactHistory: data?.artifactHistory ?? [],
+      model: data?.model || state.model,
+      activeSurfaces: ['chat'],
+      toolLog: [],
+      coworkSteps: [],
+      researchPhase: 'idle',
+      researchSources: [],
+      codeContent: '',
+    })
+  },
+
+  deleteConversation: (id: string) => {
+    const state = get()
+    if (state.streaming) return
+
+    removeConversationData(id)
+    const updated = state.conversations.filter(c => c.id !== id)
+    saveConversationList(updated)
+
+    if (state.currentConversationId === id) {
+      const nextId = updated.length > 0 ? updated[0].id : null
+      const nextData = nextId ? loadConversationData(nextId) : null
+      saveActiveConversationId(nextId)
+      set({
+        conversations: updated,
+        currentConversationId: nextId,
+        messages: nextData?.messages ?? [],
+        currentArtifact: nextData?.currentArtifact ?? null,
+        artifactHistory: nextData?.artifactHistory ?? [],
+        activeSurfaces: ['chat'],
+        toolLog: [],
+      })
+    } else {
+      set({ conversations: updated })
+    }
+  },
+
+  // Backward-compat alias
+  clearSession: () => get().newConversation(),
+
+  // ─── Send Message ────────────────────────────────────────────
+
   sendMessage: async (text: string) => {
-    const { model, messages, streaming } = get()
+    const state = get()
+    const { model, messages, streaming } = state
     if (!text.trim() || streaming) return
+
+    // Auto-create conversation if none active
+    let convId = state.currentConversationId
+    if (!convId) {
+      convId = generateId()
+      const meta: ConversationMeta = {
+        id: convId,
+        title: text.trim().length > 50 ? text.trim().slice(0, 47) + '...' : text.trim(),
+        updatedAt: new Date().toISOString(),
+        messageCount: 0,
+      }
+      const updated = [meta, ...state.conversations]
+      saveConversationList(updated)
+      saveActiveConversationId(convId)
+      set({ conversations: updated, currentConversationId: convId })
+    }
 
     const userMsg: GodmodeMessage = { role: 'user', content: text.trim() }
     const assistantMsg: GodmodeMessage = { role: 'assistant', content: '', tools: [] }
@@ -156,8 +401,8 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
         }))
         const lastArtifact = artifacts.length > 0 ? artifacts[artifacts.length - 1]! : null
 
-        set(state => {
-          const msgs = [...state.messages]
+        set(s => {
+          const msgs = [...s.messages]
           const last = msgs[msgs.length - 1]
           if (last?.role === 'assistant') {
             msgs[msgs.length - 1] = { ...last, content: reply }
@@ -166,15 +411,14 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
             messages: msgs,
             ...(lastArtifact ? {
               currentArtifact: lastArtifact,
-              artifactHistory: [...state.artifactHistory, ...artifacts],
-              activeSurfaces: [...state.activeSurfaces, 'artifact'] as SurfaceId[],
+              artifactHistory: [...s.artifactHistory, ...artifacts],
+              activeSurfaces: [...s.activeSurfaces, 'artifact'] as SurfaceId[],
             } : {}),
             ...(json.model ? { model: json.model } : {}),
           }
         })
         set({ streaming: false })
-        const final = get()
-        saveSession({ messages: final.messages, artifactHistory: final.artifactHistory, currentArtifact: final.currentArtifact, model: final.model })
+        persistCurrentConversation(get())
         return
       }
 
@@ -206,8 +450,8 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                 break
               }
               case 'thinking': {
-                set(state => {
-                  const msgs = [...state.messages]
+                set(s => {
+                  const msgs = [...s.messages]
                   const last = msgs[msgs.length - 1]
                   if (last?.role === 'assistant') {
                     msgs[msgs.length - 1] = { ...last, thinking: (last.thinking ?? '') + (evt.content as string) }
@@ -218,15 +462,15 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
               }
               case 'token': {
                 const content = evt.content as string
-                set(state => {
-                  const msgs = [...state.messages]
+                set(s => {
+                  const msgs = [...s.messages]
                   const last = msgs[msgs.length - 1]
                   if (last?.role === 'assistant') {
                     msgs[msgs.length - 1] = { ...last, content: last.content + content }
                   }
                   // Detect code blocks for code surface
                   const newContent = last?.content ?? ''
-                  const codeContent = state.activeSurfaces.includes('code') ? newContent : state.codeContent
+                  const codeContent = s.activeSurfaces.includes('code') ? newContent : s.codeContent
                   return { messages: msgs, codeContent }
                 })
                 break
@@ -238,10 +482,10 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                   params: evt.params as Record<string, unknown>,
                   status: 'running'
                 }
-                set(state => ({
-                  toolLog: [...state.toolLog, tool],
+                set(s => ({
+                  toolLog: [...s.toolLog, tool],
                   messages: (() => {
-                    const msgs = [...state.messages]
+                    const msgs = [...s.messages]
                     const last = msgs[msgs.length - 1]
                     if (last?.role === 'assistant') {
                       msgs[msgs.length - 1] = { ...last, tools: [...(last.tools ?? []), tool] }
@@ -255,10 +499,10 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                 const id = evt.id as string
                 const result = evt.result as string
                 const duration = evt.duration as number
-                set(state => ({
-                  toolLog: state.toolLog.map(t => t.id === id ? { ...t, result, duration, status: 'done' as const } : t),
+                set(s => ({
+                  toolLog: s.toolLog.map(t => t.id === id ? { ...t, result, duration, status: 'done' as const } : t),
                   messages: (() => {
-                    const msgs = [...state.messages]
+                    const msgs = [...s.messages]
                     const last = msgs[msgs.length - 1]
                     if (last?.role === 'assistant') {
                       msgs[msgs.length - 1] = {
@@ -278,9 +522,9 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                         title: titleMatches[i]?.[1] ?? m[1]!,
                         snippet: ''
                       }))
-                      return [...state.researchSources, ...newSources]
+                      return [...s.researchSources, ...newSources]
                     }
-                    return state.researchSources
+                    return s.researchSources
                   })()
                 }))
                 break
@@ -292,12 +536,12 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                   title: evt.title as string,
                   content: evt.content as string
                 }
-                set(state => ({
+                set(s => ({
                   currentArtifact: artifact,
-                  artifactHistory: [...state.artifactHistory, artifact],
-                  activeSurfaces: state.activeSurfaces.includes('artifact')
-                    ? state.activeSurfaces
-                    : [...state.activeSurfaces, 'artifact']
+                  artifactHistory: [...s.artifactHistory, artifact],
+                  activeSurfaces: s.activeSurfaces.includes('artifact')
+                    ? s.activeSurfaces
+                    : [...s.activeSurfaces, 'artifact']
                 }))
                 break
               }
@@ -313,9 +557,9 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                   action: evt.action as string,
                   status: evt.status as CoworkStep['status']
                 }
-                set(state => {
-                  const steps = [...state.coworkSteps]
-                  const existing = steps.findIndex(s => s.index === step.index)
+                set(s => {
+                  const steps = [...s.coworkSteps]
+                  const existing = steps.findIndex(ss => ss.index === step.index)
                   if (existing >= 0) steps[existing] = step
                   else steps.push(step)
                   return { coworkSteps: steps }
@@ -328,8 +572,8 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
                 break
               }
               case 'error': {
-                set(state => {
-                  const msgs = [...state.messages]
+                set(s => {
+                  const msgs = [...s.messages]
                   const last = msgs[msgs.length - 1]
                   if (last?.role === 'assistant') {
                     msgs[msgs.length - 1] = { ...last, content: evt.message as string, error: true }
@@ -343,8 +587,8 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
         }
       }
     } catch (e) {
-      set(state => {
-        const msgs = [...state.messages]
+      set(s => {
+        const msgs = [...s.messages]
         const last = msgs[msgs.length - 1]
         if (last?.role === 'assistant') {
           msgs[msgs.length - 1] = { ...last, content: e instanceof Error ? e.message : String(e), error: true }
@@ -355,8 +599,8 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
 
     // If the assistant message is still empty after the stream (e.g. API returned
     // plain JSON instead of SSE, or the model produced no tokens), show an error.
-    set(state => {
-      const msgs = [...state.messages]
+    set(s => {
+      const msgs = [...s.messages]
       const last = msgs[msgs.length - 1]
       if (last?.role === 'assistant' && !last.content && !last.error) {
         msgs[msgs.length - 1] = {
@@ -371,37 +615,14 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
 
     set({ streaming: false })
 
-    // Persist to sessionStorage
-    const final = get()
-    saveSession({
-      messages: final.messages,
-      artifactHistory: final.artifactHistory,
-      currentArtifact: final.currentArtifact,
-      model: final.model,
-    })
-  },
-
-  clearSession: () => {
-    try { sessionStorage.removeItem(STORAGE_KEY) } catch {}
-    set({
-      messages: [],
-      streaming: false,
-      activeSurfaces: ['chat'],
-      currentArtifact: null,
-      artifactHistory: [],
-      artifactViewMode: 'preview',
-      researchPhase: 'idle',
-      researchSources: [],
-      coworkSteps: [],
-      codeContent: '',
-      toolLog: [],
-    })
+    // Persist to localStorage
+    persistCurrentConversation(get())
   },
 
   setArtifactViewMode: (mode) => set({ artifactViewMode: mode }),
   setModel: (model) => set({ model }),
   setModels: (models) => set({ models }),
-  closeSurface: (id) => set(state => ({
-    activeSurfaces: state.activeSurfaces.filter(s => s !== id)
+  closeSurface: (id) => set(s => ({
+    activeSurfaces: s.activeSurfaces.filter(ss => ss !== id)
   })),
 }})


### PR DESCRIPTION
## Summary
- **Godmode**: switch `sessionStorage` → `localStorage` with multi-conversation support (sidebar, switch, delete, auto-save). Legacy session data migrated automatically.
- **Ask Jarvis**: keep component mounted on sidebar close (CSS hidden), save on every state change (no streaming guard), add unmount safety net via ref.

## Changes (4 files)
- `godmode-store.ts` — localStorage + conversation list model, per-conversation storage keys, migration from legacy `sessionStorage`
- `Godmode.tsx` — conversation sidebar (collapsible, sorted by recency, delete on hover), sidebar toggle in header, "New chat" button
- `AssistantRail.tsx` — `display: none` instead of conditional return (prevents JarvisChat unmount)
- `JarvisChat.tsx` — remove `!streaming` guard on save effect, add `useEffect` cleanup that saves via ref on unmount

## Test plan
- [ ] Godmode: send message → click "New chat" → old conversation shows in sidebar → click it → messages restored
- [ ] Godmode: close browser tab → reopen `/godmode` → conversations list and last active chat restored
- [ ] Ask Jarvis: open sidebar → send message → close sidebar → reopen → conversation still there
- [ ] Ask Jarvis: send message → navigate to CRM page → come back → open sidebar → messages still there
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)