### PR TITLE
Add database-backed chat history with auto-summarization

### DIFF
--- a/packages/jarvis-dashboard/src/api/conversations.ts
+++ b/packages/jarvis-dashboard/src/api/conversations.ts
@@ -1,0 +1,335 @@
+/**
+ * /api/conversations — Database-backed conversation persistence.
+ *
+ * Stores chat conversations in runtime.db via ChannelStore (channel_threads +
+ * channel_messages). Supports both "dashboard-chat" (Ask Jarvis) and
+ * "dashboard-godmode" (Godmode) channels.
+ *
+ * Long conversations are automatically summarized via a non-blocking LLM call
+ * when the message count or estimated token count exceeds the configured
+ * thresholds. The summary is stored on the thread and served as context when
+ * the conversation is resumed.
+ */
+
+import { Router } from 'express'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import { DatabaseSync } from 'node:sqlite'
+import { ChannelStore } from '@jarvis/runtime'
+import { randomUUID } from 'node:crypto'
+
+// ─── Config ────────────────────────────────────────────────────────────────
+
+const RUNTIME_DB_PATH = path.join(os.homedir(), '.jarvis', 'runtime.db')
+const LMS_URL = process.env.LMS_URL ?? 'http://localhost:1234'
+const LMS_MODEL = process.env.LMS_MODEL ?? 'auto'
+const CONTEXT_WINDOW = Number(process.env.LMS_CONTEXT_WINDOW ?? '8192')
+const SUMMARY_MSG_THRESHOLD = 10
+const SUMMARY_TOKEN_RATIO = 0.7 // trigger when estimated tokens > 70% of context
+const RECENT_MESSAGES_COUNT = 6 // keep this many recent messages alongside summary
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function openDb(): DatabaseSync {
+  const db = new DatabaseSync(RUNTIME_DB_PATH)
+  db.exec('PRAGMA journal_mode = WAL;')
+  db.exec('PRAGMA busy_timeout = 5000;')
+  return db
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 3.5)
+}
+
+function deriveTitle(content: string): string {
+  const trimmed = content.trim()
+  return trimmed.length > 50 ? trimmed.slice(0, 47) + '...' : trimmed
+}
+
+// ─── Summarization ─────────────────────────────────────────────────────────
+
+const SUMMARY_SYSTEM_PROMPT = `Compress this conversation into a brief context summary (max 300 words). Capture:
+- Key topics discussed
+- Decisions made
+- User preferences expressed
+- Any pending questions or tasks
+Write in third person as a context briefing for an AI assistant resuming this conversation.`
+
+async function generateSummary(
+  messages: Array<{ direction: string; content_preview: string | null }>,
+  model: string,
+): Promise<string | null> {
+  const conversationText = messages
+    .map(m => `${m.direction === 'inbound' ? 'User' : 'Assistant'}: ${m.content_preview ?? ''}`)
+    .join('\n')
+
+  try {
+    const res = await fetch(`${LMS_URL}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: model === 'auto' ? undefined : model,
+        messages: [
+          { role: 'system', content: SUMMARY_SYSTEM_PROMPT },
+          { role: 'user', content: conversationText },
+        ],
+        stream: false,
+        temperature: 0.1,
+        max_tokens: 500,
+      }),
+    })
+    if (!res.ok) return null
+    const json = await res.json() as { choices?: Array<{ message?: { content?: string } }> }
+    return json.choices?.[0]?.message?.content?.trim() ?? null
+  } catch {
+    return null
+  }
+}
+
+function shouldSummarize(
+  messages: Array<{ content_preview: string | null }>,
+): boolean {
+  if (messages.length > SUMMARY_MSG_THRESHOLD) return true
+  const totalChars = messages.reduce((sum, m) => sum + (m.content_preview?.length ?? 0), 0)
+  if (estimateTokens(totalChars.toString()) > SUMMARY_TOKEN_RATIO * CONTEXT_WINDOW) return true
+  // More accurate: estimate from actual text
+  if (totalChars / 3.5 > SUMMARY_TOKEN_RATIO * CONTEXT_WINDOW) return true
+  return false
+}
+
+/** Fire-and-forget summary generation. Does not block the caller. */
+function triggerSummaryIfNeeded(threadId: string, model: string): void {
+  // Run async — errors are logged but don't propagate
+  (async () => {
+    try {
+      const db = openDb()
+      const cs = new ChannelStore(db)
+      const messages = cs.getThreadMessages(threadId, 500)
+      if (!shouldSummarize(messages)) { db.close(); return }
+
+      const summary = await generateSummary(messages, model)
+      if (summary) {
+        // Re-open db in case the connection went stale during LLM call
+        const db2 = openDb()
+        const cs2 = new ChannelStore(db2)
+        cs2.updateThreadSummary(threadId, summary)
+        db2.close()
+      }
+      db.close()
+    } catch (e) {
+      console.error('[conversations] summary generation failed:', e)
+    }
+  })()
+}
+
+// ─── Router ────────────────────────────────────────────────────────────────
+
+const router = Router()
+
+/**
+ * GET /api/conversations?channel=dashboard-godmode
+ * List conversations for a channel.
+ */
+router.get('/', (req, res) => {
+  const channel = (req.query.channel as string) ?? 'dashboard-godmode'
+  try {
+    const db = openDb()
+    const cs = new ChannelStore(db)
+    const threads = cs.getThreadsByChannel(channel, undefined, 100)
+
+    const result = threads
+      .filter(t => t.status !== 'archived')
+      .map(t => ({
+        id: t.thread_id,
+        title: t.subject ?? 'Untitled',
+        updatedAt: t.updated_at,
+        messageCount: cs.getThreadMessageCount(t.thread_id),
+        hasSummary: cs.getThreadSummary(t.thread_id) !== null,
+      }))
+
+    db.close()
+    res.json(result)
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to list conversations' })
+  }
+})
+
+/**
+ * POST /api/conversations
+ * Create a new conversation.
+ * Body: { channel: string, title?: string }
+ */
+router.post('/', (req, res) => {
+  const { channel, title } = req.body as { channel?: string; title?: string }
+  const ch = channel ?? 'dashboard-godmode'
+
+  try {
+    const db = openDb()
+    const cs = new ChannelStore(db)
+    const externalId = `conv-${Date.now()}-${randomUUID().slice(0, 8)}`
+    const threadId = cs.getOrCreateThread(ch, externalId, title ?? 'New chat')
+    db.close()
+    res.json({ id: threadId, externalId })
+  } catch {
+    res.status(500).json({ error: 'Failed to create conversation' })
+  }
+})
+
+/**
+ * GET /api/conversations/:id
+ * Get conversation detail: messages + summary.
+ */
+router.get('/:id', (req, res) => {
+  const { id } = req.params
+  try {
+    const db = openDb()
+    const cs = new ChannelStore(db)
+    const thread = cs.getThread(id)
+    if (!thread) { db.close(); res.status(404).json({ error: 'Conversation not found' }); return }
+
+    const messages = cs.getThreadMessages(id, 500)
+    const summary = cs.getThreadSummary(id)
+    db.close()
+
+    res.json({
+      id: thread.thread_id,
+      channel: thread.channel,
+      title: thread.subject,
+      status: thread.status,
+      summary,
+      messages: messages.map(m => ({
+        id: m.message_id,
+        role: m.direction === 'inbound' ? 'user' : 'assistant',
+        content: m.content_preview ?? '',
+        createdAt: m.created_at,
+      })),
+    })
+  } catch {
+    res.status(500).json({ error: 'Failed to load conversation' })
+  }
+})
+
+/**
+ * POST /api/conversations/:id/messages
+ * Append a message to a conversation.
+ * Body: { role: 'user' | 'assistant', content: string, model?: string }
+ * Triggers summary generation after assistant messages if thresholds exceeded.
+ */
+router.post('/:id/messages', (req, res) => {
+  const { id } = req.params
+  const { role, content, model } = req.body as {
+    role: 'user' | 'assistant'
+    content: string
+    model?: string
+  }
+
+  if (!role || !content) {
+    res.status(400).json({ error: 'role and content required' })
+    return
+  }
+
+  try {
+    const db = openDb()
+    const cs = new ChannelStore(db)
+    const thread = cs.getThread(id)
+    if (!thread) { db.close(); res.status(404).json({ error: 'Conversation not found' }); return }
+
+    const direction = role === 'user' ? 'inbound' : 'outbound'
+    const messageId = cs.recordMessage({
+      threadId: id,
+      channel: thread.channel,
+      direction: direction as 'inbound' | 'outbound',
+      contentPreview: content,
+      contentFull: content,
+      sender: role === 'user' ? 'operator' : 'jarvis',
+    })
+
+    // Update thread title from first user message
+    if (role === 'user') {
+      const msgCount = cs.getThreadMessageCount(id)
+      if (msgCount <= 1) {
+        // First message — set title
+        db.prepare('UPDATE channel_threads SET subject = ?, updated_at = ? WHERE thread_id = ?')
+          .run(deriveTitle(content), new Date().toISOString(), id)
+      }
+    }
+
+    db.close()
+
+    // Trigger summary after assistant messages (non-blocking)
+    if (role === 'assistant') {
+      triggerSummaryIfNeeded(id, model ?? LMS_MODEL)
+    }
+
+    res.json({ messageId })
+  } catch {
+    res.status(500).json({ error: 'Failed to record message' })
+  }
+})
+
+/**
+ * DELETE /api/conversations/:id
+ * Archive a conversation (soft delete).
+ */
+router.delete('/:id', (req, res) => {
+  const { id } = req.params
+  try {
+    const db = openDb()
+    const cs = new ChannelStore(db)
+    cs.updateThreadStatus(id, 'archived')
+    db.close()
+    res.json({ ok: true })
+  } catch {
+    res.status(500).json({ error: 'Failed to archive conversation' })
+  }
+})
+
+/**
+ * GET /api/conversations/:id/context
+ * Get LLM-ready conversation context.
+ * If conversation is short (<=threshold), returns all messages.
+ * If long, returns { summary, recentMessages } for efficient context injection.
+ */
+router.get('/:id/context', (req, res) => {
+  const { id } = req.params
+  try {
+    const db = openDb()
+    const cs = new ChannelStore(db)
+    const thread = cs.getThread(id)
+    if (!thread) { db.close(); res.status(404).json({ error: 'Conversation not found' }); return }
+
+    const allMessages = cs.getThreadMessages(id, 500)
+    const summary = cs.getThreadSummary(id)
+    db.close()
+
+    const formatted = allMessages.map(m => ({
+      role: m.direction === 'inbound' ? 'user' as const : 'assistant' as const,
+      content: m.content_preview ?? '',
+    }))
+
+    // If we have a summary and conversation is long, use compressed context
+    if (summary && formatted.length > SUMMARY_MSG_THRESHOLD) {
+      const recent = formatted.slice(-RECENT_MESSAGES_COUNT)
+      res.json({
+        mode: 'summarized',
+        summary,
+        recentMessages: recent,
+        totalMessages: formatted.length,
+      })
+      return
+    }
+
+    // Short conversation — return everything
+    res.json({
+      mode: 'full',
+      summary: null,
+      messages: formatted,
+      totalMessages: formatted.length,
+    })
+  } catch {
+    res.status(500).json({ error: 'Failed to build context' })
+  }
+})
+
+export const conversationsRouter = router

--- a/packages/jarvis-dashboard/src/api/server.ts
+++ b/packages/jarvis-dashboard/src/api/server.ts
@@ -35,6 +35,7 @@ import { repairRouter } from './repair.js'
 import { provenanceRouter } from './provenance.js'
 import { evalRouter } from './eval.js'
 import { modeRouter } from './settings.js'
+import { conversationsRouter } from './conversations.js'
 import fs from 'fs'
 import { getHealthReport, getReadinessReport, loadConfig, writeTelegramQueue } from '@jarvis/runtime'
 import { getMetricsText, getMetricsContentType } from '@jarvis/observability'
@@ -154,6 +155,7 @@ app.use('/api/repair', repairRouter)
 app.use('/api/provenance', provenanceRouter)
 app.use('/api/eval', evalRouter)
 app.use('/api/mode', modeRouter)
+app.use('/api/conversations', conversationsRouter)
 
 // ── Telegram routes ──────────────────────────────────────────────────────────
 app.get('/api/telegram/status', (_req, res) => {

--- a/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
+++ b/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
@@ -16,7 +16,50 @@ interface ChatSession {
   updatedAt: string
 }
 
-// ─── Persistent state helpers ───────────────────────────────
+// ─── Conversations API (database-backed) ───────────────────
+const API_CHANNEL = 'dashboard-chat'
+
+const chatApi = {
+  async listConversations(): Promise<Array<{ id: string; title: string; updatedAt: string; messageCount: number }>> {
+    try {
+      const res = await fetch(`/api/conversations?channel=${API_CHANNEL}`)
+      if (!res.ok) return []
+      return await res.json()
+    } catch { return [] }
+  },
+  async createConversation(title?: string): Promise<string | null> {
+    try {
+      const res = await fetch('/api/conversations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: API_CHANNEL, title }),
+      })
+      if (!res.ok) return null
+      return ((await res.json()) as { id: string }).id
+    } catch { return null }
+  },
+  async recordMessage(convId: string, role: 'user' | 'assistant', content: string, model?: string): Promise<void> {
+    try {
+      await fetch(`/api/conversations/${convId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role, content, model }),
+      })
+    } catch { /* best-effort */ }
+  },
+  async getContext(id: string): Promise<{ mode: string; summary: string | null; messages?: Array<{ role: string; content: string }>; recentMessages?: Array<{ role: string; content: string }> } | null> {
+    try {
+      const res = await fetch(`/api/conversations/${id}/context`)
+      if (!res.ok) return null
+      return await res.json()
+    } catch { return null }
+  },
+  async deleteConversation(id: string): Promise<void> {
+    try { await fetch(`/api/conversations/${id}`, { method: 'DELETE' }) } catch {}
+  },
+}
+
+// ─── Persistent state helpers (localStorage cache) ─────────
 const SESSIONS_KEY = 'jarvis-chat-sessions'
 const ACTIVE_KEY = 'jarvis-chat-active'
 
