### PR TITLE
Fix race condition in chat conversation creation

### DIFF
--- a/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
+++ b/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
@@ -268,8 +268,9 @@ export default function JarvisChat() {
 
     // Create session if none active
     if (!activeId) {
+      const localId = generateId()
       const newSession: ChatSession = {
-        id: generateId(),
+        id: localId,
         title: trimmed.length > 50 ? trimmed.slice(0, 47) + '...' : trimmed,
         messages: [],
         model,
@@ -277,9 +278,20 @@ export default function JarvisChat() {
         updatedAt: new Date().toISOString(),
       }
       setSessions(prev => [newSession, ...prev])
-      setActiveId(newSession.id)
-      // We need to wait a tick for state to settle, so use the ID directly
-      await sendToSession(newSession.id, trimmed, [])
+      setActiveId(localId)
+
+      // Create on server synchronously so messages record against real ID
+      let sessionId = localId
+      try {
+        const serverId = await chatApi.createConversation(newSession.title)
+        if (serverId) {
+          sessionId = serverId
+          setSessions(prev => prev.map(s => s.id === localId ? { ...s, id: serverId } : s))
+          setActiveId(serverId)
+        }
+      } catch { /* offline */ }
+
+      await sendToSession(sessionId, trimmed, [])
       return
     }
 

--- a/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
+++ b/packages/jarvis-dashboard/src/ui/stores/godmode-store.ts
@@ -456,29 +456,33 @@ export const useGodmodeStore = create<GodmodeState>((set, get) => {
     // Auto-create conversation if none active
     let convId = state.currentConversationId
     if (!convId) {
-      convId = generateId()
+      const localId = generateId()
+      convId = localId
       const meta: ConversationMeta = {
-        id: convId,
+        id: localId,
         title: text.trim().length > 50 ? text.trim().slice(0, 47) + '...' : text.trim(),
         updatedAt: new Date().toISOString(),
         messageCount: 0,
       }
       const updated = [meta, ...state.conversations]
       saveConversationList(updated)
-      saveActiveConversationId(convId)
-      set({ conversations: updated, currentConversationId: convId })
+      saveActiveConversationId(localId)
+      set({ conversations: updated, currentConversationId: localId })
 
-      // Create on server
-      api.createConversation(meta.title).then(serverId => {
-        if (serverId && serverId !== convId) {
-          const cur = get()
-          const remapped = cur.conversations.map(c => c.id === convId ? { ...c, id: serverId } : c)
+      // Create on server synchronously so we can record messages against the real ID
+      try {
+        const serverId = await api.createConversation(meta.title)
+        if (serverId) {
+          convId = serverId
+          const remapped = get().conversations.map(c => c.id === localId ? { ...c, id: serverId } : c)
           saveConversationList(remapped)
           saveActiveConversationId(serverId)
+          // Also remap localStorage data key
+          const localData = loadConversationData(localId)
+          if (localData) { saveConversationData(serverId, localData); removeConversationData(localId) }
           set({ conversations: remapped, currentConversationId: serverId })
-          convId = serverId
         }
-      }).catch(() => {})
+      } catch { /* offline — use local ID */ }
     }
 
     // Record user message to API (non-blocking)


### PR DESCRIPTION
## Summary
Found during testing: `sendMessage()` fired `api.createConversation()` in a `.then()` (non-blocking) then immediately called `api.recordMessage()` with the local ID. The server didn't have that ID yet, so the record call returned 404 and messages were lost.

Fix: `await` the create call so the server-generated UUID is available before recording messages. Also remaps the localStorage data key when the server returns a different ID.

Affects both Godmode store and JarvisChat component.

## Test plan
- [ ] Send message in Godmode with no active conversation → verify DB gets messages
- [ ] Send message in Ask Jarvis with no active session → verify DB gets messages
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)