### PR TITLE
Fix Assistant panel layout and remove hardcoded model label

### DIFF
--- a/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
+++ b/packages/jarvis-dashboard/src/ui/components/JarvisChat.tsx
@@ -414,10 +414,10 @@ export default function JarvisChat() {
   }
 
   return (
-    <div className="flex bg-slate-800/30 backdrop-blur-sm border border-white/5 rounded-xl overflow-hidden" style={{ height: '500px' }}>
+    <div className="flex h-full overflow-hidden">
       {/* ── History sidebar ──────────────────────────────── */}
-      <div className={`${showHistory ? 'w-64' : 'w-0'} shrink-0 transition-all duration-200 overflow-hidden border-r border-white/5 bg-slate-900/50`}>
-        <div className="w-64 h-full flex flex-col">
+      <div className={`${showHistory ? 'w-52' : 'w-0'} shrink-0 transition-all duration-200 overflow-hidden border-r border-white/5 bg-slate-900/50`}>
+        <div className="w-52 h-full flex flex-col">
           <div className="flex items-center justify-between px-3 py-3 border-b border-white/5">
             <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Chats</span>
             <button

--- a/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
+++ b/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
@@ -14,14 +14,14 @@ export default function AssistantRail({ open, onClose }: { open: boolean; onClos
 
       {/* Panel -- always mounted for state, positioned off-screen when closed */}
       <aside
-        className={`fixed top-0 right-0 h-full w-[340px] bg-j-surface border-l border-j-border flex flex-col z-50 transition-transform duration-200 ${
+        className={`fixed top-0 right-0 h-full w-[420px] max-w-[90vw] bg-j-surface border-l border-j-border flex flex-col z-50 transition-transform duration-200 ${
           open ? 'translate-x-0' : 'translate-x-full'
         }`}
         aria-label="Jarvis assistant"
         aria-hidden={!open}
       >
         {/* Header */}
-        <div className="px-4 py-3 border-b border-j-border flex items-center gap-2.5">
+        <div className="px-4 py-3 border-b border-j-border flex items-center gap-2.5 shrink-0">
           <div className="size-5 rounded bg-j-accent/15 flex items-center justify-center" aria-hidden="true">
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
               <circle cx="5" cy="5" r="3" stroke="currentColor" strokeWidth="1" className="text-j-accent" />
@@ -29,10 +29,9 @@ export default function AssistantRail({ open, onClose }: { open: boolean; onClos
             </svg>
           </div>
           <span className="text-[12px] font-semibold text-j-text tracking-tight">Jarvis Assistant</span>
-          <span className="ml-auto text-[10px] text-j-text-muted font-mono">claude-opus</span>
           <button
             onClick={onClose}
-            className="ml-2 text-j-text-muted hover:text-j-text transition-colors cursor-pointer p-0.5"
+            className="ml-auto text-j-text-muted hover:text-j-text transition-colors cursor-pointer p-0.5"
             aria-label="Close assistant"
           >
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
@@ -41,7 +40,7 @@ export default function AssistantRail({ open, onClose }: { open: boolean; onClos
           </button>
         </div>
 
-        {/* Chat */}
+        {/* Chat -- fill remaining height */}
         <div className="flex-1 overflow-hidden">
           <JarvisChat />
         </div>


### PR DESCRIPTION
## Summary
- Remove hardcoded "claude-opus" text from AssistantRail header (the actual model is shown in the JarvisChat header inside)
- Widen panel from 340px → 420px (max 90vw) so chat content + history sidebar fit without overflow
- Remove fixed `height: 500px` from JarvisChat → use `h-full` to fill the panel naturally
- Narrow history sidebar from 256px → 208px to fit comfortably within the wider panel

## Test plan
- [ ] Open Assistant → no "claude-opus" in header
- [ ] Open history sidebar → fits within panel without overflow
- [ ] Panel fills full height of screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)