### PR TITLE
Add drag-to-resize on Assistant panel

### DIFF
--- a/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
+++ b/packages/jarvis-dashboard/src/ui/shell/AssistantRail.tsx
@@ -1,6 +1,58 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
 import JarvisChat from '../components/JarvisChat.tsx'
 
+const MIN_WIDTH = 320
+const MAX_WIDTH_RATIO = 0.85 // max 85% of viewport
+const DEFAULT_WIDTH = 420
+const STORAGE_KEY = 'jarvis-assistant-width'
+
+function loadWidth(): number {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    if (v) { const n = Number(v); if (n >= MIN_WIDTH) return n }
+  } catch {}
+  return DEFAULT_WIDTH
+}
+
 export default function AssistantRail({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [width, setWidth] = useState(loadWidth)
+  const dragging = useRef(false)
+  const startX = useRef(0)
+  const startW = useRef(0)
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    dragging.current = true
+    startX.current = e.clientX
+    startW.current = width
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }, [width])
+
+  useEffect(() => {
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragging.current) return
+      const delta = startX.current - e.clientX // dragging left = wider
+      const maxW = window.innerWidth * MAX_WIDTH_RATIO
+      const newW = Math.max(MIN_WIDTH, Math.min(maxW, startW.current + delta))
+      setWidth(newW)
+    }
+    const onMouseUp = () => {
+      if (!dragging.current) return
+      dragging.current = false
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      // Persist
+      try { localStorage.setItem(STORAGE_KEY, String(Math.round(width))) } catch {}
+    }
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+  }, [width])
+
   return (
     <>
       {/* Backdrop */}
@@ -14,12 +66,20 @@ export default function AssistantRail({ open, onClose }: { open: boolean; onClos
 
       {/* Panel -- always mounted for state, positioned off-screen when closed */}
       <aside
-        className={`fixed top-0 right-0 h-full w-[420px] max-w-[90vw] bg-j-surface border-l border-j-border flex flex-col z-50 transition-transform duration-200 ${
+        className={`fixed top-0 right-0 h-full bg-j-surface border-l border-j-border flex flex-col z-50 transition-transform duration-200 ${
           open ? 'translate-x-0' : 'translate-x-full'
         }`}
+        style={{ width: `${width}px`, maxWidth: '90vw' }}
         aria-label="Jarvis assistant"
         aria-hidden={!open}
       >
+        {/* Drag handle (left edge) */}
+        <div
+          onMouseDown={handleMouseDown}
+          className="absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize hover:bg-j-accent/30 active:bg-j-accent/50 transition-colors z-10"
+          title="Drag to resize"
+        />
+
         {/* Header */}
         <div className="px-4 py-3 border-b border-j-border flex items-center gap-2.5 shrink-0">
           <div className="size-5 rounded bg-j-accent/15 flex items-center justify-center" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Drag handle on the left edge of the Assistant panel -- hover highlights, drag to resize
- Min width: 320px, max: 85% of viewport
- Width saved to localStorage, restored on next open
- Default: 420px

## Test plan
- [ ] Hover left edge of panel → cursor changes to col-resize, edge highlights
- [ ] Drag left → panel widens; drag right → panel narrows
- [ ] Stops at min (320px) and max (85vw)
- [ ] Close and reopen → width preserved
- [ ] Reload page → width preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)