### PR TITLE
Clear hardcoded API token from launch.json

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,7 +8,7 @@
       "port": 4243,
       "cwd": "packages/jarvis-dashboard",
       "env": {
-        "JARVIS_API_TOKEN": "48a95757c64d16375ef6b8940ca9302e71a0856990e529def4df0b68eb2d66e1"
+        "JARVIS_API_TOKEN": ""
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Remove hardcoded API token from `.claude/launch.json` so Vite proxy reads from config file instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)