### PR TITLE
Fix chat UI bugs found during testing

### DIFF
--- a/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
@@ -65,7 +65,7 @@ export default function Godmode() {
   const hasRightPanel = rightSurface !== null
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-full">
       {/* Header */}
       <div className="shrink-0 flex items-center justify-between px-5 py-3 border-b border-white/5 bg-[#030712]">
         <div className="flex items-center gap-3">

--- a/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
+++ b/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
@@ -2,36 +2,50 @@ import JarvisChat from '../components/JarvisChat.tsx'
 
 export default function AssistantRail({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
-    <aside
-      className="w-[340px] shrink-0 bg-j-surface border-l border-j-border flex flex-col h-full animate-j-slide-in"
-      style={{ display: open ? undefined : 'none' }}
-      aria-label="Jarvis assistant"
-    >
-      {/* Header */}
-      <div className="px-4 py-3 border-b border-j-border flex items-center gap-2.5">
-        <div className="size-5 rounded bg-j-accent/15 flex items-center justify-center" aria-hidden="true">
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-            <circle cx="5" cy="5" r="3" stroke="currentColor" strokeWidth="1" className="text-j-accent" />
-            <circle cx="5" cy="5" r="1" fill="currentColor" className="text-j-accent" />
-          </svg>
-        </div>
-        <span className="text-[12px] font-semibold text-j-text tracking-tight">Jarvis Assistant</span>
-        <span className="ml-auto text-[10px] text-j-text-muted font-mono">claude-opus</span>
-        <button
+    <>
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/30 z-40"
           onClick={onClose}
-          className="ml-2 text-j-text-muted hover:text-j-text transition-colors cursor-pointer p-0.5"
-          aria-label="Close assistant"
-        >
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
-            <path d="M3 3l6 6M9 3l-6 6" />
-          </svg>
-        </button>
-      </div>
+          aria-hidden="true"
+        />
+      )}
 
-      {/* Chat */}
-      <div className="flex-1 overflow-hidden">
-        <JarvisChat />
-      </div>
-    </aside>
+      {/* Panel -- always mounted for state, positioned off-screen when closed */}
+      <aside
+        className={`fixed top-0 right-0 h-full w-[340px] bg-j-surface border-l border-j-border flex flex-col z-50 transition-transform duration-200 ${
+          open ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        aria-label="Jarvis assistant"
+        aria-hidden={!open}
+      >
+        {/* Header */}
+        <div className="px-4 py-3 border-b border-j-border flex items-center gap-2.5">
+          <div className="size-5 rounded bg-j-accent/15 flex items-center justify-center" aria-hidden="true">
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+              <circle cx="5" cy="5" r="3" stroke="currentColor" strokeWidth="1" className="text-j-accent" />
+              <circle cx="5" cy="5" r="1" fill="currentColor" className="text-j-accent" />
+            </svg>
+          </div>
+          <span className="text-[12px] font-semibold text-j-text tracking-tight">Jarvis Assistant</span>
+          <span className="ml-auto text-[10px] text-j-text-muted font-mono">claude-opus</span>
+          <button
+            onClick={onClose}
+            className="ml-2 text-j-text-muted hover:text-j-text transition-colors cursor-pointer p-0.5"
+            aria-label="Close assistant"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+              <path d="M3 3l6 6M9 3l-6 6" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Chat */}
+        <div className="flex-1 overflow-hidden">
+          <JarvisChat />
+        </div>
+      </aside>
+    </>
   )
 }

--- a/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
+++ b/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
@@ -205,7 +205,10 @@ function initState(): {
   }
 }
 
-function persistCurrentConversation(state: GodmodeState): void {
+function persistCurrentConversation(
+  state: GodmodeState,
+  storeSetter: (partial: Partial<GodmodeState>) => void,
+): void {
   const { currentConversationId, messages, artifactHistory, currentArtifact, model, conversations } = state
   if (!currentConversationId) return
 
@@ -219,6 +222,9 @@ function persistCurrentConversation(state: GodmodeState): void {
       : c
   )
   saveConversationList(updated)
+
+  // Sync metadata back to store so sidebar reflects current counts
+  storeSetter({ conversations: updated })
 }
 
 export const useGodmodeStore = create<GodmodeState>((set, get) => {
@@ -247,7 +253,7 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     if (state.streaming) return
 
     // Persist current conversation first
-    persistCurrentConversation(state)
+    persistCurrentConversation(state, set)
 
     // Create new empty conversation
     const id = generateId()
@@ -283,7 +289,7 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     if (state.streaming || id === state.currentConversationId) return
 
     // Persist current first
-    persistCurrentConversation(state)
+    persistCurrentConversation(state, set)
 
     // Load target
     const data = loadConversationData(id)
@@ -418,7 +424,7 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
           }
         })
         set({ streaming: false })
-        persistCurrentConversation(get())
+        persistCurrentConversation(get(), set)
         return
       }
 


### PR DESCRIPTION
## Summary
Follow-up to PR #106 -- fixes 3 bugs found during live testing:

- **AssistantRail**: `display: none` broke the overlay behavior (pushed content instead of floating). Now uses `position: fixed` with `translate-x-full` slide transition + backdrop. Component stays mounted (state preserved) but slides off-screen when closed.
- **Godmode height**: `h-screen` caused the Godmode page to overflow AppShell's flex layout, cutting off the header. Changed to `h-full`.
- **Godmode message count**: Sidebar showed "0 msgs" after sending because `persistCurrentConversation()` saved to localStorage but never called `set()` to update the store. Now syncs metadata back to React state.

## Test plan
- [x] Ask Jarvis: sidebar opens as overlay, closes with slide animation, messages persist across close/open/reload
- [x] Godmode: header visible with sidebar toggle + model selector + "New chat" button
- [x] Godmode: "New chat" creates new conversation, old one preserved in sidebar
- [x] Godmode: clicking old conversation restores messages
- [x] Godmode: message count updates after response completes
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)