@@ -180,8 +223,9 @@ export default function JarvisChat() {
   }, [activeId])
 
   const startNewSession = useCallback(() => {
+    const localId = generateId()
     const newSession: ChatSession = {
-      id: generateId(),
+      id: localId,
       title: 'New chat',
       messages: [],
       model,
@@ -192,6 +236,13 @@ export default function JarvisChat() {
     setActiveId(newSession.id)
     setInput('')
     inputRef.current?.focus()
+    // Create on server in background
+    chatApi.createConversation('New chat').then(serverId => {
+      if (serverId && serverId !== localId) {
+        setSessions(prev => prev.map(s => s.id === localId ? { ...s, id: serverId } : s))
+        setActiveId(prev => prev === localId ? serverId : prev)
+      }
+    }).catch(() => {})
   }, [model])
 
   const switchSession = useCallback((id: string) => {
@@ -207,6 +258,7 @@ export default function JarvisChat() {
       const remaining = sessions.filter(s => s.id !== id)
       setActiveId(remaining.length > 0 ? remaining[0].id : null)
     }
+    chatApi.deleteConversation(id).catch(() => {})
   }, [activeId, sessions])
 
   const send = async (text: string) => {
@@ -246,7 +298,23 @@ export default function JarvisChat() {
     ))
     setStreaming(true)
 
-    const history = currentMessages.map(m => ({ role: m.role, content: m.content }))
+    // Record user message to DB (non-blocking)
+    chatApi.recordMessage(sessionId, 'user', trimmed, model).catch(() => {})
+
+    // Build smart history: use server context (with summary) if available
+    let history: Array<{ role: string; content: string }>
+    const ctx = await chatApi.getContext(sessionId).catch(() => null)
+    if (ctx?.mode === 'summarized' && ctx.summary && ctx.recentMessages) {
+      history = [
+        { role: 'user', content: `[Previous conversation context: ${ctx.summary}]` },
+        { role: 'assistant', content: 'Understood, I have the context from our previous conversation.' },
+        ...ctx.recentMessages,
+      ]
+    } else if (ctx?.mode === 'full' && ctx.messages) {
+      history = ctx.messages
+    } else {
+      history = currentMessages.map(m => ({ role: m.role, content: m.content }))
+    }
 
     try {
       const res = await fetch('/api/chat', {
@@ -316,6 +384,14 @@ export default function JarvisChat() {
 
     setStreaming(false)
     inputRef.current?.focus()
+
+    // Record assistant response to DB (non-blocking)
+    const finalSessions = sessionsRef.current
+    const finalSession = finalSessions.find(s => s.id === sessionId)
+    const lastMsg = finalSession?.messages[finalSession.messages.length - 1]
+    if (lastMsg?.role === 'assistant' && lastMsg.content && !lastMsg.error) {
+      chatApi.recordMessage(sessionId, 'assistant', lastMsg.content, model).catch(() => {})
+    }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
+++ b/packages/jarvis-dashboard/src/ui/pages/Godmode.tsx
@@ -33,10 +33,12 @@ export default function Godmode() {
   const switchConversation = useGodmodeStore(s => s.switchConversation)
   const deleteConversation = useGodmodeStore(s => s.deleteConversation)
 
+  const loadFromApi = useGodmodeStore(s => s.loadFromApi)
+
   const [rightPanelWidth, setRightPanelWidth] = useState(45) // percentage
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
-  // Fetch available models
+  // Fetch available models + hydrate conversations from database
   useEffect(() => {
     fetch('/api/godmode/models')
       .then(r => r.json())
@@ -45,6 +47,7 @@ export default function Godmode() {
         if (d.default && !model) setModel(d.default)
       })
       .catch(() => {})
+    loadFromApi()
   }, [])
 
   const handleResize = useCallback((deltaX: number) => {

--- a/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
+++ b/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
@@ -1,6 +1,64 @@
 import { create } from 'zustand'
 
-// ─── Multi-Conversation Persistence (localStorage) ─────────────────────────
+// ─── Conversations API (database-backed, source of truth) ──────────────────
+
+const API_CHANNEL = 'dashboard-godmode'
+
+const api = {
+  async listConversations(): Promise<ConversationMeta[]> {
+    try {
+      const res = await fetch(`/api/conversations?channel=${API_CHANNEL}`)
+      if (!res.ok) return []
+      return await res.json() as ConversationMeta[]
+    } catch { return [] }
+  },
+  async createConversation(title?: string): Promise<string | null> {
+    try {
+      const res = await fetch('/api/conversations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channel: API_CHANNEL, title }),
+      })
+      if (!res.ok) return null
+      const data = await res.json() as { id: string }
+      return data.id
+    } catch { return null }
+  },
+  async loadConversation(id: string): Promise<{ messages: Array<{ role: 'user' | 'assistant'; content: string }>; summary: string | null } | null> {
+    try {
+      const res = await fetch(`/api/conversations/${id}`)
+      if (!res.ok) return null
+      const data = await res.json() as { messages: Array<{ role: string; content: string }>; summary: string | null }
+      return {
+        messages: data.messages.map(m => ({ role: m.role as 'user' | 'assistant', content: m.content })),
+        summary: data.summary,
+      }
+    } catch { return null }
+  },
+  async recordMessage(convId: string, role: 'user' | 'assistant', content: string, model?: string): Promise<void> {
+    try {
+      await fetch(`/api/conversations/${convId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role, content, model }),
+      })
+    } catch { /* best-effort */ }
+  },
+  async deleteConversation(id: string): Promise<void> {
+    try {
+      await fetch(`/api/conversations/${id}`, { method: 'DELETE' })
+    } catch { /* best-effort */ }
+  },
+  async getContext(id: string): Promise<{ mode: string; summary: string | null; messages?: Array<{ role: 'user' | 'assistant'; content: string }>; recentMessages?: Array<{ role: 'user' | 'assistant'; content: string }> } | null> {
+    try {
+      const res = await fetch(`/api/conversations/${id}/context`)
+      if (!res.ok) return null
+      return await res.json()
+    } catch { return null }
+  },
+}
+
+// ─── Multi-Conversation Persistence (localStorage cache) ───────────────────
 
 const CONVERSATIONS_KEY = 'godmode-conversations'
 const ACTIVE_CONV_KEY = 'godmode-active'
@@ -150,6 +208,7 @@ interface GodmodeState {
   newConversation: () => void
   switchConversation: (id: string) => void
   deleteConversation: (id: string) => void
+  loadFromApi: () => Promise<void>  // hydrate from database
   clearSession: () => void // backward-compat alias for newConversation
   setArtifactViewMode: (mode: 'preview' | 'code') => void
   setModel: (model: string) => void
@@ -248,6 +307,26 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
 
   // ─── Conversation Management ─────────────────────────────────
 
+  loadFromApi: async () => {
+    const convs = await api.listConversations()
+    if (convs.length > 0) {
+      // API has data — use it as source of truth
+      saveConversationList(convs)
+      set({ conversations: convs })
+
+      // Load active conversation from API
+      const activeId = get().currentConversationId
+      const targetId = activeId && convs.find(c => c.id === activeId) ? activeId : convs[0].id
+      const data = await api.loadConversation(targetId)
+      if (data) {
+        const msgs: GodmodeMessage[] = data.messages.map(m => ({ role: m.role, content: m.content }))
+        saveConversationData(targetId, { messages: msgs, artifactHistory: [], currentArtifact: null, model: get().model })
+        saveActiveConversationId(targetId)
+        set({ currentConversationId: targetId, messages: msgs })
+      }
+    }
+  },
+
   newConversation: () => {
     const state = get()
     if (state.streaming) return
@@ -255,21 +334,21 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     // Persist current conversation first
     persistCurrentConversation(state, set)
 
-    // Create new empty conversation
-    const id = generateId()
+    // Create new empty conversation (optimistic with local ID, API syncs in background)
+    const localId = generateId()
     const meta: ConversationMeta = {
-      id,
+      id: localId,
       title: 'New chat',
       updatedAt: new Date().toISOString(),
       messageCount: 0,
     }
     const updated = [meta, ...state.conversations]
     saveConversationList(updated)
-    saveActiveConversationId(id)
+    saveActiveConversationId(localId)
 
     set({
       conversations: updated,
-      currentConversationId: id,
+      currentConversationId: localId,
       messages: [],
       streaming: false,
       activeSurfaces: ['chat'],
@@ -282,6 +361,22 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
       codeContent: '',
       toolLog: [],
     })
+
+    // Create on server in background; update ID if server returns a different one
+    api.createConversation('New chat').then(serverId => {
+      if (serverId && serverId !== localId) {
+        const cur = get()
+        // Remap local ID to server ID
+        const remapped = cur.conversations.map(c => c.id === localId ? { ...c, id: serverId } : c)
+        saveConversationList(remapped)
+        saveActiveConversationId(serverId)
+        if (cur.currentConversationId === localId) {
+          set({ conversations: remapped, currentConversationId: serverId })
+        } else {
+          set({ conversations: remapped })
+        }
+      }
+    }).catch(() => { /* offline — localStorage is fine */ })
   },
 
   switchConversation: (id: string) => {
@@ -291,16 +386,16 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     // Persist current first
     persistCurrentConversation(state, set)
 
-    // Load target
-    const data = loadConversationData(id)
+    // Load from localStorage cache first (instant)
+    const cached = loadConversationData(id)
     saveActiveConversationId(id)
 
     set({
       currentConversationId: id,
-      messages: data?.messages ?? [],
-      currentArtifact: data?.currentArtifact ?? null,
-      artifactHistory: data?.artifactHistory ?? [],
-      model: data?.model || state.model,
+      messages: cached?.messages ?? [],
+      currentArtifact: cached?.currentArtifact ?? null,
+      artifactHistory: cached?.artifactHistory ?? [],
+      model: cached?.model || state.model,
       activeSurfaces: ['chat'],
       toolLog: [],
       coworkSteps: [],
@@ -308,6 +403,15 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
       researchSources: [],
       codeContent: '',
     })
+
+    // Then hydrate from API (may have newer data from another session)
+    api.loadConversation(id).then(data => {
+      if (data && get().currentConversationId === id) {
+        const msgs: GodmodeMessage[] = data.messages.map(m => ({ role: m.role, content: m.content }))
+        saveConversationData(id, { messages: msgs, artifactHistory: get().artifactHistory, currentArtifact: get().currentArtifact, model: get().model })
+        set({ messages: msgs })
+      }
+    }).catch(() => { /* offline — cached data is fine */ })
   },
 
   deleteConversation: (id: string) => {
@@ -317,6 +421,9 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     removeConversationData(id)
     const updated = state.conversations.filter(c => c.id !== id)
     saveConversationList(updated)
+
+    // Delete on server in background
+    api.deleteConversation(id).catch(() => {})
 
     if (state.currentConversationId === id) {
       const nextId = updated.length > 0 ? updated[0].id : null
@@ -360,7 +467,23 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
       saveConversationList(updated)
       saveActiveConversationId(convId)
       set({ conversations: updated, currentConversationId: convId })
+
+      // Create on server
+      api.createConversation(meta.title).then(serverId => {
+        if (serverId && serverId !== convId) {
+          const cur = get()
+          const remapped = cur.conversations.map(c => c.id === convId ? { ...c, id: serverId } : c)
+          saveConversationList(remapped)
+          saveActiveConversationId(serverId)
+          set({ conversations: remapped, currentConversationId: serverId })
+          convId = serverId
+        }
+      }).catch(() => {})
     }
+
+    // Record user message to API (non-blocking)
+    const activeConvId = convId
+    api.recordMessage(activeConvId, 'user', text.trim(), model).catch(() => {})
 
     const userMsg: GodmodeMessage = { role: 'user', content: text.trim() }
     const assistantMsg: GodmodeMessage = { role: 'assistant', content: '', tools: [] }
@@ -376,7 +499,22 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
       codeContent: '',
     })
 
-    const history = messages.map(m => ({ role: m.role, content: m.content }))
+    // Build smart history: use server context (with summary) if available, fall back to local
+    let history: Array<{ role: string; content: string }>
+    const ctx = await api.getContext(activeConvId).catch(() => null)
+    if (ctx?.mode === 'summarized' && ctx.summary && ctx.recentMessages) {
+      // Inject summary as context, then recent messages
+      history = [
+        { role: 'user', content: `[Previous conversation context: ${ctx.summary}]` },
+        { role: 'assistant', content: 'Understood, I have the context from our previous conversation.' },
+        ...ctx.recentMessages,
+      ]
+    } else if (ctx?.mode === 'full' && ctx.messages) {
+      history = ctx.messages
+    } else {
+      // Offline fallback: use local messages
+      history = messages.map(m => ({ role: m.role, content: m.content }))
+    }
 
     try {
       const res = await fetch('/api/godmode', {
@@ -425,6 +563,8 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
         })
         set({ streaming: false })
         persistCurrentConversation(get(), set)
+        // Record assistant response to API
+        if (reply) api.recordMessage(activeConvId, 'assistant', reply, get().model).catch(() => {})
         return
       }
 
@@ -622,7 +762,14 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     set({ streaming: false })
 
     // Persist to localStorage
-    persistCurrentConversation(get())
+    persistCurrentConversation(get(), set)
+
+    // Record assistant response to API (non-blocking)
+    const finalMsgs = get().messages
+    const lastAssistant = finalMsgs[finalMsgs.length - 1]
+    if (lastAssistant?.role === 'assistant' && lastAssistant.content && !lastAssistant.error) {
+      api.recordMessage(get().currentConversationId ?? activeConvId, 'assistant', lastAssistant.content, get().model).catch(() => {})
+    }
   },
 
   setArtifactViewMode: (mode) => set({ artifactViewMode: mode }),

--- a/packages/jarvis-runtime/src/channel-store.ts
+++ b/packages/jarvis-runtime/src/channel-store.ts
@@ -396,4 +396,34 @@ export class ChannelStore {
       "SELECT * FROM channel_threads WHERE channel = ? ORDER BY updated_at DESC LIMIT ?",
     ).all(channel, limit) as ChannelThread[];
   }
+
+  // ─── Thread summaries (#106) ─────────────────────────────────────────
+
+  /** Update the compressed conversation summary for a thread. */
+  updateThreadSummary(threadId: string, summary: string): void {
+    const now = new Date().toISOString();
+    try {
+      this.db.prepare(
+        "UPDATE channel_threads SET summary = ?, updated_at = ? WHERE thread_id = ?",
+      ).run(summary, now, threadId);
+    } catch { /* summary column may not exist yet */ }
+  }
+
+  /** Get the current compressed summary for a thread (null if none). */
+  getThreadSummary(threadId: string): string | null {
+    try {
+      const row = this.db.prepare(
+        "SELECT summary FROM channel_threads WHERE thread_id = ?",
+      ).get(threadId) as { summary: string | null } | undefined;
+      return row?.summary ?? null;
+    } catch { return null; }
+  }
+
+  /** Count messages in a thread. */
+  getThreadMessageCount(threadId: string): number {
+    const row = this.db.prepare(
+      "SELECT COUNT(*) as cnt FROM channel_messages WHERE thread_id = ?",
+    ).get(threadId) as { cnt: number } | undefined;
+    return row?.cnt ?? 0;
+  }
 }

--- a/packages/jarvis-runtime/src/migrations/0012_thread_summary.ts
+++ b/packages/jarvis-runtime/src/migrations/0012_thread_summary.ts
@@ -1,0 +1,9 @@
+import type { Migration } from "./runner.js";
+
+export const migration0012: Migration = {
+  id: "0012",
+  name: "thread_summary",
+  sql: `
+ALTER TABLE channel_threads ADD COLUMN summary TEXT;
+`,
+};

--- a/packages/jarvis-runtime/src/migrations/runner.ts
+++ b/packages/jarvis-runtime/src/migrations/runner.ts
@@ -10,6 +10,7 @@ import { migration0008 } from "./0008_channel_model.js";
 import { migration0009 } from "./0009_provenance.js";
 import { migration0010 } from "./0010_provenance_trace_idx.js";
 import { migration0011 } from "./0011_jobs_table.js";
+import { migration0012 } from "./0012_thread_summary.js";
 import { crmMigration0001 } from "./crm_0001_core.js";
 import { knowledgeMigration0001 } from "./knowledge_0001_core.js";
 
@@ -49,6 +50,7 @@ export const RUNTIME_MIGRATIONS: Migration[] = [
   migration0009,
   migration0010,
   migration0011,
+  migration0012,
 ];
 
 /** CRM DB migrations — contacts, notes, stages, campaigns. */


### PR DESCRIPTION
## Summary
- Conversations stored in SQLite (`runtime.db`) via `ChannelStore` — survives browser clears, daemon restarts, works across machines
- Auto-summarization: when conversations exceed 10 messages or ~70% of context window, a non-blocking LLM call compresses history into a ~300-word briefing
- New `/api/conversations` REST API (6 endpoints: list, create, load, record message, delete, get smart context)
- Frontend syncs to API with localStorage as fast cache; falls back to localStorage when API unavailable
- Smart LLM context: short conversations send full history; long ones send `summary + last 6 messages`

## Test results (API integration test)
- [x] `POST /api/conversations` creates thread in `channel_threads` table
- [x] `POST /api/conversations/:id/messages` records to `channel_messages` table
- [x] `GET /api/conversations/:id` returns messages + summary
- [x] `GET /api/conversations/:id/context` returns `mode: "full"` for short conversations
- [x] `GET /api/conversations?channel=dashboard-godmode` lists with correct message counts
- [x] `DELETE /api/conversations/:id` archives (soft delete)
- [x] Data verified in SQLite via direct query
- [x] `npm run build` passes

## Test plan (manual)
- [ ] Send 12+ messages in Godmode → verify summary appears in `channel_threads.summary`
- [ ] Reload page → verify conversations load from API (not just localStorage)
- [ ] Clear localStorage → reload → conversations still load from DB
- [ ] Resume a long conversation → LLM response reflects earlier context via summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)